### PR TITLE
Fix VWC irrigation never firing pump for numeric light sensors

### DIFF
--- a/custom_components/growspace_manager/binary_sensor.py
+++ b/custom_components/growspace_manager/binary_sensor.py
@@ -69,7 +69,12 @@ from .strategies.mold import MoldRiskEvaluatorStrategy
 from .strategies.optimal import OptimalConditionsEvaluatorStrategy
 from .strategies.stress import StressEvaluatorStrategy
 from .trend_analyzer import TrendAnalyzer
-from .utils import VPDCalculator, calculate_days_since, calculate_stage_transition
+from .utils import (
+    VPDCalculator,
+    any_light_sensor_on,
+    calculate_days_since,
+    calculate_stage_transition,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -490,32 +495,10 @@ class BayesianEnvironmentSensor(
         if not light_sensors:
             return None
 
-        any_on = False
-        any_valid = False
-
-        for sensor in light_sensors:
-            is_on, valid = self._check_light_sensor(sensor)
-            if valid:
-                any_valid = True
-                if is_on:
-                    any_on = True
-
-        current_lights_on = any_on if any_valid else None
+        current_lights_on = any_light_sensor_on(self.hass, light_sensors)
         self._check_light_state_change(current_lights_on)
         self._last_light_state = current_lights_on
         return current_lights_on
-
-    def _check_light_sensor(self, sensor_id: str) -> tuple[bool, bool]:
-        """Check a single light sensor state and return (is_on, is_valid)."""
-        state = self.hass.states.get(sensor_id)
-        if not state or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
-            return False, False
-
-        if state.domain == "sensor":
-            val = self._get_sensor_value(sensor_id)
-            return val is not None and val > 0, val is not None
-
-        return state.state == "on", True
 
     def _check_light_state_change(self, current_lights_on: bool | None) -> None:
         """Check for state change to trigger notification cooldown."""

--- a/custom_components/growspace_manager/irrigation_coordinator.py
+++ b/custom_components/growspace_manager/irrigation_coordinator.py
@@ -26,6 +26,7 @@ from .const import (
 )
 from .exceptions import GrowspaceError
 from .models import Growspace, GrowspaceEvent
+from .utils import any_light_sensor_on
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -354,18 +355,17 @@ class BaseIrrigationCoordinator:
         return duration * flow_rate / 1000.0
 
     def _is_lights_dark(self) -> bool:
-        """Return True when all configured light sensors report off or are unavailable.
+        """Return True when no configured light sensor reports lights on.
 
         Returns False (lights considered on) when no light sensors are configured,
-        so irrigation is not blocked by default.
+        so irrigation is not blocked by default. Sensors that are unavailable or
+        unknown fail toward "dark" — under-watering for one cycle is recoverable,
+        whereas watering during an actual dark/dry-back period is not.
         """
         light_sensors = self.growspace.environment_config.light_sensors
         if not light_sensors:
             return False
-        return all(
-            (state := self.hass.states.get(sensor)) is None or state.state != "on"
-            for sensor in light_sensors
-        )
+        return any_light_sensor_on(self.hass, light_sensors) is not True
 
     def _find_low_tank(self) -> tuple[str, float, float] | None:
         """Return (name, current_level, warning_level) for the first below-warning tank.

--- a/custom_components/growspace_manager/utils.py
+++ b/custom_components/growspace_manager/utils.py
@@ -347,6 +347,38 @@ def read_sensor_value(hass: HomeAssistant, sensor_id: str | None) -> float | Non
         return None
 
 
+def is_light_sensor_on(hass: HomeAssistant, sensor_id: str) -> tuple[bool, bool]:
+    """Return (is_on, is_valid) for a light sensor.
+
+    Numeric `sensor.` domain entities (e.g. power-consumption sensors) are
+    considered on when their value is greater than zero. Binary-style entities
+    (binary_sensor, switch, etc.) are considered on when their state is "on".
+    Unavailable/unknown/missing entities are reported as invalid.
+    """
+    state = hass.states.get(sensor_id)
+    if not state or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+        return False, False
+
+    if state.domain == "sensor":
+        value = read_sensor_value(hass, sensor_id)
+        return value is not None and value > 0, value is not None
+
+    return state.state == "on", True
+
+
+def any_light_sensor_on(hass: HomeAssistant, sensor_ids: list[str]) -> bool | None:
+    """OR-aggregate light sensor states; None when no sensor has a valid reading."""
+    any_on = False
+    any_valid = False
+    for sensor_id in sensor_ids:
+        is_on, valid = is_light_sensor_on(hass, sensor_id)
+        if valid:
+            any_valid = True
+            if is_on:
+                any_on = True
+    return any_on if any_valid else None
+
+
 def read_aggregated_sensor_value(
     hass: HomeAssistant, sensor_ids: list[str]
 ) -> float | None:

--- a/custom_components/growspace_manager/vwc_irrigation_coordinator.py
+++ b/custom_components/growspace_manager/vwc_irrigation_coordinator.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.event import (
     async_track_time_change,
     async_track_time_interval,
 )
-from homeassistant.util.dt import now
+from homeassistant.util.dt import now, parse_datetime
 
 if TYPE_CHECKING:
     from .coordinator import GrowspaceCoordinator
@@ -39,7 +39,6 @@ class VWCIrrigationCoordinator(BaseIrrigationCoordinator):
 
         # State tracking
         self._current_phase = "P3"  # Start in safe state
-        self._last_shot_time: datetime | None = None
         self._target_reached_today = False
         self._last_reset_date: str | None = None
 
@@ -277,12 +276,24 @@ class VWCIrrigationCoordinator(BaseIrrigationCoordinator):
                 )
                 self._handle_watering(strategy, "P2")
 
+    def _last_shot_dt(self) -> datetime | None:
+        """Return the last confirmed pump-cycle start time, or None.
+
+        Reads `_last_cycle_timestamp` (set by `_run_pump_cycle` only after the
+        switch is confirmed on) rather than stamping optimistically — a skipped
+        cycle (e.g. dark-period guard) must not silently rate-limit future shots.
+        """
+        if not self._last_cycle_timestamp:
+            return None
+        return parse_datetime(self._last_cycle_timestamp)
+
     def _handle_watering(self, strategy: IrrigationStrategy, phase: str) -> None:
         """Handle execution of a shot if interval permits."""
         now_dt = now()
 
-        if self._last_shot_time:
-            elapsed = (now_dt - self._last_shot_time).total_seconds() / 60.0
+        last_shot = self._last_shot_dt()
+        if last_shot:
+            elapsed = (now_dt - last_shot).total_seconds() / 60.0
             if elapsed < strategy.shot_interval_minutes:
                 return
 
@@ -317,8 +328,6 @@ class VWCIrrigationCoordinator(BaseIrrigationCoordinator):
             f"irrigation_pump_{self._growspace_id}_irrigation",
         )
         self._running_tasks["irrigation"] = task
