### PR TITLE
fix: Correct `determine_granular_stage` to return "empty" when no pla…

### DIFF
--- a/custom_components/growspace_manager/environment_analyzer.py
+++ b/custom_components/growspace_manager/environment_analyzer.py
@@ -189,9 +189,9 @@ class EnvironmentAnalyzer:
                     return "seedling"
                 if max_clone > 0:
                     return "clone"
-                return "veg"
+                return "empty"
             case _:
-                return "veg"
+                return "empty"
 
     def determine_is_day(self, growspace: Growspace) -> bool:
         """Determine if it is currently day or night in the growspace.

--- a/tests/logic/test_environment_analyzer.py
+++ b/tests/logic/test_environment_analyzer.py
@@ -76,9 +76,9 @@ def test_determine_granular_stage(analyzer: EnvironmentAnalyzer) -> None:
         def __gt__(self, other):
             return "not_a_bool"
 
-    assert analyzer.determine_granular_stage(0, 0, 0, NonBool()) == "veg"
+    assert analyzer.determine_granular_stage(0, 0, 0, NonBool()) == "empty"
     # Default Veg Early (all 0)
-    assert analyzer.determine_granular_stage(0, 0, 0, 0) == "veg"
+    assert analyzer.determine_granular_stage(0, 0, 0, 0) == "empty"
 
 
 def test_determine_is_day(


### PR DESCRIPTION
…nts are present instead of "veg".