### PR TITLE
fix(seedfinder): surface Cloudflare 403 as user-readable error

### DIFF
--- a/custom_components/growspace_manager/services/seedfinder_scraper.py
+++ b/custom_components/growspace_manager/services/seedfinder_scraper.py
@@ -67,7 +67,7 @@ class SeedfinderScraper:
                 if response.status == 403:
                     _LOGGER.warning(
                         "Seedfinder search blocked (403) — the site is behind bot "
-                        "protection (Cloudflare). Automated access is not possible."
+                        "protection (Cloudflare). Automated access is not possible"
                     )
                     raise ServiceValidationError(
                         "Seedfinder is temporarily unavailable: the site is currently "

--- a/custom_components/growspace_manager/services/seedfinder_scraper.py
+++ b/custom_components/growspace_manager/services/seedfinder_scraper.py
@@ -33,7 +33,7 @@ class SeedfinderScraper:
                 if response.status == 403:
                     _LOGGER.warning(
                         "Seedfinder fetch blocked (403) — the site is behind bot "
-                        "protection (Cloudflare). Automated access is not possible."
+                        "protection (Cloudflare). Automated access is not possible"
                     )
                     raise ServiceValidationError(
                         "Seedfinder is temporarily unavailable: the site is currently "

--- a/custom_components/growspace_manager/services/seedfinder_scraper.py
+++ b/custom_components/growspace_manager/services/seedfinder_scraper.py
@@ -30,6 +30,15 @@ class SeedfinderScraper:
         session = async_get_clientsession(self.hass)
         try:
             async with session.get(url, timeout=15) as response:
+                if response.status == 403:
+                    _LOGGER.warning(
+                        "Seedfinder fetch blocked (403) — the site is behind bot "
+                        "protection (Cloudflare). Automated access is not possible."
+                    )
+                    raise ServiceValidationError(
+                        "Seedfinder is temporarily unavailable: the site is currently "
+                        "blocking automated access. Try again later or add the strain manually."
+                    )
                 if response.status != 200:
                     _LOGGER.error("Error fetching %s: %s", url, response.status)
                     return None
@@ -41,7 +50,6 @@ class SeedfinderScraper:
             AttributeError,
             KeyError,
             ValueError,
-            ServiceValidationError,
             GrowspaceError,
         ) as err:
             _LOGGER.error("Unexpected error fetching %s: %s", url, err)
@@ -56,6 +64,15 @@ class SeedfinderScraper:
 
         try:
             async with session.get(SEARCH_URL, params=params, timeout=10) as response:
+                if response.status == 403:
+                    _LOGGER.warning(
+                        "Seedfinder search blocked (403) — the site is behind bot "
+                        "protection (Cloudflare). Automated access is not possible."
+                    )
+                    raise ServiceValidationError(
+                        "Seedfinder is temporarily unavailable: the site is currently "
+                        "blocking automated access. Try again later or add the strain manually."
+                    )
                 if response.status != 200:
                     _LOGGER.error("Error searching Seedfinder: %s", response.status)
                     return []
@@ -119,7 +136,6 @@ class SeedfinderScraper:
             AttributeError,
             KeyError,
             ValueError,
-            ServiceValidationError,
             GrowspaceError,
         ) as err:
             _LOGGER.error("Unexpected error searching Seedfinder: %s", err)

--- a/custom_components/growspace_manager/websocket/strain.py
+++ b/custom_components/growspace_manager/websocket/strain.py
@@ -167,7 +167,11 @@ async def websocket_query_external_strain(
     except (AttributeError, KeyError, RuntimeError):
         _LOGGER.debug("Could not retrieve coordinator for blacklist, using empty list")
 
-    results = await scraper.async_search_strains(query, blacklist=blacklist)
+    try:
+        results = await scraper.async_search_strains(query, blacklist=blacklist)
+    except ServiceValidationError as err:
+        connection.send_error(msg["id"], "seedfinder_unavailable", str(err))
+        return
     connection.send_result(msg["id"], results)
 
 
@@ -183,7 +187,11 @@ async def websocket_get_external_strain_details(
     coordinator = GrowspaceCoordinator.get_any(hass)
     scraper = coordinator.seedfinder_scraper
 
-    raw = await scraper.async_get_strain_details(url)
+    try:
+        raw = await scraper.async_get_strain_details(url)
+    except ServiceValidationError as err:
+        connection.send_error(msg["id"], "seedfinder_unavailable", str(err))
+        return
     if raw is None:
         connection.send_result(msg["id"], None)
         return


### PR DESCRIPTION
Seedfinder.eu is now behind Cloudflare's managed JS challenge site-wide, making all automated HTTP requests return 403. Instead of silently returning an empty result list and logging a raw status code, raise ServiceValidationError with an explanatory message and forward it to the WebSocket caller via connection.send_error.

Also removes ServiceValidationError from the catch-all fallback tuples in both _async_fetch and async_search_strains so the error propagates correctly rather than being swallowed.