-
-        self._last_shot_time = now_dt
 
     def _is_halted_by_runoff_ec(self, growspace: Growspace) -> bool:
         """Return True and log a warning when the latest drain EC exceeds the configured threshold."""
@@ -417,10 +426,9 @@ class VWCIrrigationCoordinator(BaseIrrigationCoordinator):
             return self._tomorrows_shot_window(strategy, growspace, today)
 
         earliest = current_dt
-        if self._last_shot_time:
-            cooldown_end = self._last_shot_time + timedelta(
-                minutes=strategy.shot_interval_minutes
-            )
+        last_shot = self._last_shot_dt()
+        if last_shot:
+            cooldown_end = last_shot + timedelta(minutes=strategy.shot_interval_minutes)
             if cooldown_end > current_dt:
                 earliest = cooldown_end
 

--- a/tests/components/test_binary_sensor.py
+++ b/tests/components/test_binary_sensor.py
@@ -1228,6 +1228,28 @@ def test_determine_light_state_unavailable(
     assert sensor._determine_light_state() is None
 
 
+def test_determine_light_state_numeric_power_sensor(
+    hass: HomeAssistant, mock_coordinator, env_config
+) -> None:
+    """A numeric power-consumption sensor reporting > 0 means lights are on."""
+    sensor = create_test_sensor(
+        mock_coordinator,
+        "gs1",
+        GrowspaceSensorType.STRESS,
+        StressEvaluatorStrategy,
+        env_config,
+    )
+    sensor.hass = hass
+
+    env_config.light_sensors = ["sensor.grow_light_power"]
+
+    set_sensor_state(hass, "sensor.grow_light_power", "4")
+    assert sensor._determine_light_state() is True
+
+    set_sensor_state(hass, "sensor.grow_light_power", "0")
+    assert sensor._determine_light_state() is False
+
+
 @patch(
     "custom_components.growspace_manager.binary_sensor.BayesianEnvironmentSensor.async_analyze_sensor_trend",
     new_callable=AsyncMock,
@@ -2272,15 +2294,30 @@ class TestBayesianEnvironmentSensor:
         assert result is None
 
     def test_get_base_environment_state_light_sensor_domain_sensor(self, base_sensor):
-        """Test _get_base_environment_state when light sensor is a sensor domain."""
+        """Test _get_base_environment_state when light sensor is a sensor domain.
+
+        The light sensor's on/off determination reads directly from
+        `hass.states` (via `any_light_sensor_on`/`is_light_sensor_on`), so its
+        state must be driven through `hass.states.get` rather than through the
+        unrelated `_get_sensor_value` instance method (used for the other
+        environment readings like temperature/humidity).
+        """
         base_sensor.hass = MagicMock()
         base_sensor.env_config.light_sensors = ["sensor.light_level"]
 
-        # Mock light_state to have domain "sensor"
-        mock_light_state = MagicMock(spec=State)
-        mock_light_state.domain = "sensor"
-        mock_light_state.state = "100"
-        base_sensor.hass.states.get.return_value = mock_light_state
+        light_state_value = "100"
+
+        def _states_get_side_effect(entity_id):
+            if entity_id == "sensor.light_level":
+                mock_light_state = MagicMock(spec=State)
+                mock_light_state.domain = "sensor"
+                mock_light_state.state = light_state_value
+                return mock_light_state
+            return MagicMock(spec=State, domain="sensor", state="0")
+
+        base_sensor.hass.states.get.side_effect = lambda eid: _states_get_side_effect(
+            eid
+        )
 
         def _get_sensor_value_side_effect(entity_id):
             values = {
@@ -2288,7 +2325,6 @@ class TestBayesianEnvironmentSensor:
                 "sensor.humidity": 60.0,
                 "sensor.vpd": 1.0,
                 "sensor.co2": 800.0,
-                "sensor.light_level": 100.0,
                 "sensor.exhaust": 0.0,
                 "sensor.humidifier": 0.0,
                 "sensor.soil_moisture": 0.0,
@@ -2297,7 +2333,7 @@ class TestBayesianEnvironmentSensor:
 
         with patch.object(
             base_sensor, "_get_sensor_value", side_effect=_get_sensor_value_side_effect
-        ) as mock_get_value:
+        ):
             # Mock _get_growth_stage_info
             base_sensor._get_growth_stage_info = MagicMock(
                 return_value={"veg_days": 20, "flower_days": -1}
@@ -2305,6 +2341,7 @@ class TestBayesianEnvironmentSensor:
 
             # Test with sensor_value > 0
             # Avoid hysteresis
+            light_state_value = "100"
             base_sensor._last_light_change_time = utcnow() - timedelta(minutes=10)
             base_sensor._last_light_state = True
 
@@ -2312,16 +2349,7 @@ class TestBayesianEnvironmentSensor:
             assert env_state.is_lights_on is True
 
             # Test with sensor_value = 0
-            mock_get_value.side_effect = lambda eid: {
-                "sensor.temp": 25.0,
-                "sensor.humidity": 60.0,
-                "sensor.vpd": 1.0,
-                "sensor.co2": 800.0,
-                "sensor.light_level": 0.0,
-                "sensor.exhaust": 0.0,
-                "sensor.humidifier": 0.0,
-                "sensor.soil_moisture": 0.0,
-            }.get(eid, 0.0)  # Light sensor value is 0
+            light_state_value = "0"
             # Reset hysteresis avoidance for new state
             base_sensor._last_light_change_time = utcnow() - timedelta(minutes=10)
             base_sensor._last_light_state = False
@@ -2329,21 +2357,12 @@ class TestBayesianEnvironmentSensor:
             env_state = base_sensor._get_base_environment_state()
             assert env_state.is_lights_on is False
 
-            # Test with sensor_value is None
-            mock_get_value.side_effect = lambda eid: {
-                "sensor.temp": 25.0,
-                "sensor.humidity": 60.0,
-                "sensor.vpd": 1.0,
-                "sensor.co2": 800.0,
-                "sensor.light_level": None,
-                "sensor.exhaust": 0.0,
-                "sensor.humidifier": 0.0,
-                "sensor.soil_moisture": 0.0,
-            }.get(eid, 0.0)  # Light sensor value is None
+            # Test with sensor_value unavailable (no valid reading)
+            light_state_value = STATE_UNAVAILABLE
             base_sensor._last_light_change_time = utcnow() - timedelta(minutes=10)
             base_sensor._last_light_state = False
             env_state = base_sensor._get_base_environment_state()
-            assert env_state.is_lights_on is None  # None when sensor_value is None
+            assert env_state.is_lights_on is None  # None when no valid reading
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_vwc_irrigation_coordinator.py
+++ b/tests/integration/test_vwc_irrigation_coordinator.py
@@ -415,7 +415,7 @@ async def test_shot_interval_logic(vwc_coordinator, mock_hass) -> None:
     strategy.shot_interval_minutes = 15
 
     # 1. Fire first shot
-    vwc_coordinator._last_shot_time = None
+    vwc_coordinator._last_cycle_timestamp = None
     vwc_coordinator._handle_watering(strategy, "P1")
 
     # Await the async task triggered by _handle_watering
@@ -425,11 +425,11 @@ async def test_shot_interval_logic(vwc_coordinator, mock_hass) -> None:
     mock_hass.services.async_call.reset_mock()
 
     # 2. Try again 5 minutes later via _handle_watering directly
-    # Need to patch now() inside the method or set _last_shot_time manually
+    # Need to patch now() inside the method or set _last_cycle_timestamp manually
 
     # Set last shot time to 12:00
     last_time = datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt_util.UTC)
-    vwc_coordinator._last_shot_time = last_time
+    vwc_coordinator._last_cycle_timestamp = last_time.isoformat()
 
     # Current time 12:05 (Elapsed 5 min < 15)
     current_time = datetime(2023, 1, 1, 12, 5, 0, tzinfo=dt_util.UTC)
@@ -599,6 +599,48 @@ async def test_vwc_skips_watering_when_dark_and_skip_enabled(
         await await_pump_task()
 
     mock_hass.services.async_call.assert_not_called()
+
+
+async def test_vwc_waters_when_numeric_light_sensor_reports_on(
+    vwc_coordinator: VWCIrrigationCoordinator,
+    mock_hass: MagicMock,
+    mock_growspace: Growspace,
+) -> None:
+    """A numeric power sensor reporting a positive value means lights are ON.
+
+    Reproduces a real-world bug: a `sensor.*_current_power` entity reporting
+    "4" (watts) was misread as "off" by a binary-only on-check, permanently
+    blocking VWC pulse watering via the dark-period skip guard.
+    """
+    mock_growspace.irrigation_config.skip_during_dark = True
+    mock_growspace.environment_config = EnvironmentConfig(
+        soil_moisture_sensor="sensor.moisture",
+        light_sensors=["sensor.grow_light_power"],
+    )
+
+    def states_side_effect(entity_id: str) -> MagicMock | None:
+        if entity_id == "sensor.grow_light_power":
+            return MagicMock(state="4", domain="sensor")  # Light draws 4W → ON
+        if entity_id == "sensor.moisture":
+            return MagicMock(state="40.0")
+        return None
+
+    mock_hass.states.get.side_effect = states_side_effect
+
+    now_dt = datetime(2023, 1, 1, 9, 30, 0, tzinfo=dt_util.UTC)
+    with patch(
+        "custom_components.growspace_manager.vwc_irrigation_coordinator.now",
+        return_value=now_dt,
+    ):
+        await vwc_coordinator._update_loop(now_dt)
+        await await_pump_task()
+
+    mock_hass.services.async_call.assert_any_call(
+        "switch",
+        "turn_on",
+        {"entity_id": mock_growspace.irrigation_config.irrigation_pump_entity},
+        blocking=True,
+    )
 
 
 async def test_vwc_phase_transition_fires_logbook_event(
@@ -960,8 +1002,8 @@ async def test_handle_watering_cancels_lingering_task(
     mock_task.done.return_value = False
     vwc_coordinator._running_tasks["irrigation"] = mock_task
 
-    # We trigger watering (ensure _last_shot_time allows it)
-    vwc_coordinator._last_shot_time = None
+    # We trigger watering (ensure _last_cycle_timestamp allows it)
+    vwc_coordinator._last_cycle_timestamp = None
 
     now_dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt_util.UTC)
     with patch(
@@ -1033,7 +1075,7 @@ async def test_projected_shot_window_during_active_watering_window(
     # 09:30 — inside the P1/P2 window (P0 ends 09:00, P2 stops 18:00)
     now_dt = datetime(2023, 1, 1, 9, 30, 0, tzinfo=dt_util.UTC)
     vwc_coordinator._current_phase = "P2 - Maintenance"
-    vwc_coordinator._last_shot_time = None
+    vwc_coordinator._last_cycle_timestamp = None
 
     with patch(
         "custom_components.growspace_manager.vwc_irrigation_coordinator.now",
@@ -1054,7 +1096,9 @@ async def test_projected_shot_window_during_active_watering_window_with_cooldown
     # 09:30 — inside the P1/P2 window; last shot 5 minutes ago, interval is 15 minutes
     now_dt = datetime(2023, 1, 1, 9, 30, 0, tzinfo=dt_util.UTC)
     vwc_coordinator._current_phase = "P2 - Maintenance"
-    vwc_coordinator._last_shot_time = datetime(2023, 1, 1, 9, 25, 0, tzinfo=dt_util.UTC)
+    vwc_coordinator._last_cycle_timestamp = (
+        datetime(2023, 1, 1, 9, 25, 0, tzinfo=dt_util.UTC)
+    ).isoformat()
 
     with patch(
         "custom_components.growspace_manager.vwc_irrigation_coordinator.now",
@@ -1075,7 +1119,9 @@ async def test_projected_shot_window_ignores_expired_cooldown(
     # 09:30 — last shot 20 minutes ago, interval is 15 minutes, so cooldown has expired
     now_dt = datetime(2023, 1, 1, 9, 30, 0, tzinfo=dt_util.UTC)
     vwc_coordinator._current_phase = "P2 - Maintenance"
-    vwc_coordinator._last_shot_time = datetime(2023, 1, 1, 9, 10, 0, tzinfo=dt_util.UTC)
+    vwc_coordinator._last_cycle_timestamp = (
+        datetime(2023, 1, 1, 9, 10, 0, tzinfo=dt_util.UTC)
+    ).isoformat()
 
     with patch(
         "custom_components.growspace_manager.vwc_irrigation_coordinator.now",
@@ -1096,7 +1142,7 @@ async def test_projected_shot_window_during_p0_activation(
     # 08:30 — inside P0 (lights on 08:00, P0 ends 09:00)
     now_dt = datetime(2023, 1, 1, 8, 30, 0, tzinfo=dt_util.UTC)
     vwc_coordinator._current_phase = "P0 - Activation"
-    vwc_coordinator._last_shot_time = None
+    vwc_coordinator._last_cycle_timestamp = None
 
     with patch(
         "custom_components.growspace_manager.vwc_irrigation_coordinator.now",
@@ -1138,9 +1184,9 @@ async def test_projected_shot_window_rolls_to_tomorrow_near_end_of_active_window
     # 17:50 — still in P2; last shot 5 minutes ago means cooldown ends 18:05, past P2 stop (18:00)
     now_dt = datetime(2023, 1, 1, 17, 50, 0, tzinfo=dt_util.UTC)
     vwc_coordinator._current_phase = "P2 - Maintenance"
-    vwc_coordinator._last_shot_time = datetime(
+    vwc_coordinator._last_cycle_timestamp = datetime(
         2023, 1, 1, 17, 45, 0, tzinfo=dt_util.UTC
-    )
+    ).isoformat()
 
     with patch(
         "custom_components.growspace_manager.vwc_irrigation_coordinator.now",

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -33,6 +33,8 @@ from custom_components.growspace_manager.utils import (
     parse_date_field_v2,
     read_aggregated_sensor_value,
     read_environment_vpd,
+    any_light_sensor_on,
+    is_light_sensor_on,
     read_sensor_value,
     strip_markdown_fence,
 )
@@ -436,6 +438,52 @@ def test_read_sensor_value(hass: HomeAssistant) -> None:
     # 5. Invalid float states
     hass.states.async_set("sensor.invalid_test", "not-a-float")
     assert read_sensor_value(hass, "sensor.invalid_test") is None
+
+
+def test_is_light_sensor_on_numeric_sensor(hass: HomeAssistant) -> None:
+    """A numeric power sensor reporting a positive value is considered on."""
+    hass.states.async_set("sensor.light_power", "4")
+    assert is_light_sensor_on(hass, "sensor.light_power") == (True, True)
+
+    hass.states.async_set("sensor.light_power", "0")
+    assert is_light_sensor_on(hass, "sensor.light_power") == (False, True)
+
+
+def test_is_light_sensor_on_binary_sensor(hass: HomeAssistant) -> None:
+    """A binary-style entity is on/off based on its literal state string."""
+    hass.states.async_set("binary_sensor.light_switch", "on")
+    assert is_light_sensor_on(hass, "binary_sensor.light_switch") == (True, True)
+
+    hass.states.async_set("binary_sensor.light_switch", "off")
+    assert is_light_sensor_on(hass, "binary_sensor.light_switch") == (False, True)
+
+
+def test_is_light_sensor_on_unavailable_is_invalid(hass: HomeAssistant) -> None:
+    """Unavailable, unknown, or missing entities are reported as invalid."""
+    assert is_light_sensor_on(hass, "sensor.does_not_exist") == (False, False)
+
+    hass.states.async_set("sensor.flaky", STATE_UNAVAILABLE)
+    assert is_light_sensor_on(hass, "sensor.flaky") == (False, False)
+
+    hass.states.async_set("sensor.flaky", STATE_UNKNOWN)
+    assert is_light_sensor_on(hass, "sensor.flaky") == (False, False)
+
+
+def test_any_light_sensor_on_or_aggregates(hass: HomeAssistant) -> None:
+    """any_light_sensor_on ORs across sensors and is None when none are valid."""
+    assert any_light_sensor_on(hass, []) is None
+    assert any_light_sensor_on(hass, ["sensor.missing"]) is None
+
+    hass.states.async_set("sensor.power_a", "0")
+    hass.states.async_set("sensor.power_b", "5")
+    assert any_light_sensor_on(hass, ["sensor.power_a", "sensor.power_b"]) is True
+
+    hass.states.async_set("sensor.power_b", "0")
+    assert any_light_sensor_on(hass, ["sensor.power_a", "sensor.power_b"]) is False
+
+    assert (
+        any_light_sensor_on(hass, ["sensor.power_a", "sensor.unavailable_one"]) is False
+    )
 
 
 def test_read_aggregated_sensor_value(hass: HomeAssistant) -> None:


### PR DESCRIPTION
_is_lights_dark only treated binary "on" states as lights-on, so a numeric power-consumption sensor (e.g. sensor.*_current_power reporting "4") was always read as "off", permanently tripping the dark-period skip guard and silently blocking VWC pulse watering.

Extracts shared is_light_sensor_on/any_light_sensor_on helpers (handling both numeric sensor.* domains and binary state checks) and uses them in both _is_lights_dark and binary_sensor._determine_light_state, removing the duplicated _check_light_sensor method.

Also eliminates VWCIrrigationCoordinator._last_shot_time, which was stamped optimistically before the pump's "on" state was confirmed. Shot cooldown logic now reads the inherited _last_cycle_timestamp (only set once _run_pump_cycle confirms the switch turned on), so a skipped cycle no longer silently rate-limits subsequent shot attempts.