### PR TITLE
feat(tests): Add comprehensive tests for binary_sensor logic

### DIFF
--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -360,3 +360,371 @@ async def test_light_cycle_verification_sensor(mock_coordinator, mock_hass):
     )
     await sensor.async_update()
     assert not sensor.is_on
+
+
+@pytest.mark.parametrize(
+    "state_value, expected",
+    [
+        ("25.5", 25.5),
+        (STATE_UNAVAILABLE, None),
+        (STATE_UNKNOWN, None),
+        ("on", None),
+        (None, None),
+    ],
+)
+async def test_get_sensor_value_edge_cases(
+    mock_hass, mock_coordinator, env_config, state_value, expected
+):
+    """Test the _get_sensor_value helper with various invalid states."""
+    # Use any sensor class, as they share the same helper
+    sensor = BayesianStressSensor(mock_coordinator, "gs1", env_config)
+    sensor.hass = mock_hass
+
+    # Set up the mock state
+    if state_value is None:
+        mock_hass.states.get.return_value = None
+    else:
+        set_sensor_state(mock_hass, "sensor.temp", state_value)
+
+    assert sensor._get_sensor_value("sensor.temp") == expected
+
+
+# Helper to create mock history states
+def create_mock_history(
+    states: list[tuple[datetime, float | str]],
+) -> dict[str, list[MagicMock]]:
+    """Create a mock history list for get_significant_states."""
+    mock_states = []
+    for dt, state_val in states:
+        mock_state = MagicMock()
+        mock_state.last_updated = dt
+        mock_state.state = str(state_val)
+        mock_states.append(mock_state)
+    return {"sensor.temp": mock_states}
+
+
+@patch("custom_components.growspace_manager.binary_sensor.get_recorder_instance")
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "history_data, duration, threshold, expected_trend, expected_crossed",
+    [
+        # Case 1: Rising trend
+        (
+            [
+                (utcnow() - timedelta(minutes=10), 20.0),
+                (utcnow(), 22.0),
+            ],
+            15,
+            21.0,
+            "rising",
+            True,
+        ),
+        # Case 2: Falling trend
+        (
+            [
+                (utcnow() - timedelta(minutes=10), 22.0),
+                (utcnow(), 20.0),
+            ],
+            15,
+            21.0,
+            "falling",
+            False,
+        ),
+        # Case 3: Stable trend
+        (
+            [
+                (utcnow() - timedelta(minutes=10), 20.0),
+                (utcnow(), 20.0),
+            ],
+            15,
+            21.0,
+            "stable",
+            False,
+        ),
+        # Case 4: Not enough data
+        (
+            [
+                (utcnow(), 20.0),
+            ],
+            15,
+            21.0,
+            "stable",
+            False,
+        ),
+        # Case 5: Contains invalid states
+        (
+            [
+                (utcnow() - timedelta(minutes=10), 20.0),
+                (utcnow() - timedelta(minutes=5), STATE_UNAVAILABLE),
+                (utcnow(), 22.0),
+            ],
+            15,
+            21.0,
+            "rising",
+            True,
+        ),
+    ],
+)
+async def test_async_analyze_sensor_trend(
+    mock_recorder,
+    mock_hass,
+    mock_coordinator,
+    env_config,
+    history_data,
+    duration,
+    threshold,
+    expected_trend,
+    expected_crossed,
+):
+    """Test the _async_analyze_sensor_trend helper."""
+    # Mock the recorder history call
+    mock_history = create_mock_history(history_data)
+    mock_recorder.return_value.async_add_executor_job.return_value = mock_history
+
+    sensor = BayesianStressSensor(mock_coordinator, "gs1", env_config)
+    sensor.hass = mock_hass
+
+    analysis = await sensor._async_analyze_sensor_trend(
+        "sensor.temp", duration, threshold
+    )
+
+    assert analysis["trend"] == expected_trend
+    assert analysis["crossed_threshold"] == expected_crossed
+
+
+@patch("custom_components.growspace_manager.binary_sensor.get_recorder_instance")
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "sensor_readings, stage_info, expected_reason",
+    [
+        # Case 1: High temp at night
+        (
+            {"temp": 25, "humidity": 60, "vpd": 1.0, "light": "off"},
+            {"veg_days": 20, "flower_days": 0},
+            "Night Temp High",
+        ),
+        # Case 2: High humidity in late veg
+        (
+            {"temp": 25, "humidity": 75, "vpd": 1.0, "light": "on"},
+            {"veg_days": 20, "flower_days": 0},
+            "Humidity High",
+        ),
+        # Case 3: High humidity in late flower
+        (
+            {"temp": 25, "humidity": 55, "vpd": 1.0, "light": "on"},
+            {"veg_days": 30, "flower_days": 50},
+            "Humidity out of range",
+        ),
+        # Case 4: VPD stress in early flower (day)
+        (
+            {"temp": 25, "humidity": 60, "vpd": 0.5, "light": "on"},
+            {"veg_days": 30, "flower_days": 10},
+            "VPD out of range",
+        ),
+        # Case 5: VPD stress in late flower (night)
+        (
+            {"temp": 20, "humidity": 60, "vpd": 0.5, "light": "off"},
+            {"veg_days": 30, "flower_days": 50},
+            "VPD out of range",
+        ),
+    ],
+)
+async def test_stress_sensor_stage_and_time_logic(
+    mock_recorder,
+    mock_hass,
+    mock_coordinator,
+    env_config,
+    sensor_readings,
+    stage_info,
+    expected_reason,
+):
+    """Test BayesianStressSensor with stage- and time-specific logic."""
+    mock_recorder.return_value.async_add_executor_job = AsyncMock(return_value={})
+    sensor = BayesianStressSensor(mock_coordinator, "gs1", env_config)
+    sensor.hass = mock_hass
+    sensor.entity_id = "binary_sensor.test_stress_complex"
+
+    # Mock sensor states
+    set_sensor_state(mock_hass, "sensor.temp", sensor_readings.get("temp", 25))
+    set_sensor_state(mock_hass, "sensor.humidity", sensor_readings.get("humidity", 60))
+    set_sensor_state(mock_hass, "sensor.vpd", sensor_readings.get("vpd", 1.0))
+    set_sensor_state(mock_hass, "light.grow_light", sensor_readings.get("light", "on"))
+
+    # Mock stage info
+    with patch.object(sensor, "_get_growth_stage_info", return_value=stage_info):
+        await sensor._async_update_probability()
+
+    assert sensor.is_on
+    assert any(expected_reason in reason for _, reason in sensor._reasons)
+
+
+@patch("custom_components.growspace_manager.binary_sensor.get_recorder_instance")
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "sensor_readings, stage_info, expected_reason",
+    [
+        # Case 1: High humidity at night in late flower
+        (
+            {"temp": 20, "humidity": 55, "vpd": 1.0, "light": "off"},
+            {"veg_days": 30, "flower_days": 40},
+            "Night Humidity High",
+        ),
+        # Case 2: Circulation fan is off in late flower
+        (
+            {"temp": 20, "humidity": 50, "vpd": 1.2, "light": "on", "fan": "off"},
+            {"veg_days": 30, "flower_days": 40},
+            "Circulation Fan Off",
+        ),
+        # Case 3: Low VPD (day) in late flower
+        (
+            {"temp": 22, "humidity": 50, "vpd": 1.1, "light": "on"},
+            {"veg_days": 30, "flower_days": 40},
+            "Day VPD Low",
+        ),
+    ],
+)
+async def test_mold_risk_sensor_triggers(
+    mock_recorder,
+    mock_hass,
+    mock_coordinator,
+    env_config,
+    sensor_readings,
+    stage_info,
+    expected_reason,
+):
+    """Test BayesianMoldRiskSensor with specific triggers."""
+    mock_recorder.return_value.async_add_executor_job = AsyncMock(return_value={})
+    sensor = BayesianMoldRiskSensor(mock_coordinator, "gs1", env_config)
+    sensor.hass = mock_hass
+    sensor.entity_id = "binary_sensor.test_mold_complex"
+
+    # Mock sensor states
+    set_sensor_state(mock_hass, "sensor.temp", sensor_readings.get("temp", 20))
+    set_sensor_state(mock_hass, "sensor.humidity", sensor_readings.get("humidity", 50))
+    set_sensor_state(mock_hass, "sensor.vpd", sensor_readings.get("vpd", 1.2))
+    set_sensor_state(mock_hass, "light.grow_light", sensor_readings.get("light", "on"))
+    set_sensor_state(mock_hass, "switch.fan", sensor_readings.get("fan", "on"))
+
+    # Mock stage info
+    with patch.object(sensor, "_get_growth_stage_info", return_value=stage_info):
+        await sensor._async_update_probability()
+
+    assert sensor.is_on
+    assert any(expected_reason in reason for _, reason in sensor._reasons)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "sensor_readings, stage_info, expected_reason",
+    [
+        # Case 1: Temp too high in late flower (day)
+        (
+            {"temp": 28, "humidity": 45, "vpd": 1.5, "light": "on"},
+            {"veg_days": 30, "flower_days": 50},
+            "Temp out of range",
+        ),
+        # Case 2: VPD too low in veg (day)
+        (
+            {"temp": 25, "humidity": 80, "vpd": 0.3, "light": "on"},
+            {"veg_days": 10, "flower_days": 0},
+            "VPD out of range",
+        ),
+        # Case 3: CO2 too low
+        (
+            {"temp": 25, "humidity": 60, "vpd": 1.0, "co2": 300, "light": "on"},
+            {"veg_days": 20, "flower_days": 0},
+            "CO2 Low",
+        ),
+    ],
+)
+async def test_optimal_sensor_off_states(
+    mock_hass,
+    mock_coordinator,
+    env_config,
+    sensor_readings,
+    stage_info,
+    expected_reason,
+):
+    """Test BayesianOptimalConditionsSensor for non-optimal (off) states."""
+    sensor = BayesianOptimalConditionsSensor(mock_coordinator, "gs1", env_config)
+    sensor.hass = mock_hass
+    sensor.entity_id = "binary_sensor.test_optimal_fail"
+    sensor._probability = 1.0  # Start as ON
+
+    # Mock sensor states
+    set_sensor_state(mock_hass, "sensor.temp", sensor_readings.get("temp", 25))
+    set_sensor_state(mock_hass, "sensor.humidity", sensor_readings.get("humidity", 60))
+    set_sensor_state(mock_hass, "sensor.vpd", sensor_readings.get("vpd", 1.0))
+    set_sensor_state(mock_hass, "sensor.co2", sensor_readings.get("co2", 1200))
+    set_sensor_state(mock_hass, "light.grow_light", sensor_readings.get("light", "on"))
+
+    # Mock stage info
+    with patch.object(sensor, "_get_growth_stage_info", return_value=stage_info):
+        await sensor._async_update_probability()
+
+    assert not sensor.is_on
+    assert any(expected_reason in reason for _, reason in sensor._reasons)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "sensor_class, growspace_id, sensor_readings, expected_reason",
+    [
+        # Case 1: Drying sensor, temp too high
+        (
+            BayesianDryingSensor,
+            "dry",
+            {"temp": 25, "humidity": 50},
+            "Temp out of range",
+        ),
+        # Case 2: Drying sensor, humidity too low
+        (
+            BayesianDryingSensor,
+            "dry",
+            {"temp": 18, "humidity": 40},
+            "Humidity out of range",
+        ),
+        # Case 3: Curing sensor, temp too low
+        (
+            BayesianCuringSensor,
+            "cure",
+            {"temp": 15, "humidity": 58},
+            "Temp out of range",
+        ),
+        # Case 4: Curing sensor, humidity too high
+        (
+            BayesianCuringSensor,
+            "cure",
+            {"temp": 20, "humidity": 65},
+            "Humidity out of range",
+        ),
+    ],
+)
+async def test_dry_cure_sensors_off_states(
+    mock_hass,
+    mock_coordinator,
+    env_config,
+    sensor_class,
+    growspace_id,
+    sensor_readings,
+    expected_reason,
+):
+    """Test Drying and Curing sensors for non-optimal (off) states."""
+    # Set up a specific growspace for this test
+    mock_coordinator.growspaces[growspace_id] = MagicMock(
+        name=growspace_id.capitalize()
+    )
+
+    sensor = sensor_class(mock_coordinator, growspace_id, env_config)
+    sensor.hass = mock_hass
+    sensor.entity_id = f"binary_sensor.test_{growspace_id}_fail"
+    sensor._probability = 1.0  # Start as ON
+
+    # Mock sensor states
+    set_sensor_state(mock_hass, "sensor.temp", sensor_readings.get("temp", 20))
+    set_sensor_state(mock_hass, "sensor.humidity", sensor_readings.get("humidity", 55))
+
+    await sensor._async_update_probability()
+
+    assert not sensor.is_on
+    assert any(expected_reason in reason for _, reason in sensor._reasons)


### PR DESCRIPTION
feat(tests): Add comprehensive tests for binary_sensor logic

This commit significantly improves test coverage for binary_sensor.py by adding extensive tests for the Bayesian sensor logic in tests/test_binary_sensor_logic.py.

    Added tests for the _get_sensor_value helper with invalid and unavailable states.

    Added parametrized tests for _async_analyze_sensor_trend to validate recorder history analysis, including rising, falling, and stable trends.

    Added parametrized tests for BayesianStressSensor to cover night/day and stage-specific logic (e.g., high heat, night temp, late flower humidity).

    Added parametrized tests for BayesianMoldRiskSensor to check specific triggers like fan status and night humidity.

    Added tests for BayesianOptimalConditionsSensor failure states (when conditions are not optimal).

    Added tests for BayesianDryingSensor and BayesianCuringSensor failure states.