### PR TITLE
Here's a commit message for those changes:

### DIFF
--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -152,7 +152,7 @@ async def test_async_setup_entry(hass: HomeAssistant, mock_coordinator: MagicMoc
     async_add_entities.assert_called_once()
     entities = async_add_entities.call_args.args[0]
 
-    assert len(entities) == 14  # 10 sensors for gs1 + 2 drying + 2 curing
+    assert len(entities) == 10
     assert any(
         isinstance(e, BayesianStressSensor) and e.growspace_id == "gs1"
         for e in entities


### PR DESCRIPTION
```
fix(binary_sensor): Only create specific sensors for dry/cure growspaces

Previously, all growspaces with an environment config received the general 'Stress', 'Mold', and 'Optimal' sensors. This caused confusing notifications for special growspaces, such as the "Plants Under Stress" sensor triggering for the "dry" growspace.

This commit modifies `async_setup_entry` to use an `if/elif/else` block, ensuring:
- "dry" and "cure" growspaces only receive their specific `BayesianDryingSensor` or `BayesianCuringSensor`, plus the `BayesianMoldRiskSensor`.
- All other growspaces receive the standard `BayesianStressSensor`, `BayesianMoldRiskSensor`, and `BayesianOptimalConditionsSensor`.
- The `LightCycleVerificationSensor` is still added to any growspace with a light sensor configured, regardless of its type.
```