### PR TITLE
Add sensor settling delay before reporting irrigation/drain cycle com…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,995 +1,108 @@
 # Growspace Manager
 
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
+[![HACS Custom](https://img.shields.io/badge/HACS-Custom-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
 [![Quality Scale](https://img.shields.io/badge/Quality%20Scale-Gold-gold.svg?style=for-the-badge)](https://developers.home-assistant.io/docs/integration-quality-scale/)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge)](LICENSE)
+[![Version](https://img.shields.io/badge/Version-1.2.1-blue.svg?style=for-the-badge)](https://github.com/Venosta-web/growspace_manager/releases)
+[![License](https://img.shields.io/badge/License-MIT-green.svg?style=for-the-badge)](LICENSE)
 
-**Growspace Manager** is an enterprise-grade Home Assistant custom integration designed for professional and home cultivators alike to meticulously orchestrate, monitor, and automate cannabis cultivation environments. By combining advanced sensor integration, dynamic environment profiles, a Bayesian statistical inference engine, and a context-aware AI assistant, Growspace Manager elevates home automation into a precise crop-steering and cultivation operating system.
+**Growspace Manager** is a Home Assistant integration for indoor cultivators to track plants from seed to cure, automate climate and irrigation, and catch environmental problems before they damage your crop.
 
----
-
-## Table of Contents
-
-1. [Core Features](#core-features)
-2. [Advanced Capabilities](#advanced-capabilities)
-   - [Smart Irrigation & Crop Steering](#smart-irrigation--crop-steering)
-   - [Environmental VPD Control & Mold Risk Logic](#environmental-vpd-control--mold-risk-logic)
-   - [AI Diagnostics & Vision Checkup Engine](#ai-diagnostics--vision-checkup-engine)
-   - [Genetics, Breeding & Phenotype Scoring](#genetics-breeding--phenotype-scoring)
-   - [Post-Harvest Drying & Curing Metrics](#post-harvest-drying--curing-metrics)
-   - [Integrated Pest Management (IPM) & Nutrients](#integrated-pest-management-ipm--nutrients)
-   - [QR Label Printing](#qr-label-printing)
-3. [Installation Walkthrough](#installation-walkthrough)
-4. [Step-by-Step Configuration Guide](#step-by-step-configuration-guide)
-5. [Exhaustive Service API Reference](#exhaustive-service-api-reference)
-6. [Generated Entities Directory](#generated-entities-directory)
-7. [Real-World Automation Examples](#real-world-automation-examples)
-8. [Troubleshooting & Diagnostics](#troubleshooting--diagnostics)
+![Growspace Manager UI Card](images/growspace_manager_card_example.png)
+*Visual facility monitoring via the companion Lovelace card.*
 
 ---
 
 ## Core Features
 
-- **Detailed Plant Tracking**: Track individual plants from seedling/clone to harvest and final cure, documenting their growth stages, strains, phenotypes, grid positions, and health history.
-- **Visual Grid Layouts**: Define multi-row and multi-column grid layouts for your growspaces. Interact with your facility visually via the companion [Lovelace Growspace Card](https://github.com/Venosta-web/lovelace-growspace-manager-card).
-- **Smart Irrigation & Crop Steering**: Set VWC targets, trigger automatic pump and drainage controls, and switch between generative and vegetative watering profiles.
-- **Active Environment Control**: Automate dehumidifiers and HVAC devices using day/night dynamic VPD and relative humidity (RH) stage-specific targets.
-- **Bayesian Environmental Analytics**: Leverage a state-of-the-art Bayesian inference model to detect plant stress, mold risks, and optimal environment status before physical symptoms manifest.
-- **Genetics & Breeding Registry**: Catalog seed batches, log crosses, track parentage (donor/receiver), and score phenotypes to preserve keeper mother plants.
-- **Drying & Curing Analytics**: Track weight loss curves and stem-moisture decay during drying, automatically alerting you when the **Cure-Ready Threshold** is achieved.
-- **Integrated Pest Management (IPM) & Nutrition**: Schedule, track, and log preventative and reactive IPM/feeding cycles with stage-specific presets.
-- **Niimbot Label Printing**: Direct Bluetooth integration to print QR-enabled plant tags containing strains, breeder logos, genetic lineage, and lifecycle dates.
-- **Interactive AI Assistant**: Call on the Virtual Grow Master to analyze real-time sensors, diagnose environmental issues, and suggest ideal strain matches.
+- 🌱 **Detailed Plant Tracking**: Register and track individual plants through their lifecycle stages: `seedling → clone → mother → veg → flower → dry → cure`.
+- 📐 **Visual Grid Layouts**: Arrange your plants in physical rows and columns inside logical growspaces.
+- 💧 **Smart Irrigation & Crop Steering**: Configure vegetative or generative steering profiles (VWC targets, drybacks, shot frequencies) using substrate sensors.
+- ❄️ **Adaptive VPD Control**: Automate dehumidification and HVAC devices to dynamically steer Vapor Pressure Deficit targets based on plant stage and day/night light cycles.
+- 🧠 **Bayesian Environmental Analytics**: Probabilistically assess and report plant stress levels, mold risks, and schedule drift before physical symptoms appear.
+- 🧬 **Genetics & Breeding Log**: Catalog strain lineages, parental crosses, seed inventories, and evaluate/score phenotypes to preserve keeper mother plants.
+- 📦 **Post-Harvest Analytics**: Track daily weight decay curves and stem-moisture levels during drying to pinpoint optimal cure windows.
+- 🖨️ **Niimbot Label Printing**: Connect directly via Bluetooth to print QR-coded plant tags containing strains, breeder logos, and genetic lineage.
+- 💬 **Optional AI Grow Master**: Integrate standard Home Assistant Conversation Agents to inspect camera feeds (vision checkups) and chat with a context-aware Virtual Grow Master.
 
 ---
 
-## Advanced Capabilities
+## Lovelace Dashboard Integration
 
-### Smart Irrigation & Crop Steering
+To interact with your growspaces visually using drag-and-drop grids, batch plant actions, and live graphs, install the companion card:
 
-Growspace Manager implements professional **Crop Steering** principles by adjusting watering frequency and volume to influence plant behavior:
-
-- **Vegetative Steering**: Encourages structural biomass, root growth, and node density. It employs a higher frequency of smaller irrigation events (shots) during the day, maintaining higher Volumetric Water Content (VWC) in the substrate and keeping drybacks small (e.g., 10-15%).
-- **Generative Steering**: Signals the plant to focus energy on reproductive flower and resin production. It utilizes fewer, larger watering events with a significant overnight dryback (e.g., 25-30% dryback), prompting slight osmotic stress that increases flower formation.
-- **Balanced Steering**: A middle-ground maintenance profile designed for transition stages or stable mother environments.
-- **Runoff & Drainage Control**: Link runoff sensors and a drain pump. The integration monitors feed EC versus drain EC to calculate salt buildup, triggers the drain pump automatically post-irrigation, and alerts you if runoff volume drifts from target percentages.
-
-### Environmental VPD Control & Mold Risk Logic
-
-Unlike simple threshold sensors, Growspace Manager orchestrates active climate control:
-
-- **VPD Target Ramps**: Automatically computes VPD targets based on the current lifecycle stage (e.g., Veg: 0.8–1.1 kPa, Flower: 1.2–1.6 kPa) and adapts targets dynamically when lights transition between day and night cycles.
-- **Day/Night Hysteresis**: Prevents HVAC short-cycling by applying smart buffer margins and recognizing light status.
-- **Active Mold Risk Fan Control**: Incorporates relative humidity, canopy temperature, dew point, and circulation fan telemetry. If air circulation is stagnant and humidity spikes during the dark period, the Bayesian engine flags a high mold risk and triggers circulation fans or exhaust dampers to protect flowers.
-
-### AI Diagnostics & Vision Checkup Engine
-
-Combine computer vision with LLM smarts to secure your facility:
-
-- **Vision Checkups**: Trigger a high-resolution camera snapshot when lights are on, sending the image to an AI vision agent to inspect the canopy for drooping leaves (under/over-watering), pest damage, or chlorosis (nutrient deficiency).
-- **Context-Aware Advice**: The Virtual Grow Master integrates real-time ambient parameters (canopy VPD, substrate temp, CO2 ppm) and plant stage history to deliver hyper-specific advice compared to generic LLM chatbots.
-
-### Genetics, Breeding & Phenotype Scoring
-
-Never lose track of your breeding projects or elite selections:
-
-- **Breeding Registry**: Track seed batches, acquisition dates, generations (F1, F2, S1, IBL), and cross-parentage.
-- **Pollination Logs**: Document donor (pollen source) and receiver (seed-bearing) plant IDs, along with fertilization dates, which automatically schedules seed harvest tasks.
-- **Phenotype Scoring**: Evaluate selections using a standardized 1–10 scoring metric across:
-  - _Vigor_: Growth rate and branching robustness.
-  - _Internodal Spacing_: Density of budding sites.
-  - _Terpene Intensity_: Olfactory intensity and complexity.
-  - _Resin Production_: Trichome density and quality.
-  - _Mold Resistance_: Natural resilience to environmental stress.
-- **Keeper Flag**: Flag top-scoring phenotypes to easily trace and organize mother and clone groups.
-
-### Post-Harvest Drying & Curing Metrics
-
-Harvesting is only half the battle. Manage drying and curing with scientific precision:
-
-- **Weight Decay Curves**: Log daily weights during the drying stage to chart moisture loss over time. The integration computes the weight reduction percent (e.g., targeting a 60-65% drop from wet weight).
-- **Stem Moisture Meter Logs**: Input readings from wood/material moisture meters.
-- **Cure-Ready Threshold**: The system combines weight decay velocity and moisture readings. When the decay curve plateaus in the safe zone (typically 10-12% moisture), it triggers a notification that the harvest is ready for curing, protecting your terpenes from over-drying.
-
-### Integrated Pest Management (IPM) & Nutrients
-
-Establish strict facility protocols with scheduled presets:
-
-- **Nutrient Presets**: Save complex chemical and organic feeding recipes. Schedule feed cycles by days in veg/flower to automatically send alerts or update automated doser parameters.
-- **IPM Presets**: Save recipes for foliar sprays (e.g., Neem oil, Bacillus amyloliquefaciens) or predatory insect releases. Set maximum stage restrictions (e.g., never apply foliar sprays after Week 3 of Flower) to prevent bud contamination.
-
-### QR Label Printing
-
-Keep your physical garden perfectly synced with your digital records:
-
-- **Niimbot Integration**: Connects via Bluetooth to thermal label printers (e.g., Niimbot D11/D110/B21).
-- **Smart Labels**: Prints barcodes or QR codes linking directly to the plant sensor entity in Home Assistant. Includes the strain name, phenotype, breeder logo, parental lineage, and key dates.
+* **Repository**: [Lovelace Growspace Manager Card](https://github.com/Venosta-web/lovelace-growspace-manager-card)
+* **Basic Configuration**:
+  ```yaml
+  type: 'custom:growspace-manager-card'
+  default_growspace: flower_tent
+  ```
 
 ---
 
 ## Installation Walkthrough
 
-The Growspace Manager system requires the main integration and the companion custom Lovelace card.
+### Step 1: Install frontend card via HACS
+1. Go to **HACS** > **Frontend** in Home Assistant.
+2. Click the three vertical dots in the top-right corner and select **Custom repositories**.
+3. Add URL `https://github.com/Venosta-web/lovelace-growspace-manager-card` with category **Lovelace**.
+4. Search for `Growspace Manager Card` and click **Download**.
 
-### Step 1: Install the Lovelace Card via HACS
-
-1.  Navigate to **HACS** > **Frontend** in Home Assistant.
-2.  Click the three vertical dots in the top-right corner and select **Custom repositories**.
-3.  Enter the URL: `https://github.com/Venosta-web/lovelace-growspace-manager-card`
-4.  Select **Lovelace** as the category and click **Add**.
-5.  Search for `Growspace Manager Card` in HACS and click **Download / Install**.
-
-### Step 2: Install the Integration via HACS
-
-1.  Navigate to **HACS** > **Integrations** in Home Assistant.
-2.  Click the three vertical dots in the top-right corner and select **Custom repositories**.
-3.  Enter the URL: `https://github.com/Venosta-web/growspace_manager`
-4.  Select **Integration** as the category and click **Add**.
-5.  Search for `Growspace Manager` in HACS and click **Download / Install**.
-6.  **Restart Home Assistant** when prompted.
+### Step 2: Install integration via HACS
+1. Go to **HACS** > **Integrations** in Home Assistant.
+2. Click the three vertical dots in the top-right corner and select **Custom repositories**.
+3. Add URL `https://github.com/Venosta-web/growspace_manager` with category **Integration**.
+4. Search for `Growspace Manager` and click **Download**.
+5. **Restart Home Assistant**.
 
 ---
 
 ## Step-by-Step Configuration Guide
 
-### Step 1: Initialize the Integration
-
-1.  Navigate to **Settings** > **Devices & Services** in Home Assistant.
-2.  Click **+ Add Integration** in the bottom right.
-3.  Search for **Growspace Manager** and click to install.
-4.  Once initialized, you will see a Growspace Manager integration card.
-
-### Step 2: Define Your Growspaces
-
-1.  Click **Configure** on the Growspace Manager card.
-2.  Select **Manage Growspaces** from the menu and click **Submit**.
-3.  Choose **Add Growspace**.
-4.  Configure the details:
-    - **Name**: A descriptive name (e.g., "Veg Tent", "Flower Room").
-    - **Rows & Plants Per Row**: Sets up your layout grid dimensions (e.g., 2 rows, 4 plants per row).
-    - **Notification Target**: Specify your notification service (e.g., `notify.mobile_app_my_phone`).
-5.  Click **Submit** to create. Logical special spaces (`mothers`, `clones`, `drying`, `curing`) are automatically managed or can be configured.
-
-### Step 3: Set Up Environmental Sensors and Climate Control
-
-1.  In the integration **Configure** menu, select **Configure Growspace Environment** and click **Submit**.
-2.  Select your target growspace.
-3.  Configure sensor associations:
-    - **Temperature / Humidity / VPD Sensors**: Bind your physical DHT22, RuuviTag, or Ecowitt sensor entities.
-    - **Light Sensor**: Link a light switch or photodiode sensor. This enables Day/Night environmental analysis.
-    - **Circulation Fan / Exhaust Fan / Humidifier**: Bind active switches or fan controllers.
-    - **Dehumidifier Entity**: Bind your dehumidifier switch.
-    - **Control Dehumidifier**: Toggle `true` to let the integration automatically switch the dehumidifier on/off based on live VPD targets.
-4.  Input Stage-Specific targets (RH or VPD values for Veg, Early Flower, Mid Flower, Late Flower) and click **Submit**.
-
-### Step 4: Bind Irrigation & Drainage Hardware
-
-1.  Select **Configure Irrigation** from the configuration menu.
-2.  Select your growspace.
-3.  Link your **Irrigation Pump** (switch) and **Drain Pump** (switch) entities.
-4.  Define default watering and drain run durations (in seconds). Click **Submit**.
-
-### Step 5: Configure AI Settings
-
-1.  Select **Configure AI Settings** from the configuration menu.
-2.  Check **Enable AI Features**.
-3.  Choose your configured Home Assistant **Conversation Agent** (e.g., OpenAI, Google Gemini).
-4.  Click **Submit**.
-
----
-
-## Exhaustive Service API Reference
-
-All services can be invoked from automations, Lovelace buttons, or custom scripts.
-
-### Database & Library Management
-
-#### `growspace_manager.export_strain_library`
-
-Exports the entire strain catalog including descriptions, breeder logos, and gallery images to a single, easily portable ZIP archive.
-_No parameters required._
-
-#### `growspace_manager.import_strain_library`
-
-Imports a strain library from a previously exported ZIP file.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `file_path` | `string` | No | - | Full server path to the ZIP archive. |
-| `zip_base64` | `string` | No | - | Base64-encoded ZIP file payload (used for direct frontend uploads). |
-| `replace` | `boolean` | No | `false` | If `true`, completely replaces existing catalog; otherwise merges. |
-
-_Example:_
-
-```yaml
-service: growspace_manager.import_strain_library
-data:
-  file_path: "/home/homeassistant/.homeassistant/share/strain_library_backup.zip"
-  replace: true
-```
-
-#### `growspace_manager.clear_strain_library`
-
-Completely resets the local strain catalog database, removing all strain, phenotype, and breeder records.
-_No parameters required._
-
-#### `growspace_manager.get_strain_library`
-
-Fetches and returns the full strain library database (primarily utilized by frontend dashboards).
-_No parameters required._
-
-#### `growspace_manager.add_strain`
-
-Directly inserts a new strain variety with detailed genetic metadata into the library.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `strain` | `string` | Yes | - | Name of the strain (e.g., "Gorilla Glue #4"). |
-| `phenotype` | `string` | No | - | Phenotype description or identifier (e.g., "Sour Cut"). |
-| `breeder` | `string` | No | - | Name of the breeder or seed company. |
-| `type` | `string` | No | - | Strain classification (e.g., "Indica", "Sativa Hybrid"). |
-| `lineage` | `string` | No | - | Parent strains (e.g., "Sour Dubb x Chem Sis"). |
-| `sex` | `string` | No | - | Genetic sex (e.g., "Feminized", "Regular", "Autoflower"). |
-| `flower_days_min` | `integer` | No | - | Minimum expected flowering time (days). |
-| `flower_days_max` | `integer` | No | - | Maximum expected flowering time (days). |
-| `sativa_percentage` | `integer` | No | - | Sativa ratio (0 to 100). |
-| `indica_percentage` | `integer` | No | - | Indica ratio (0 to 100). |
-| `breeder_logo` | `string` | No | - | URL or local path to breeder's logo image. |
-| `description` | `string` | No | - | Rich description of characteristics, flavor profile, and aromas. |
-| `image_base64` | `string` | No | - | Base64-encoded image string for the main strain photo. |
-| `image_path` | `string` | No | - | Local server path to the main strain photo. |
-| `image_crop_meta` | `object` | No | - | Crop coordinates and metadata for the main image. |
-| `images` | `list` | No | - | Gallery image configurations, list of objects: `{path, crop_meta, is_thumbnail}`. |
-
-_Example:_
-
-```yaml
-service: growspace_manager.add_strain
-data:
-  strain: "Mac1"
-  breeder: "Capulator"
-  type: "Hybrid"
-  sex: "Clonely"
-  flower_days_min: 63
-  flower_days_max: 70
-```
-
-#### `growspace_manager.update_strain_meta`
-
-Updates genetic metadata, logs, or photos for an existing strain catalog entry.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `strain` | `string` | Yes | - | Name of the strain to modify. |
-| `phenotype` | `string` | No | - | Phenotype matching key. |
-| `breeder` | `string` | No | - | Name of the breeder or seed company. |
-| `type` | `string` | No | - | Strain classification (e.g., "Indica", "Sativa Hybrid"). |
-| `lineage` | `string` | No | - | Parent strains (e.g., "Sour Dubb x Chem Sis"). |
-| `sex` | `string` | No | - | Genetic sex (e.g., "Feminized", "Regular", "Autoflower"). |
-| `flower_days_min` | `integer` | No | - | Minimum expected flowering time (days). |
-| `flower_days_max` | `integer` | No | - | Maximum expected flowering time (days). |
-| `description` | `string` | No | - | Rich description of characteristics, flavor profile, and aromas. |
-| `image_base64` | `string` | No | - | Base64-encoded image string for the main strain photo. |
-| `image_path` | `string` | No | - | Local server path to the main strain photo. |
-| `image_crop_meta` | `object` | No | - | Crop coordinates and metadata for the main image. |
-| `images` | `list` | No | - | Gallery image configurations, list of objects: `{path, crop_meta, is_thumbnail}`. |
-| `sativa_percentage` | `integer` | No | - | Sativa ratio (0 to 100). |
-| `indica_percentage` | `integer` | No | - | Indica ratio (0 to 100). |
-| `breeder_logo` | `string` | No | - | URL or local path to breeder's logo image. |
-
-#### `growspace_manager.remove_strain`
-
-Deletes a strain record and all associated images from the catalog.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `strain` | `string` | Yes | - | Name of the strain to remove. |
-| `phenotype` | `string` | No | - | Specific phenotype to remove. |
-
----
-
-### Facility & Growspace Management
-
-#### `growspace_manager.add_growspace`
-
-Registers a new physical growspace zone.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `name` | `string` | Yes | - | Name of the growspace zone. |
-| `rows` | `integer` | Yes | - | Number of rows in grid (1-20). |
-| `plants_per_row` | `integer` | Yes | - | Number of columns in grid (1-20). |
-| `notification_target` | `string` | No | - | Mobile notification service name. |
-
-#### `growspace_manager.update_growspace`
-
-Updates configuration of an existing growspace.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Target growspace unique ID. |
-| `name` | `string` | No | - | New descriptive name. |
-| `rows` | `integer` | No | - | New row grid count. |
-| `plants_per_row` | `integer` | No | - | New columns per row count. |
-| `notification_target` | `string` | No | - | Updated notification target. |
-
-_Example:_
-
-```yaml
-service: growspace_manager.update_growspace
-data:
-  growspace_id: "room_1"
-  notification_target: "notify.mobile_app_ipad"
-```
-
-#### `growspace_manager.remove_growspace`
-
-Deletes a growspace zone and permanently un-registers all plants housed inside it.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Growspace ID to delete. |
-
-#### `growspace_manager.analyze_all_growspaces`
-
-Triggers an automated evaluation of all facility zones, producing a detailed markdown summary of environment statuses, plant health indicators, and recommendations.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `max_length` | `integer` | No | `1000` | Max character limit for the generated facility report. |
-
----
-
-### Plant & Lifecycle Stage Tracking
-
-#### `growspace_manager.add_plant`
-
-Places a single plant into a specific coordinate on the growspace grid.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Target growspace ID. |
-| `strain` | `string` | Yes | - | Strain name. |
-| `row` | `integer` | Yes | - | Grid row coordinate (starts at 1). |
-| `col` | `integer` | Yes | - | Grid column coordinate (starts at 1). |
-| `phenotype` | `string` | No | - | Phenotype description. |
-| `seedling_start` | `date` | No | - | Seedling stage start date (YYYY-MM-DD). |
-| `mother_start` | `date` | No | - | Mother stage start date. |
-| `clone_start` | `date` | No | - | Clone stage start. |
-| `veg_start` | `date` | No | - | Veg stage start date. |
-| `flower_start` | `date` | No | - | Flower stage start date. |
-| `dry_start` | `date` | No | - | Dry stage start date. |
-| `cure_start` | `date` | No | - | Cure stage start date. |
-| `notes` | `string` | No | - | Rich notes about plant history. |
-
-#### `growspace_manager.add_plants`
-
-Batch-inserts multiple plants of the same variety into consecutive empty spots in a growspace.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Target growspace ID. |
-| `strain` | `string` | Yes | - | Strain name. |
-| `amount` | `integer` | Yes | - | Quantity of plants to insert. |
-| `start_number` | `integer` | No | `1` | Suffix numbering starting index (e.g. "Chem Dog #1", "Chem Dog #2"). |
-| `seedling_start` | `date` | No | - | Seedling stage start date (YYYY-MM-DD). |
-| `mother_start` | `date` | No | - | Mother stage start date (YYYY-MM-DD). |
-| `clone_start` | `date` | No | - | Clone stage start date (YYYY-MM-DD). |
-| `veg_start` | `date` | No | - | Vegetative stage start date (YYYY-MM-DD). |
-| `flower_start` | `date` | No | - | Flowering stage start date (YYYY-MM-DD). |
-| `dry_start` | `date` | No | - | Drying stage start date (YYYY-MM-DD). |
-| `cure_start` | `date` | No | - | Curing stage start date (YYYY-MM-DD). |
-
-#### `growspace_manager.update_plant`
-
-Edits attributes, stages, or coordinate locations of a plant.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `plant_id` | `string` | Yes | - | Target plant ID. |
-| `growspace_id` | `string` | No | - | Target growspace ID. |
-| `strain` | `string` | No | - | New strain name. |
-| `phenotype` | `string` | No | - | Phenotype. |
-| `position` | `string` | No | - | Grid position string (e.g. "A1", "B2"). |
-| `row` | `integer` | No | - | New grid row. |
-| `col` | `integer` | No | - | New grid column. |
-| `seedling_start` | `date` | No | - | Seedling stage start date (YYYY-MM-DD). |
-| `mother_start` | `date` | No | - | Mother stage start date (YYYY-MM-DD). |
-| `clone_start` | `date` | No | - | Clone stage start date (YYYY-MM-DD). |
-| `veg_start` | `date` | No | - | Vegetative stage start date (YYYY-MM-DD). |
-| `flower_start` | `date` | No | - | Flowering stage start date (YYYY-MM-DD). |
-| `dry_start` | `date` | No | - | Drying stage start date (YYYY-MM-DD). |
-| `cure_start` | `date` | No | - | Curing stage start date (YYYY-MM-DD). |
-| `stage` | `string` | No | - | Directly set stage (`seedling`, `mother`, `clone`, `veg`, `flower`, `dry`, `cure`). |
-| `notes` | `string` | No | - | Update notes. |
-
-#### `growspace_manager.remove_plant`
-
-Deletes a plant and removes its sensor entity.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `plant_id` | `string` | Yes | - | Plant ID to remove. |
-
-#### `growspace_manager.move_plant`
-
-Relocates a plant to new coordinates. If another plant occupies the target spot, their positions switch.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `plant_id` | `string` | Yes | - | Target plant ID. |
-| `new_row` | `integer` | Yes | - | Target grid row coordinate. |
-| `new_col` | `integer` | Yes | - | Target grid column coordinate. |
-
-#### `growspace_manager.switch_plants`
-
-Explicitly swaps the grid positions of two plants.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `plant1_id` | `string` | Yes | - | First plant ID. |
-| `plant2_id` | `string` | Yes | - | Second plant ID. |
-
-#### `growspace_manager.transition_plant_stage`
-
-Transitions a plant to a new growth phase (e.g. flipping from Vegetative to Flowering).
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `plant_id` | `string` | Yes | - | Plant ID. |
-| `new_stage` | `string` | Yes | - | Stage: `seedling`, `mother`, `clone`, `veg`, `flower`, `dry`, `cure`. |
-| `transition_date`| `date` | No | _Today_ | Optional date transition occurred. |
-
-#### `growspace_manager.harvest_plant`
-
-Harvests a plant, records its metrics, and auto-routes it to the **Drying** growspace.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `plant_id` | `string` | Yes | - | Plant ID. |
-| `target_growspace_id`| `string`| No | _drying_ | Destination growspace zone. |
-| `transition_date`| `date` | No | _Today_ | Date of harvest. |
-| `wet_weight` | `float` | No | - | Wet weight at harvest in grams. |
-| `dry_weight` | `float` | No | - | Final cured dry weight in grams. |
-| `trim_weight` | `float` | No | - | Sugar leaf and trim weight in grams. |
-| `thc_percentage`| `float` | No | - | THC lab test score (0-100%). |
-| `cbd_percentage`| `float` | No | - | CBD lab test score (0-100%). |
-| `terpene_profile`| `string`| No | - | Rich description of terpenes (e.g., "Limonene dominant"). |
-
-#### `growspace_manager.take_clone`
-
-Creates multiple new clone seedlings from a mother plant and places them into the clones growspace.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `mother_plant_id`| `string` | Yes | - | Mother donor plant ID. |
-| `target_growspace_id`|`string`| No | _clones_ | Destination clones zone. |
-| `transition_date`| `date` | No | _Today_ | Date clones were cut. |
-| `num_clones` | `integer` | No | `1` | Quantity of clone cuttings taken. |
-
-#### `growspace_manager.move_clone`
-
-Relocates a rooted clone to a vegetative or mother growspace grid coordinate.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `plant_id` | `string` | Yes | - | Clone plant ID. |
-| `target_growspace_id`|`string`| Yes | - | Target veg/mother growspace. |
-| `transition_date`| `date` | No | _Today_ | Date of transplanting. |
-
-#### `growspace_manager.set_visual_tag`
-
-Attaches or clears a visual identification label (e.g. colored ties, nursery tags) to track physical plants easily.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `plant_id` | `string` | Yes | - | Target plant ID. |
-| `visual_tag` | `string` | No | - | Tag label (e.g., "Orange Clip"). Omit to clear. |
-
-#### `growspace_manager.reset_plant_last_watered`
-
-_Warning: E2E and Test Fixture Use Only._ Manually clears a plant's `last_watered` timestamp.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `plant_id` | `string` | Yes | - | Plant ID to modify. |
-
-#### `growspace_manager.batch_action`
-
-Executes a synchronized action across a list of plants.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `entity_ids` | `list` | Yes | - | Array of plant IDs. |
-| `action` | `string` | Yes | - | Action: `transition`, `harvest`, `remove`, `take_clone`. |
-| `data` | `object` | No | - | Dictionary parameters corresponding to the action chosen. |
-
-_Example:_
-
-```yaml
-service: growspace_manager.batch_action
-data:
-  entity_ids:
-    - "plant_uuid_1"
-    - "plant_uuid_2"
-  action: "transition"
-  data:
-    new_stage: "flower"
-```
-
----
-
-### Environmental & HVAC Controls
-
-#### `growspace_manager.configure_environment`
-
-Binds physical environmental monitors, light schedules, and active climate controls to a growspace zone.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Growspace zone ID. |
-| `temperature_sensor`| `string`| Yes | - | Ambient temperature sensor entity. |
-| `humidity_sensor`| `string`| Yes | - | Ambient relative humidity sensor entity. |
-| `vpd_sensor` | `string` | Yes | - | Vapor Pressure Deficit sensor entity (kPa). |
-| `co2_sensor` | `string` | No | - | Carbon Dioxide sensor entity (ppm). |
-| `circulation_fan`| `string` | No | - | Circulation fan switch/fan entity. |
-| `exhaust_entity` | `string` | No | - | Exhaust fan/damper switch/fan entity. |
-| `humidifier_entity`|`string` | No | - | Humidifier controller or switch. |
-| `dehumidifier_entity`|`string`| No | - | Dehumidifier controller or switch. |
-| `light_sensor` | `string` | No | - | Light level sensor or light switch status entity. |
-| `soil_moisture_sensor`|`string`| No | - | Substrate VWC soil moisture sensor entity. |
-| `stress_threshold`|`float` | No | `0.70` | Bayesian stress alert confidence threshold (0.50-0.95). |
-| `mold_threshold` | `float` | No | `0.75` | Bayesian mold alert confidence threshold (0.50-0.95). |
-| `control_dehumidifier`|`boolean`|No| `false`| Enable active automated target steering of the dehumidifier. |
-| `sensor_groups` | `object` | No | - | Configuration mapping for multidimensional heatmaps. |
-| `sensor_coordinates`|`object`| No | - | Coordinates map for multi-sensor configurations. |
-| `irrigation_tanks`| `object` | No | - | Irrigation nutrient tank volume & EC configurations. |
-
-#### `growspace_manager.remove_environment`
-
-Permanently disconnects all climate monitors and automated climate steering controllers from a growspace.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Target growspace zone ID. |
-
-#### `growspace_manager.set_dehumidifier_control`
-
-Toggles active dynamic climate steering on/off.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Growspace ID. |
-| `enabled` | `boolean`| Yes | - | Whether active control is enabled. |
-
----
-
-### Smart Irrigation & Steering
-
-#### `growspace_manager.set_irrigation_settings`
-
-Sets the basic plumbing hardware profiles and default cycle times for simple timer waterings.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Target growspace zone ID. |
-| `irrigation_pump_entity`|`string`| No | - | Feed pump switch entity ID. |
-| `drain_pump_entity`| `string` | No | - | Drainage pump switch entity ID. |
-| `irrigation_duration`|`integer`| No | - | Standard duration to run feed pump (seconds). |
-| `drain_duration` | `integer`| No | - | Standard duration to run drain pump (seconds). |
-
-#### `growspace_manager.set_irrigation_strategy`
-
-Configures high-level Volumetric Water Content (VWC) crop-steering automation schedules.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Target growspace zone ID. |
-| `enabled` | `boolean`| No | `true` | Toggles strategy-guided pump control. |
-| `lights_on_time` | `string` | No | "06:00:00"| Time of day lights switch on (HH:MM:SS format). |
-| `p0_duration_minutes`|`integer`|No | `120` | Root warmup time post-sunrise before first irrigation. |
-| `p2_stop_before_lights_off_minutes`|`integer`|No| `120`| Stop irrigating before sunset to allow overnight dryback. |
-| `target_vwc_percent`|`float` | No | `65.0` | Target VWC percentage during Phase 1 (irrigation ramp). |
-| `maintenance_dryback_percent`|`float`|No| `5.0`| Target dryback drop before triggering single maintenance shots. |
-| `shot_duration_seconds`|`integer`|No | `30` | Duration of each individual steering shot (seconds). |
-| `shot_interval_minutes`|`integer`|No | `15` | Minimum rest interval between steering shots. |
-
-#### `growspace_manager.add_irrigation_time`
-
-Manually schedules a daily fixed-time watering event.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Growspace zone ID. |
-| `time` | `string` | Yes | - | Watering trigger time (HH:MM:SS). |
-| `duration` | `integer`| No | - | Run duration override (seconds). |
-
-#### `growspace_manager.remove_irrigation_time`
-
-Removes a specific scheduled fixed watering time.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Growspace zone ID. |
-| `time` | `string` | Yes | - | Time to delete (HH:MM:SS). |
-
-#### `growspace_manager.reset_water_tracking`
-
-Resets the cumulative water consumption counter (liters/gallons) to zero.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Target growspace zone ID. |
-
----
-
-### Drainage & Runoff Monitoring
-
-#### `growspace_manager.add_drain_time`
-
-Schedules a fixed time to trigger the drainage pump manually (useful for flushing).
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Growspace zone ID. |
-| `time` | `string` | Yes | - | Trigger time (HH:MM:SS). |
-| `duration` | `integer`| No | - | Pump run duration override (seconds). |
-
-#### `growspace_manager.remove_drain_time`
-
-Removes a scheduled drain time.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Growspace zone. |
-| `time` | `string` | Yes | - | Time to delete (HH:MM:SS). |
-
-#### `growspace_manager.log_drain_reading`
-
-Manually documents runoff chemistry and volumes to track root-zone dynamics.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Growspace ID. |
-| `feed_ec` | `float` | Yes | - | Electrical conductivity of the feed input water (mS/cm). |
-| `drain_ec` | `float` | Yes | - | Electrical conductivity of the runoff/drain output (mS/cm). |
-| `drain_volume_ml`| `integer`| No | - | Total volume of runoff collected (mL). |
-| `feed_volume_ml` | `integer`| No | - | Total volume of feed solution applied (mL). |
-
-_Example:_
-
-```yaml
-service: growspace_manager.log_drain_reading
-data:
-  growspace_id: "tent_1"
-  feed_ec: 1.8
-  drain_ec: 2.2
-  drain_volume_ml: 600
-  feed_volume_ml: 3000
-```
-
-#### `growspace_manager.configure_drain_monitoring`
-
-Sets alarms and tracking guidelines for runoff performance.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Growspace zone ID. |
-| `enabled` | `boolean`| No | `true` | Toggle active runoff monitoring alerts. |
-| `max_ec_delta` | `float` | No | `1.0` | Maximum delta (Drain EC - Feed EC) allowed before salt buildup alert (mS/cm). |
-| `target_runoff_percent`|`integer`| No | `20` | Target runoff percentage (drainage volume / feed volume \* 100). |
-
----
-
-### Nutrition & Integrated Pest Management
-
-#### `growspace_manager.save_nutrient_preset`
-
-Schedules a nutrient feeding recipe and binds it to a plant stage.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `name` | `string` | Yes | - | Name of the feeding preset (e.g. "Late Bloom Recipe"). |
-| `nutrients` | `object` | Yes | - | Dictionary mapping nutrients and volumes (e.g., `{"Base A": 5.0, "Base B": 5.0, "Bloom Boost": 2.5}`). |
-| `preset_id` | `string` | No | - | Preset ID to overwrite. |
-| `stage` | `string` | No | - | Stage constraint: `seedling`, `mother`, `clone`, `veg`, `flower`. |
-| `min_days_in_stage`|`integer`| No | `0` | Minimum growth phase days required before recommending this recipe. |
-
-#### `growspace_manager.remove_nutrient_preset`
-
-Deletes a feeding recipe.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `preset_id` | `string` | Yes | - | Nutrient preset ID to delete. |
-
-#### `growspace_manager.save_ec_ramp_curve`
-
-Saves an Electrical Conductivity ramp schedule to guide automate dosers as plants mature in a stage.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `name` | `string` | Yes | - | Ramp curve name (e.g., "9-Week Bloom Ramp"). |
-| `stage` | `string` | Yes | - | Targeted stage (e.g., `flower`). |
-| `points` | `list` | Yes | - | List of target EC boundaries per week (e.g. `[{"week": 1, "ec_min": 1.2, "ec_max": 1.5}]`). |
-| `curve_id` | `string` | No | - | Curve ID to update. |
-
-#### `growspace_manager.remove_ec_ramp_curve`
-
-Deletes an EC ramp curve.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `curve_id` | `string` | Yes | - | EC ramp curve ID to remove. |
-
-#### `growspace_manager.save_ipm_preset`
-
-Creates an Integrated Pest Management protocol preset.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `name` | `string` | Yes | - | Preset protocol name (e.g., "Weekly Preventive Foliar"). |
-| `type` | `string` | Yes | - | Type: `preventative`, `treatment`, `repopulation`. |
-| `items` | `list` | Yes | - | List of pest control ingredients or actions. |
-| `preset_id` | `string` | No | - | Overwrite target preset ID. |
-| `stage` | `string` | No | - | Safety restriction stage (e.g., `veg` - spray will block in bloom). |
-| `min_days_in_stage`|`integer`| No | `0` | Days elapsed restriction. |
-
-_Example:_
-
-```yaml
-service: growspace_manager.save_ipm_preset
-data:
-  name: "Spider Mite Treatment"
-  type: "treatment"
-  items:
-    - "Spinosad Spray at 10mL/gal"
-    - "Deploy Phytoseiulus persimilis"
-  stage: "veg"
-```
-
-#### `growspace_manager.remove_ipm_preset`
-
-Deletes an IPM protocol preset.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `preset_id` | `string` | Yes | - | IPM preset ID. |
-
-#### `growspace_manager.apply_ipm`
-
-Logs a physical IPM application at a growspace or specific plant coordinates.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `preset_id` | `string` | Yes | - | IPM preset ID applied. |
-| `growspace_id` | `string` | No | - | Target growspace zone ID. |
-| `plant_ids` | `list` | No | - | Specific array of plant IDs treated. |
-| `notes` | `string` | No | - | Rich notes regarding observation. |
-
----
-
-### AI Assistant & Diagnostics
-
-#### `growspace_manager.ask_grow_advice`
-
-Interrogates the Virtual Grow Master regarding environmental state or general cultivation strategies.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Target growspace zone ID. |
-| `user_query` | `string` | No | - | Question (e.g., "Why are my leaves yellowing?"). |
-| `context_type` | `string` | No | `"general"` | Options: `general`, `diagnostic`, `optimization`, `planning`. |
-| `max_length` | `integer` | No | `1000` | Character ceiling for returned advice text. |
-
-#### `growspace_manager.strain_recommendation`
-
-Generates a context-aware strain recommendation based on your garden history and goals.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `user_query` | `string` | No | - | Natural language description of what you are looking for. |
-| `preferences` | `object` | No | - | Key-value pairs defining preferences. |
-| `growspace_id` | `string` | No | - | Specific growspace zone intended. |
-| `max_length` | `integer` | No | `1000` | Character ceiling for response. |
-
-#### `growspace_manager.trigger_vision_checkup`
-
-Instructs your camera system to snap a photo and run deep visual diagnosis on the canopy.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `growspace_id` | `string` | Yes | - | Target growspace zone ID. |
-
----
-
-### Genetics & Breeding Registry
-
-#### `growspace_manager.add_seed_batch`
-
-Registers a new seed collection batch in the inventory.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `strain_name` | `string` | Yes | - | Name of the strain variety. |
-| `breeder` | `string` | Yes | - | Seed company/breeder. |
-| `quantity` | `integer` | Yes | - | Quantity of seeds. |
-| `acquisition_date`|`string`| Yes | - | Acquisition date (YYYY-MM-DD). |
-| `generation` | `string` | Yes | - | Genetic stage (e.g. F1, F3, S1, IBL). |
-| `lineage` | `string` | Yes | - | Parental cross lineage (e.g. "Sour Kush x Blueberry"). |
-| `notes` | `string` | No | - | Custom notes. |
-
-#### `growspace_manager.update_seed_batch`
-
-Modifies inventory quantities or genetic parameters of an existing seed batch.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `batch_id` | `string` | Yes | - | Unique Seed Batch ID. |
-| `strain_name` | `string` | No | - | Name of the strain variety. |
-| `breeder` | `string` | No | - | Seed company/breeder. |
-| `quantity` | `integer` | No | - | Quantity of seeds. |
-| `acquisition_date`| `string` | No | - | Acquisition date (YYYY-MM-DD). |
-| `generation` | `string` | No | - | Genetic stage (e.g. F1, F3, S1, IBL). |
-| `lineage` | `string` | No | - | Parental cross lineage (e.g. "Sour Kush x Blueberry"). |
-| `notes` | `string` | No | - | Custom notes. |
-
-#### `growspace_manager.log_pollination`
-
-Registers a pollination event between two active plants to establish pedigree tracking.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `date` | `string` | Yes | - | Pollination date (YYYY-MM-DD). |
-| `donor_plant_id` | `string` | Yes | - | Pollen donor plant ID (Male/Reversed). |
-| `receiver_plant_id`|`string` | Yes | - | Seed receiver plant ID (Female). |
-| `notes` | `string` | No | - | Cross details. |
-
-#### `growspace_manager.score_phenotype`
-
-Evaluates a plant selections characteristics on a 1-10 scale.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `plant_id` | `string` | Yes | - | Target plant ID. |
-| `vigor` | `integer` | No | - | Vigor score (1-10). |
-| `internodal_spacing`|`integer`|No | - | Internodal density score (1-10). |
-| `terpene_intensity`|`integer`| No | - | Aromatics score (1-10). |
-| `resin` | `integer` | No | - | Trichome coverage score (1-10). |
-| `mold_resistance`|`integer`| No | - | Humidity tolerance / rot resistance (1-10). |
-| `yield_potential`|`integer` | No | - | Yield productivity potential (1-10). |
-| `keeper` | `boolean`| No | `false` | Tag this selection as an elite keeper. |
-| `notes` | `string` | No | - | Descriptive traits. |
-
-#### `growspace_manager.harvest_seeds`
-
-Converts a documented pollination event into a finalized seed batch inventory record.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `event_id` | `string` | Yes | - | Pollination event ID. |
-| `quantity` | `integer` | Yes | - | Number of viable seeds harvested. |
-| `notes` | `string` | No | - | Harvest information. |
-
----
-
-### Post-Harvest Drying & Curing
-
-#### `growspace_manager.log_drying_weight`
-
-Inputs daily weight checkpoints of a drying plant to calculate moisture decay curves.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `plant_id` | `string` | Yes | - | Drying plant ID. |
-| `weight_grams` | `float` | Yes | - | Current weight in grams. |
-| `date` | `string` | No | _Today_ | Reading date (ISO format YYYY-MM-DD). |
-
-_Example:_
-
-```yaml
-service: growspace_manager.log_drying_weight
-data:
-  plant_id: "dried_plant_01"
-  weight_grams: 420.5
-```
-
-#### `growspace_manager.log_moisture_reading`
-
-Records stem-moisture percentage values using material meters to pinpoint cure windows.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `plant_id` | `string` | Yes | - | Plant ID. |
-| `moisture_percent`|`float` | Yes | - | Substrate or stem moisture (0 to 100%). |
-| `date` | `string` | No | _Today_ | Reading date. |
-
----
-
-### Alerts & Utility
-
-#### `growspace_manager.test_notification`
-
-Simulates a scheduled milestone notification event to verify correct push routing.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `plant_id` | `string` | Yes | - | Target plant ID. |
-| `stage` | `string` | Yes | - | Stage: `veg` or `flower`. |
-| `days` | `integer` | Yes | - | Simulated day index (matches specific triggers). |
-
-#### `growspace_manager.print_label`
-
-Dispatches label files directly to a paired Niimbot bluetooth printer.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `plant_id` | `string` | No | - | Plant ID. If provided, prints individual tag. |
-| `strain` | `string` | No | - | Strain name (fallback if no plant ID). |
-| `phenotype` | `string` | No | - | Phenotype name. |
-| `breeder` | `string` | No | - | Breeder override. |
-| `lineage` | `string` | No | - | Genetic parents override. |
-| `breeder_logo` | `string` | No | - | Breeder logo image URL. |
-| `device_id` | `string` | No | - | Specific bluetooth MAC address override. |
-| `preview` | `boolean`| No | `false` | If `true`, returns base64 image preview in logs. |
-| `base_url` | `string` | No | - | Custom base URL for the QR code. |
-
-#### `growspace_manager.log_training_event`
-
-Logs physical canopy modifications (e.g. topping, lollipopping, defoliating) to build a plant timeline.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `technique` | `string` | Yes | - | Technique (e.g. "Topped", "LST", "Defoliated"). |
-| `growspace_id` | `string` | No | - | Target growspace zone. |
-| `plant_ids` | `list` | No | - | Specific treated plant ID array. |
-| `notes` | `string` | No | - | Rich notes describing training. |
-
----
-
-### Debugging & Maintenance Utilities
-
-#### `growspace_manager.debug_cleanup_legacy`
-
-Utility to remove orphans and legacy data rows from state databases.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `dry_only` | `boolean`| No | `false` | Only purges dry logs. |
-| `cure_only` | `boolean`| No | `false` | Only purges cure logs. |
-
-#### `growspace_manager.debug_list_growspaces`
-
-Dumps facility configurations and active registry maps directly into the Home Assistant system log for debugging.
-_No parameters required._
-
-#### `growspace_manager.debug_reset_special_growspaces`
-
-Resets system-managed physical zones (`drying`, `curing`, `clones`, `mothers`) back to standard state definitions.
-| Parameter | Type | Required | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `reset_dry` | `boolean`| No | `true` | Re-initializes dry overview zone. |
-| `reset_cure` | `boolean`| No | `true` | Re-initializes cure overview zone. |
-| `preserve_plants`|`boolean`| No | `true` | Preserves plant registers during reset. |
-
----
-
-## Generated Entities Directory
-
-Each growspace and registered plant dynamically populates a suite of entities in Home Assistant.
-
-### Facility & Zone Sensors
-
-- **Growspace Overview Sensor** (`sensor.<growspace_name>`): The heart of each zone. The state represents the active plant count, while the attributes maintain the layout grid dimensions, specific coordinates occupied, and detailed plant records. Used directly by the Lovelace Card.
-- **Growspaces List Sensor** (`sensor.growspaces_list`): Exposes an array of all registered facility zones.
-- **Notification Switch** (`switch.<growspace_name>_notifications`): Simple toggle to mute or unmute scheduled push alerts.
-- **Task Calendar** (`calendar.<growspace_name>_tasks`): Dedicated calendar mapping out feeding days, IPM sprays, tissue tests, and anticipated harvest targets.
-- **Strain Library Sensor** (`sensor.growspace_strain_library`): Displays cataloged strain counts. The attributes expose the average vegetative and flowering periods computed from historical harvest logs.
-
-### Plant Registry Sensors
-
-- **Plant Sensor** (`sensor.<plant_strain>_<row>_<col>`): Tracks lifecycle stage (`seedling`, `veg`, `flower`, etc.). Attributes preserve genetic details, acquisition dates, training events, watering counters, and unique plant ID strings.
-
-### Bayesian Environmental Monitors
-
-When environment sensors are bound to a zone, these high-intelligence binary sensors are spawned:
-
-- **Plants Under Stress** (`binary_sensor.<growspace_name>_plants_under_stress`): Evaluates temperature, humidity, VPD, and substrate moisture. Turns **ON** if conditions signal high osmotic or thermal stress.
-- **High Mold Risk** (`binary_sensor.<growspace_name>_high_mold_risk`): Monitored during dark cycles in mid-to-late flower. Combines dew point, RH, and air circulation fan statuses. Turns **ON** to warn of powdery mildew or bud rot risk.
-- **Optimal Conditions** (`binary_sensor.<growspace_name>_optimal_conditions`): Turns **ON** when environment parameters reside perfectly in the ideal VPD envelope for the current stage.
-- **Light Schedule Correct** (`binary_sensor.<growspace_name>_light_schedule_correct`): Matches the daily photoperiod run hours against stage constraints (e.g. 18/6 for veg, 12/12 for flower). Turns **OFF** to signal timer failures or accidental light leaks.
+1. **Initialize the Integration**: Go to **Settings** > **Devices & Services** > **+ Add Integration**, search for **Growspace Manager**, and install it.
+2. **Define Your Growspaces**: Click **Configure** on the integration card, select **Manage Growspaces**, and choose **Add Growspace** (e.g., set up a 2x4 grid for "Flower Room").
+3. **Configure Environment Sensors**: Bind your temperature, humidity, VPD, light, and circulation fan entities. Toggle **Control Dehumidifier** if you want target VPD-driven automation.
+4. **Bind Irrigation Hardware**: Bind your feed pump and drainage switches under **Configure Irrigation** to enable timers and steering triggers.
+5. **Configure AI (Optional)**: If you wish to use AI briefings and vision checkups, ensure you have set up a Home Assistant **Conversation Agent** (e.g., Google Generative AI or OpenAI) first. Then enable AI features in the integration configuration and bind it to that agent.
 
 ---
 
 ## Real-World Automation Examples
 
-### 1. Stage-Adaptive Humidifier & Dehumidifier Target Automation
-
-Automatically dynamically steers climate settings as plants mature through growth stages.
+### 1. Toggle Automated Dehumidifier Steering
+Turn on/off the integration's built-in target-VPD dehumidifier steering based on whether the growspace has active plants.
 
 ```yaml
-alias: "Climate: Stage-Adaptive VPD Targets"
-description: "Sync dehumidifier and humidifier targets to the current growth stage"
+alias: "Dehumidifier: Toggle Active Steering"
+description: "Enable dehumidifier steering only when the growspace is active"
 trigger:
   - platform: state
     entity_id: sensor.flower_tent_overview
 action:
   - choose:
-      # Vegetative stage environmental setup
+      # If plant count is greater than 0, enable steering
       - conditions:
-          - condition: state
+          - condition: numeric_state
             entity_id: sensor.flower_tent_overview
-            attribute: dominant_stage
-            state: "veg"
+            above: 0
         sequence:
           - service: growspace_manager.set_dehumidifier_control
             data:
               growspace_id: "flower_tent"
               enabled: true
-              target_vpd: 0.9
-      # Flowering stage environmental setup
+      # If growspace is empty, turn off dehumidifier steering
       - conditions:
-          - condition: state
+          - condition: numeric_state
             entity_id: sensor.flower_tent_overview
-            attribute: dominant_stage
-            state: "flower"
+            below: 1
         sequence:
           - service: growspace_manager.set_dehumidifier_control
             data:
               growspace_id: "flower_tent"
-              enabled: true
-              target_vpd: 1.4
+              enabled: false
 ```
 
-### 2. High Mold Risk Emergency Mitigation Automation
-
-Activates exhaust fans and increases internal air movement when Bayesian analysis flags mold threats.
+### 2. High Mold Risk Emergency Mitigation
+Boosts air movement and ventilation when the Bayesian analysis flags high mold risk during dark cycles.
 
 ```yaml
 alias: "IPM: High Mold Risk Mitigation"
@@ -1008,58 +121,41 @@ action:
       entity_id: switch.tent_exhaust_boost
   - service: notify.mobile_app_iphone
     data:
-      title: "⚠️ Facility Alert: High Mold Risk!"
-      message: "Relative humidity spiking during dark cycle in bloom. Exhaust fans boosted to 100%."
+      title: "⚠️ Mold Risk Alert: Flower Tent"
+      message: "Dew point and humidity thresholds crossed during dark cycle. Exhaust and circulation fans boosted to 100%."
 ```
 
-### 3. VWC-Guided Steering Automation
-
-Triggers micro-watering shots based on live substrate moisture and crop steering guidelines.
+### 3. Harvest Cure-Ready Notification
+Sends an alert to your phone when a drying plant's moisture decay curve reaches the cure-ready threshold (≤ 12%).
 
 ```yaml
-alias: "Irrigation: Substrate Steering Shot"
+alias: "Harvest: Plant Ready for Curing"
 trigger:
-  - platform: numeric_state
-    entity_id: sensor.flower_tent_substrate_moisture
-    below: 55 # VWC dryback target reached
-condition:
-  # Verify light cycle is on (steering occurs during day phase)
-  - condition: state
-    entity_id: binary_sensor.flower_tent_optimal_conditions
-    attribute: light_status
-    state: "on"
+  - platform: state
+    entity_id: binary_sensor.gorilla_glue_4_drying_ready_for_cure
+    to: "on"
 action:
-  - service: switch.turn_on
-    target:
-      entity_id: switch.irrigation_pump
-  - delay: "00:00:30" # Run for standard shot duration
-  - service: switch.turn_off
-    target:
-      entity_id: switch.irrigation_pump
-  - service: growspace_manager.log_training_event
+  - service: notify.mobile_app_iphone
     data:
-      technique: "Irrigation Shot"
-      notes: "Steering shot triggered at 55% VWC"
+      title: "🍯 Harvest Alert: Cure Ready!"
+      message: "Gorilla Glue #4 stem moisture is under 12%. Ready to transfer from dry rack to curing jars."
 ```
+
+---
+
+## Service API & Developers Reference
+
+All database, plant tracking, environmental setup, and scheduling operations are exposed as standard Home Assistant services.
+
+For a complete description of all services, parameters, and example payloads, see the [Exhaustive Service API Reference](docs/services.md).
 
 ---
 
 ## Troubleshooting & Diagnostics
 
-### Q: Why are my Bayesian environment sensors showing "Unavailable"?
-
-- **Check Sensor Binding**: Verify that the temperature, humidity, and VPD entities are correctly spelled and functioning.
-- **Initial Baseline**: The Bayesian engine needs a short warm-up period to gather baseline data. Ensure that the associated sensors have updated at least once since restarting Home Assistant.
-
-### Q: My Niimbot printer is paired but fails to print.
-
-- **Bluetooth Range**: Thermal printers require a strong BLE connection. Move the printer closer to your Home Assistant server or use a BLE proxy.
-- **Correct MAC Address**: Make sure to enter the printer's Bluetooth MAC address in the `device_id` field if auto-discovery fails.
-
-### Q: Database issues after upgrading the integration version.
-
-- **Run Diagnostics**: Use `growspace_manager.debug_cleanup_legacy` to clean orphaned records.
-- **Re-initialize Special Zones**: Run `growspace_manager.debug_reset_special_growspaces` to repair drying/curing registers.
+* **Bayesian environment sensors showing "Unavailable"**: Ensure you have successfully configured and bound valid Temperature, Humidity, and VPD sensors to the growspace environment. The Bayesian model also requires a brief warm-up period to pull initial sensor histories.
+* **Niimbot printer fails to print**: Verify Bluetooth signal strength and range. Consider utilizing a Bluetooth proxy if the Home Assistant server is located away from the grow room.
+* **Database errors after upgrades**: Run the `growspace_manager.debug_cleanup_legacy` service to purge orphaned data tables, and `growspace_manager.debug_reset_special_growspaces` to reconstruct overview zones.
 
 ---
 

--- a/custom_components/growspace_manager/CONTEXT.md
+++ b/custom_components/growspace_manager/CONTEXT.md
@@ -77,6 +77,16 @@ Contrast with **dark period skip** (category `irrigation_error`, gated by `log_t
 
 Success events (irrigation started, irrigation completed) use `CATEGORY_ALERT` and are gated by `log_to_logbook`.
 
+## Sensor Settling Delay
+
+The wait inserted between a cycle's pump turning off and the moment its "after" sensor reading (e.g. soil moisture) is captured for reporting. Water needs time to redistribute through the substrate before a moisture sensor reflects the cycle's true effect — reading immediately produces misleading "before -> after" comparisons (e.g. `46.2% -> 46.2%`) that look like the cycle had no effect.
+
+Computed as `min(measured_cycle_duration, 15s)` — longer cycles imply more water moved, so more settling time is allowed, capped so a long manual run doesn't stall reporting indefinitely.
+
+Applies to both **irrigation** and **drain** cycles (drain reporting does not yet capture moisture, but the delay is shared infrastructure for when it does). It runs as a background task *after* the pump is switched off and the cycle is freed up to run again — it never delays turning off hardware or blocks the next scheduled cycle. All values needed for the eventual report (timestamps, duration, moisture-before, volume/cycle counters) are snapshotted before the background task starts, so a fast-following cycle can't corrupt the numbers being reported for the previous one.
+
+Contrast with **Irrigation Failure Event** — failure paths (abort, error, skip) report immediately and do not wait for sensor settling, since there's no "after" reading to compare.
+
 ## IrrigationConfig.log_to_logbook
 
 Boolean flag (default `True`) that gates verbose operational logbook entries: successful starts, successful completions, and dark-period skips. It does **not** gate failure events — low tank, safety guard, aborts, and exceptions always appear in the logbook regardless of this flag.

--- a/custom_components/growspace_manager/const.py
+++ b/custom_components/growspace_manager/const.py
@@ -788,6 +788,9 @@ NOTIFICATION_DEBOUNCE_SECONDS: Final = 5
 MIN_STRESS_DURATION_SECONDS: Final = 180
 """Minimum seconds a stress event must persist before any notification is sent."""
 
+SENSOR_SETTLING_DELAY_CAP_SECONDS: Final = 15
+"""Upper bound on how long to wait for a moisture sensor to settle after a cycle."""
+
 NOTIFICATION_GROUP: Final = "growspace-manager"
 """Notification group/thread identifier for grouping on Android and iOS."""
 

--- a/custom_components/growspace_manager/irrigation_coordinator.py
+++ b/custom_components/growspace_manager/irrigation_coordinator.py
@@ -23,6 +23,7 @@ from .const import (
     CATEGORY_ALERT,
     CATEGORY_IRRIGATION_ERROR,
     EVENT_GROWSPACE_LOG_ENTRY,
+    SENSOR_SETTLING_DELAY_CAP_SECONDS,
 )
 from .exceptions import GrowspaceError
 from .models import Growspace, GrowspaceEvent
@@ -48,6 +49,7 @@ class BaseIrrigationCoordinator:
         self._main_coordinator = main_coordinator
         self._listeners: list[Callable[[], None]] = []
         self._running_tasks: dict[str, asyncio.Task[Any]] = {}
+        self._settling_tasks: set[asyncio.Task[Any]] = set()
         self._active_events: dict[str, dict[str, Any]] = {}
         self._last_cycle_timestamp: str | None = None
         # Daily safety-guard counters (reset by sub-coordinators at midnight)
@@ -136,6 +138,11 @@ class BaseIrrigationCoordinator:
                 if task and not task.done():
                     task.cancel()
             self._running_tasks.clear()
+
+            for settling_task in list(self._settling_tasks):
+                if not settling_task.done():
+                    settling_task.cancel()
+            self._settling_tasks.clear()
         _LOGGER.debug(
             "Cancelled all irrigation listeners for growspace %s", self._growspace_id
         )
@@ -592,50 +599,14 @@ class BaseIrrigationCoordinator:
                         cycle_volume = self._compute_cycle_volume_liters(duration)
                         self._volume_dispensed_today += cycle_volume
 
-                    # Capture moisture after
-                    moisture_after = None
-                    if self.growspace.environment_config.soil_moisture_sensor:
-                        moisture_after = self._get_sensor_value(
-                            self.growspace.environment_config.soil_moisture_sensor
-                        )
-
-                    # Build reasons
-                    reasons = [f"{event_type.capitalize()} cycle completed"]
-
-                    # Add Duration
-                    reasons.append(f"Duration: {int(duration_sec)}s")
-
-                    # Add Moisture Data
-                    if moisture_before is not None and moisture_after is not None:
-                        reasons.append(
-                            f"Moisture: {moisture_before:.1f}% -> {moisture_after:.1f}%"
-                        )
-                    elif moisture_after is not None:
-                        reasons.append(f"Moisture: {moisture_after:.1f}%")
-
-                    if (
-                        event_type == "irrigation"
-                        and self.growspace.irrigation_config.log_to_logbook
-                    ):
-                        self._fire_logbook_event(
-                            f"Irrigation completed — {int(duration_sec)}s "
-                            f"({self._volume_dispensed_today:.3f}L dispensed today)",
-                        )
-
-                    # Create and add the event
-                    event = GrowspaceEvent(
-                        sensor_type="irrigation"
-                        if event_type == "irrigation"
-                        else "drain",
-                        growspace_id=self._growspace_id,
-                        start_time=start_dt.isoformat(),
-                        end_time=end_dt.isoformat(),
-                        duration_sec=int(duration_sec),
-                        severity=1.0,
-                        category="irrigation",
-                        reasons=reasons,
+                    self._async_spawn_settling_report(
+                        event_type=event_type,
+                        start_dt=start_dt,
+                        end_dt=end_dt,
+                        duration_sec=duration_sec,
+                        moisture_before=moisture_before,
+                        volume_dispensed_today=self._volume_dispensed_today,
                     )
-                    self._main_coordinator.add_event(self._growspace_id, event)
             except Exception as e:  # noqa: BLE001
                 _LOGGER.error("Failed to log %s event: %s", event_type, e)
 
@@ -650,6 +621,95 @@ class BaseIrrigationCoordinator:
             )
             if event_type in self._running_tasks:
                 self._running_tasks.pop(event_type)
+
+    @callback
+    def _async_spawn_settling_report(
+        self,
+        *,
+        event_type: str,
+        start_dt: datetime,
+        end_dt: datetime,
+        duration_sec: float,
+        moisture_before: float | None,
+        volume_dispensed_today: float,
+    ) -> None:
+        """Spawn a background task that reports cycle completion after the sensor settles.
+
+        Snapshots everything the report needs up front so a fast-following
+        cycle can't corrupt the numbers describing this one — the only "live"
+        read the background task performs is the post-wait moisture value.
+        """
+        wait_seconds = min(duration_sec, SENSOR_SETTLING_DELAY_CAP_SECONDS)
+        task = self.hass.async_create_task(
+            self._async_report_cycle_completion(
+                event_type=event_type,
+                start_dt=start_dt,
+                end_dt=end_dt,
+                duration_sec=duration_sec,
+                moisture_before=moisture_before,
+                volume_dispensed_today=volume_dispensed_today,
+                wait_seconds=wait_seconds,
+            ),
+            name=f"irrigation_settling_report_{self._growspace_id}_{event_type}",
+        )
+        self._settling_tasks.add(task)
+        task.add_done_callback(self._settling_tasks.discard)
+
+    async def _async_report_cycle_completion(
+        self,
+        *,
+        event_type: str,
+        start_dt: datetime,
+        end_dt: datetime,
+        duration_sec: float,
+        moisture_before: float | None,
+        volume_dispensed_today: float,
+        wait_seconds: float,
+    ) -> None:
+        """Wait for the moisture sensor to settle, then report cycle completion."""
+        try:
+            # Water needs time to redistribute through the substrate before the
+            # sensor reflects the cycle's true effect.
+            await asyncio.sleep(wait_seconds)
+        except asyncio.CancelledError:
+            return
+
+        moisture_after = None
+        if self.growspace.environment_config.soil_moisture_sensor:
+            moisture_after = self._get_sensor_value(
+                self.growspace.environment_config.soil_moisture_sensor
+            )
+
+        reasons = [
+            f"{event_type.capitalize()} cycle completed",
+            f"Duration: {int(duration_sec)}s",
+        ]
+
+        if moisture_before is not None and moisture_after is not None:
+            reasons.append(f"Moisture: {moisture_before:.1f}% -> {moisture_after:.1f}%")
+        elif moisture_after is not None:
+            reasons.append(f"Moisture: {moisture_after:.1f}%")
+
+        if (
+            event_type == "irrigation"
+            and self.growspace.irrigation_config.log_to_logbook
+        ):
+            self._fire_logbook_event(
+                f"Irrigation completed — {int(duration_sec)}s "
+                f"({volume_dispensed_today:.3f}L dispensed today)",
+            )
+
+        event = GrowspaceEvent(
+            sensor_type="irrigation" if event_type == "irrigation" else "drain",
+            growspace_id=self._growspace_id,
+            start_time=start_dt.isoformat(),
+            end_time=end_dt.isoformat(),
+            duration_sec=int(duration_sec),
+            severity=1.0,
+            category="irrigation",
+            reasons=reasons,
+        )
+        self._main_coordinator.add_event(self._growspace_id, event)
 
     async def async_manual_run(self, duration: int | None) -> None:
         """Trigger a manual irrigation cycle, bypassing the schedule.

--- a/docs/adr/0008-sensor-settling-delay-as-background-task.md
+++ b/docs/adr/0008-sensor-settling-delay-as-background-task.md
@@ -1,0 +1,33 @@
+# ADR 0008 — Sensor Settling Delay runs as a snapshotted background task, not an inline wait
+
+**Status:** Accepted
+
+## Context
+
+Irrigation logbook entries report a "before -> after" moisture comparison (e.g. `Moisture: 46.2% -> 46.2%`). The "after" reading was being captured the instant the cycle's `asyncio.sleep(duration)` completed — before the pump even switched off — so the sensor had no time to reflect the water that was just delivered. The comparison routinely showed no change, making the report misleading.
+
+The fix is the **Sensor Settling Delay**: wait `min(measured_cycle_duration, 15s)` after the cycle ends before reading the "after" value and firing the completion report.
+
+Two structural questions had genuine alternatives:
+
+1. **Where does the wait live relative to "cycle is done"?**
+   - *Inline*: extend the `finally` block — sleep, then read sensor, then report, then release `_running_tasks`/`_active_events`. Simple, but ties up to 15 extra seconds of "this event type is busy", blocking a fast-following scheduled or manual cycle even though the pump is already off and hardware is ready.
+   - *Background task*: release `_running_tasks`/`_active_events` and turn the pump off immediately as today; spawn a separate task that sleeps, reads the sensor, and reports.
+
+2. **What does the background task read — live coordinator state, or a snapshot?**
+   - *Live*: re-read `self._volume_dispensed_today`, `self._cycles_today`, etc. when the task wakes up. Simpler, but if a new cycle starts during the 15s window, the report would describe the *old* cycle using the *new* cycle's counters.
+   - *Snapshot*: capture every value the report needs (`start_dt`, `end_dt`, `duration_sec`, `moisture_before`, `volume_dispensed_today`, `cycles_today`, `event_type`) into local variables before spawning the task. The task's only "live" read is the post-wait moisture sensor value — the one thing that *must* be read late.
+
+## Decision
+
+Run the Sensor Settling Delay as a **background task spawned after the pump is off and the running-task slots are released**, operating entirely on a **snapshot of pre-wait state**, with the post-wait moisture read as the sole live value. The task is tracked and cancelled on integration unload, mirroring the existing `_running_tasks`/`_active_events` cleanup discipline.
+
+## Rationale
+
+Decoupling "cycle is operationally complete" from "we're still composing its report" matches the existing principle that reporting/cosmetic concerns shouldn't gate hardware readiness — the pump must be free to run again the moment it's safe, regardless of how long sensor settling takes. Snapshotting is the only way to guarantee the eventual logbook entry actually describes the cycle it claims to, rather than whichever cycle happens to be running 15 seconds later.
+
+## Consequences
+
+- A `GrowspaceEvent` for a cycle can land in the timeline up to 15s after the cycle's pump switched off — slightly out of step with a fast-following cycle's "started" event, but internally consistent and accurate.
+- The background task must handle `CancelledError` cleanly (no firing events on a torn-down coordinator) and be registered for cleanup via the integration's unload path.
+- This delay/snapshot machinery is shared infrastructure: drain cycles don't yet report moisture, but when they do, they reuse the same settling wait rather than inventing a parallel mechanism.

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,0 +1,863 @@
+# Service API Reference
+
+All services provided by the Growspace Manager integration can be invoked from Home Assistant automations, Lovelace buttons, developer tools, or custom scripts.
+
+## Table of Services
+
+1. [Database & Library Management](#database--library-management)
+   - [growspace_manager.export_strain_library](#growspace_managerexport_strain_library)
+   - [growspace_manager.import_strain_library](#growspace_managerimport_strain_library)
+   - [growspace_manager.clear_strain_library](#growspace_managerclear_strain_library)
+   - [growspace_manager.get_strain_library](#growspace_managerget_strain_library)
+   - [growspace_manager.add_strain](#growspace_manageradd_strain)
+   - [growspace_manager.update_strain_meta](#growspace_managerupdate_strain_meta)
+   - [growspace_manager.remove_strain](#growspace_managerremove_strain)
+2. [Facility & Growspace Management](#facility--growspace-management)
+   - [growspace_manager.add_growspace](#growspace_manageradd_growspace)
+   - [growspace_manager.update_growspace](#growspace_managerupdate_growspace)
+   - [growspace_manager.remove_growspace](#growspace_managerremove_growspace)
+   - [growspace_manager.analyze_all_growspaces](#growspace_manageranalyze_all_growspaces)
+3. [Plant & Lifecycle Stage Tracking](#plant--lifecycle-stage-tracking)
+   - [growspace_manager.add_plant](#growspace_manageradd_plant)
+   - [growspace_manager.add_plants](#growspace_manageradd_plants)
+   - [growspace_manager.update_plant](#growspace_managerupdate_plant)
+   - [growspace_manager.remove_plant](#growspace_managerremove_plant)
+   - [growspace_manager.move_plant](#growspace_managermove_plant)
+   - [growspace_manager.switch_plants](#growspace_managerswitch_plants)
+   - [growspace_manager.transition_plant_stage](#growspace_managertransition_plant_stage)
+   - [growspace_manager.harvest_plant](#growspace_managerharvest_plant)
+   - [growspace_manager.take_clone](#growspace_managertake_clone)
+   - [growspace_manager.move_clone](#growspace_managermove_clone)
+   - [growspace_manager.set_visual_tag](#growspace_managerset_visual_tag)
+   - [growspace_manager.reset_plant_last_watered](#growspace_managerreset_plant_last_watered)
+   - [growspace_manager.batch_action](#growspace_managerbatch_action)
+4. [Environmental & HVAC Controls](#environmental--hvac-controls)
+   - [growspace_manager.configure_environment](#growspace_managerconfigure_environment)
+   - [growspace_manager.remove_environment](#growspace_managerremove_environment)
+   - [growspace_manager.set_dehumidifier_control](#growspace_managerset_dehumidifier_control)
+5. [Smart Irrigation & Steering](#smart-irrigation--steering)
+   - [growspace_manager.set_irrigation_settings](#growspace_managerset_irrigation_settings)
+   - [growspace_manager.set_irrigation_strategy](#growspace_managerset_irrigation_strategy)
+   - [growspace_manager.add_irrigation_time](#growspace_manageradd_irrigation_time)
+   - [growspace_manager.remove_irrigation_time](#growspace_managerremove_irrigation_time)
+   - [growspace_manager.reset_water_tracking](#growspace_managerreset_water_tracking)
+6. [Drainage & Runoff Monitoring](#drainage--runoff-monitoring)
+   - [growspace_manager.add_drain_time](#growspace_manageradd_drain_time)
+   - [growspace_manager.remove_drain_time](#growspace_managerremove_drain_time)
+   - [growspace_manager.log_drain_reading](#growspace_managerlog_drain_reading)
+   - [growspace_manager.configure_drain_monitoring](#growspace_managerconfigure_drain_monitoring)
+7. [Nutrition & Integrated Pest Management](#nutrition--integrated-pest-management)
+   - [growspace_manager.save_nutrient_preset](#growspace_managersave_nutrient_preset)
+   - [growspace_manager.remove_nutrient_preset](#growspace_managerremove_nutrient_preset)
+   - [growspace_manager.save_ec_ramp_curve](#growspace_managersave_ec_ramp_curve)
+   - [growspace_manager.remove_ec_ramp_curve](#growspace_managerremove_ec_ramp_curve)
+   - [growspace_manager.save_ipm_preset](#growspace_managersave_ipm_preset)
+   - [growspace_manager.remove_ipm_preset](#growspace_managerremove_ipm_preset)
+   - [growspace_manager.apply_ipm](#growspace_managerapply_ipm)
+8. [AI Assistant & Diagnostics](#ai-assistant--diagnostics)
+   - [growspace_manager.ask_grow_advice](#growspace_managerask_grow_advice)
+   - [growspace_manager.strain_recommendation](#growspace_managerstrain_recommendation)
+   - [growspace_manager.trigger_vision_checkup](#growspace_managertrigger_vision_checkup)
+9. [Genetics & Breeding Registry](#genetics--breeding-registry)
+   - [growspace_manager.add_seed_batch](#growspace_manageradd_seed_batch)
+   - [growspace_manager.update_seed_batch](#growspace_managerupdate_seed_batch)
+   - [growspace_manager.log_pollination](#growspace_managerlog_pollination)
+   - [growspace_manager.score_phenotype](#growspace_managerscore_phenotype)
+   - [growspace_manager.harvest_seeds](#growspace_managerharvest_seeds)
+10. [Post-Harvest Drying & Curing](#post-harvest-drying--curing)
+    - [growspace_manager.log_drying_weight](#growspace_managerlog_drying_weight)
+    - [growspace_manager.log_moisture_reading](#growspace_managerlog_moisture_reading)
+11. [Alerts & Utility](#alerts--utility)
+    - [growspace_manager.test_notification](#growspace_managertest_notification)
+    - [growspace_manager.print_label](#growspace_managerprint_label)
+    - [growspace_manager.log_training_event](#growspace_managerlog_training_event)
+12. [Debugging & Maintenance Utilities](#debugging--maintenance-utilities)
+    - [growspace_manager.debug_cleanup_legacy](#growspace_managerdebug_cleanup_legacy)
+    - [growspace_manager.debug_list_growspaces](#growspace_managerdebug_list_growspaces)
+    - [growspace_manager.debug_reset_special_growspaces](#growspace_managerdebug_reset_special_growspaces)
+
+---
+
+## Database & Library Management
+
+### `growspace_manager.export_strain_library`
+
+Exports the entire strain catalog including descriptions, breeder logos, and gallery images to a single, easily portable ZIP archive.
+*No parameters required.*
+
+### `growspace_manager.import_strain_library`
+
+Imports a strain library from a previously exported ZIP file.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `file_path` | `string` | No | - | Full server path to the ZIP archive. |
+| `zip_base64` | `string` | No | - | Base64-encoded ZIP file payload (used for direct frontend uploads). |
+| `replace` | `boolean` | No | `false` | If `true`, completely replaces existing catalog; otherwise merges. |
+
+*Example:*
+```yaml
+service: growspace_manager.import_strain_library
+data:
+  file_path: "/home/homeassistant/.homeassistant/share/strain_library_backup.zip"
+  replace: true
+```
+
+### `growspace_manager.clear_strain_library`
+
+Completely resets the local strain catalog database, removing all strain, phenotype, and breeder records.
+*No parameters required.*
+
+### `growspace_manager.get_strain_library`
+
+Fetches and returns the full strain library database (primarily utilized by frontend dashboards).
+*No parameters required.*
+
+### `growspace_manager.add_strain`
+
+Directly inserts a new strain variety with detailed genetic metadata into the library.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `strain` | `string` | Yes | - | Name of the strain (e.g., "Gorilla Glue #4"). |
+| `phenotype` | `string` | No | - | Phenotype description or identifier (e.g., "Sour Cut"). |
+| `breeder` | `string` | No | - | Name of the breeder or seed company. |
+| `type` | `string` | No | - | Strain classification (e.g., "Indica", "Sativa Hybrid"). |
+| `lineage` | `string` | No | - | Parent strains (e.g., "Sour Dubb x Chem Sis"). |
+| `sex` | `string` | No | - | Genetic sex (e.g., "Feminized", "Regular", "Autoflower"). |
+| `flower_days_min` | `integer` | No | - | Minimum expected flowering time (days). |
+| `flower_days_max` | `integer` | No | - | Maximum expected flowering time (days). |
+| `sativa_percentage` | `integer` | No | - | Sativa ratio (0 to 100). |
+| `indica_percentage` | `integer` | No | - | Indica ratio (0 to 100). |
+| `breeder_logo` | `string` | No | - | URL or local path to breeder's logo image. |
+| `description` | `string` | No | - | Rich description of characteristics, flavor profile, and aromas. |
+| `image_base64` | `string` | No | - | Base64-encoded image string for the main strain photo. |
+| `image_path` | `string` | No | - | Local server path to the main strain photo. |
+| `image_crop_meta` | `object` | No | - | Crop coordinates and metadata for the main image. |
+| `images` | `list` | No | - | Gallery image configurations, list of objects: `{path, crop_meta, is_thumbnail}`. |
+
+*Example:*
+```yaml
+service: growspace_manager.add_strain
+data:
+  strain: "Mac1"
+  breeder: "Capulator"
+  type: "Hybrid"
+  sex: "Clonely"
+  flower_days_min: 63
+  flower_days_max: 70
+```
+
+### `growspace_manager.update_strain_meta`
+
+Updates genetic metadata, logs, or photos for an existing strain catalog entry.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `strain` | `string` | Yes | - | Name of the strain to modify. |
+| `phenotype` | `string` | No | - | Phenotype matching key. |
+| `breeder` | `string` | No | - | Name of the breeder or seed company. |
+| `type` | `string` | No | - | Strain classification (e.g., "Indica", "Sativa Hybrid"). |
+| `lineage` | `string` | No | - | Parent strains (e.g., "Sour Dubb x Chem Sis"). |
+| `sex` | `string` | No | - | Genetic sex (e.g., "Feminized", "Regular", "Autoflower"). |
+| `flower_days_min` | `integer` | No | - | Minimum expected flowering time (days). |
+| `flower_days_max` | `integer` | No | - | Maximum expected flowering time (days). |
+| `description` | `string` | No | - | Rich description of characteristics, flavor profile, and aromas. |
+| `image_base64` | `string` | No | - | Base64-encoded image string for the main strain photo. |
+| `image_path` | `string` | No | - | Local server path to the main strain photo. |
+| `image_crop_meta` | `object` | No | - | Crop coordinates and metadata for the main image. |
+| `images` | `list` | No | - | Gallery image configurations, list of objects: `{path, crop_meta, is_thumbnail}`. |
+| `sativa_percentage` | `integer` | No | - | Sativa ratio (0 to 100). |
+| `indica_percentage` | `integer` | No | - | Indica ratio (0 to 100). |
+| `breeder_logo` | `string` | No | - | URL or local path to breeder's logo image. |
+
+### `growspace_manager.remove_strain`
+
+Deletes a strain record and all associated images from the catalog.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `strain` | `string` | Yes | - | Name of the strain to remove. |
+| `phenotype` | `string` | No | - | Specific phenotype to remove. |
+
+---
+
+## Facility & Growspace Management
+
+### `growspace_manager.add_growspace`
+
+Registers a new physical growspace zone.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `name` | `string` | Yes | - | Name of the growspace zone. |
+| `rows` | `integer` | Yes | - | Number of rows in grid (1-20). |
+| `plants_per_row` | `integer` | Yes | - | Number of columns in grid (1-20). |
+| `notification_target` | `string` | No | - | Mobile notification service name. |
+
+### `growspace_manager.update_growspace`
+
+Updates configuration of an existing growspace.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Target growspace unique ID. |
+| `name` | `string` | No | - | New descriptive name. |
+| `rows` | `integer` | No | - | New row grid count. |
+| `plants_per_row` | `integer` | No | - | New columns per row count. |
+| `notification_target` | `string` | No | - | Updated notification target. |
+
+*Example:*
+```yaml
+service: growspace_manager.update_growspace
+data:
+  growspace_id: "room_1"
+  notification_target: "notify.mobile_app_ipad"
+```
+
+### `growspace_manager.remove_growspace`
+
+Deletes a growspace zone and permanently un-registers all plants housed inside it.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Growspace ID to delete. |
+
+### `growspace_manager.analyze_all_growspaces`
+
+Triggers an automated evaluation of all facility zones, producing a detailed markdown summary of environment statuses, plant health indicators, and recommendations.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `max_length` | `integer` | No | `1000` | Max character limit for the generated facility report. |
+
+---
+
+## Plant & Lifecycle Stage Tracking
+
+### `growspace_manager.add_plant`
+
+Places a single plant into a specific coordinate on the growspace grid.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Target growspace ID. |
+| `strain` | `string` | Yes | - | Strain name. |
+| `row` | `integer` | Yes | - | Grid row coordinate (starts at 1). |
+| `col` | `integer` | Yes | - | Grid column coordinate (starts at 1). |
+| `phenotype` | `string` | No | - | Phenotype description. |
+| `seedling_start` | `date` | No | - | Seedling stage start date (YYYY-MM-DD). |
+| `mother_start` | `date` | No | - | Mother stage start date. |
+| `clone_start` | `date` | No | - | Clone stage start. |
+| `veg_start` | `date` | No | - | Veg stage start date. |
+| `flower_start` | `date` | No | - | Flower stage start date. |
+| `dry_start` | `date` | No | - | Dry stage start date. |
+| `cure_start` | `date` | No | - | Cure stage start date. |
+| `notes` | `string` | No | - | Rich notes about plant history. |
+
+### `growspace_manager.add_plants`
+
+Batch-inserts multiple plants of the same variety into consecutive empty spots in a growspace.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Target growspace ID. |
+| `strain` | `string` | Yes | - | Strain name. |
+| `amount` | `integer` | Yes | - | Quantity of plants to insert. |
+| `start_number` | `integer` | No | `1` | Suffix numbering starting index (e.g. "Chem Dog #1", "Chem Dog #2"). |
+| `seedling_start` | `date` | No | - | Seedling stage start date (YYYY-MM-DD). |
+| `mother_start` | `date` | No | - | Mother stage start date (YYYY-MM-DD). |
+| `clone_start` | `date` | No | - | Clone stage start date (YYYY-MM-DD). |
+| `veg_start` | `date` | No | - | Vegetative stage start date (YYYY-MM-DD). |
+| `flower_start` | `date` | No | - | Flowering stage start date (YYYY-MM-DD). |
+| `dry_start` | `date` | No | - | Drying stage start date (YYYY-MM-DD). |
+| `cure_start` | `date` | No | - | Curing stage start date (YYYY-MM-DD). |
+
+### `growspace_manager.update_plant`
+
+Edits attributes, stages, or coordinate locations of a plant.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `plant_id` | `string` | Yes | - | Target plant ID. |
+| `growspace_id` | `string` | No | - | Target growspace ID. |
+| `strain` | `string` | No | - | New strain name. |
+| `phenotype` | `string` | No | - | Phenotype. |
+| `position` | `string` | No | - | Grid position string (e.g. "A1", "B2"). |
+| `row` | `integer` | No | - | New grid row. |
+| `col` | `integer` | No | - | New grid column. |
+| `seedling_start` | `date` | No | - | Seedling stage start date (YYYY-MM-DD). |
+| `mother_start` | `date` | No | - | Mother stage start date (YYYY-MM-DD). |
+| `clone_start` | `date` | No | - | Clone stage start date (YYYY-MM-DD). |
+| `veg_start` | `date` | No | - | Vegetative stage start date (YYYY-MM-DD). |
+| `flower_start` | `date` | No | - | Flowering stage start date (YYYY-MM-DD). |
+| `dry_start` | `date` | No | - | Drying stage start date (YYYY-MM-DD). |
+| `cure_start` | `date` | No | - | Curing stage start date (YYYY-MM-DD). |
+| `stage` | `string` | No | - | Directly set stage (`seedling`, `mother`, `clone`, `veg`, `flower`, `dry`, `cure`). |
+| `notes` | `string` | No | - | Update notes. |
+
+### `growspace_manager.remove_plant`
+
+Deletes a plant and removes its sensor entity.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `plant_id` | `string` | Yes | - | Plant ID to remove. |
+
+### `growspace_manager.move_plant`
+
+Relocates a plant to new coordinates. If another plant occupies the target spot, their positions switch.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `plant_id` | `string` | Yes | - | Target plant ID. |
+| `new_row` | `integer` | Yes | - | Target grid row coordinate. |
+| `new_col` | `integer` | Yes | - | Target grid column coordinate. |
+
+### `growspace_manager.switch_plants`
+
+Explicitly swaps the grid positions of two plants.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `plant1_id` | `string` | Yes | - | First plant ID. |
+| `plant2_id` | `string` | Yes | - | Second plant ID. |
+
+### `growspace_manager.transition_plant_stage`
+
+Transitions a plant to a new growth phase (e.g. flipping from Vegetative to Flowering).
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `plant_id` | `string` | Yes | - | Plant ID. |
+| `new_stage` | `string` | Yes | - | Stage: `seedling`, `mother`, `clone`, `veg`, `flower`, `dry`, `cure`. |
+| `transition_date`| `date` | No | _Today_ | Optional date transition occurred. |
+
+### `growspace_manager.harvest_plant`
+
+Harvests a plant, records its metrics, and auto-routes it to the drying or curing growspaces.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `plant_id` | `string` | Yes | - | Plant ID. |
+| `target_growspace_id`| `string`| No | _drying_ | Destination growspace zone. |
+| `transition_date`| `date` | No | _Today_ | Date of harvest. |
+| `wet_weight` | `float` | No | - | Wet weight at harvest in grams. |
+| `dry_weight` | `float` | No | - | Final cured dry weight in grams. |
+| `trim_weight` | `float` | No | - | Sugar leaf and trim weight in grams. |
+| `thc_percentage`| `float` | No | - | THC lab test score (0-100%). |
+| `cbd_percentage`| `float` | No | - | CBD lab test score (0-100%). |
+| `terpene_profile`| `string`| No | - | Rich description of terpenes (e.g., "Limonene dominant"). |
+
+### `growspace_manager.take_clone`
+
+Creates multiple new clone seedlings from a mother plant and places them into the clones growspace.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `mother_plant_id`| `string` | Yes | - | Mother donor plant ID. |
+| `target_growspace_id`|`string`| No | _clones_ | Destination clones zone. |
+| `transition_date`| `date` | No | _Today_ | Date clones were cut. |
+| `num_clones` | `integer` | No | `1` | Quantity of clone cuttings taken. |
+
+### `growspace_manager.move_clone`
+
+Relocates a rooted clone to a vegetative or mother growspace grid coordinate.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `plant_id` | `string` | Yes | - | Clone plant ID. |
+| `target_growspace_id`|`string`| Yes | - | Target veg/mother growspace. |
+| `transition_date`| `date` | No | _Today_ | Date of transplanting. |
+
+### `growspace_manager.set_visual_tag`
+
+Attaches or clears a visual identification label (e.g. colored ties, nursery tags) to track physical plants easily.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `plant_id` | `string` | Yes | - | Target plant ID. |
+| `visual_tag` | `string` | No | - | Tag label (e.g., "Orange Clip"). Omit to clear. |
+
+### `growspace_manager.reset_plant_last_watered`
+
+*Warning: E2E and Test Fixture Use Only.* Manually clears a plant's `last_watered` timestamp.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `plant_id` | `string` | Yes | - | Plant ID to modify. |
+
+### `growspace_manager.batch_action`
+
+Executes a synchronized action across a list of plants.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `entity_ids` | `list` | Yes | - | Array of plant IDs. |
+| `action` | `string` | Yes | - | Action: `transition`, `harvest`, `remove`, `take_clone`. |
+| `data` | `object` | No | - | Dictionary parameters corresponding to the action chosen. |
+
+*Example:*
+```yaml
+service: growspace_manager.batch_action
+data:
+  entity_ids:
+    - "plant_uuid_1"
+    - "plant_uuid_2"
+  action: "transition"
+  data:
+    new_stage: "flower"
+```
+
+---
+
+## Environmental & HVAC Controls
+
+### `growspace_manager.configure_environment`
+
+Binds physical environmental monitors, light schedules, and active climate controls to a growspace zone.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Growspace zone ID. |
+| `temperature_sensor`| `string`| Yes | - | Ambient temperature sensor entity. |
+| `humidity_sensor`| `string`| Yes | - | Ambient relative humidity sensor entity. |
+| `vpd_sensor` | `string` | Yes | - | Vapor Pressure Deficit sensor entity (kPa). |
+| `co2_sensor` | `string` | No | - | Carbon Dioxide sensor entity (ppm). |
+| `circulation_fan`| `string` | No | - | Circulation fan switch/fan entity. |
+| `exhaust_entity` | `string` | No | - | Exhaust fan/damper switch/fan entity. |
+| `humidifier_entity`|`string` | No | - | Humidifier controller or switch. |
+| `dehumidifier_entity`|`string`| No | - | Dehumidifier controller or switch. |
+| `light_sensor` | `string` | No | - | Light level sensor or light switch status entity. |
+| `soil_moisture_sensor`|`string`| No | - | Substrate VWC soil moisture sensor entity. |
+| `stress_threshold`|`float` | No | `0.70` | Bayesian stress alert confidence threshold (0.50-0.95). |
+| `mold_threshold` | `float` | No | `0.75` | Bayesian mold alert confidence threshold (0.50-0.95). |
+| `control_dehumidifier`|`boolean`|No| `false`| Enable active automated target steering of the dehumidifier. |
+| `sensor_groups` | `object` | No | - | Configuration mapping for multidimensional heatmaps. |
+| `sensor_coordinates`|`object`| No | - | Coordinates map for multi-sensor configurations. |
+| `irrigation_tanks`| `object` | No | - | Irrigation nutrient tank volume & EC configurations. |
+
+### `growspace_manager.remove_environment`
+
+Permanently disconnects all climate monitors and automated climate steering controllers from a growspace.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Target growspace zone ID. |
+
+### `growspace_manager.set_dehumidifier_control`
+
+Toggles active dynamic climate steering on/off.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Growspace ID. |
+| `enabled` | `boolean`| Yes | - | Whether active control is enabled. |
+
+---
+
+## Smart Irrigation & Steering
+
+### `growspace_manager.set_irrigation_settings`
+
+Sets the basic plumbing hardware profiles and default cycle times for simple timer waterings.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Target growspace zone ID. |
+| `irrigation_pump_entity`|`string`| No | - | Feed pump switch entity ID. |
+| `drain_pump_entity`| `string` | No | - | Drainage pump switch entity ID. |
+| `irrigation_duration`|`integer`| No | - | Standard duration to run feed pump (seconds). |
+| `drain_duration` | `integer`| No | - | Standard duration to run drain pump (seconds). |
+
+### `growspace_manager.set_irrigation_strategy`
+
+Configures high-level Volumetric Water Content (VWC) crop-steering automation schedules.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Target growspace zone ID. |
+| `enabled` | `boolean`| No | `true` | Toggles strategy-guided pump control. |
+| `lights_on_time` | `string` | No | "06:00:00"| Time of day lights switch on (HH:MM:SS format). |
+| `p0_duration_minutes`|`integer`|No | `120` | Root warmup time post-sunrise before first irrigation. |
+| `p2_stop_before_lights_off_minutes`|`integer`|No| `120`| Stop irrigating before sunset to allow overnight dryback. |
+| `target_vwc_percent`|`float` | No | `65.0` | Target VWC percentage during Phase 1 (irrigation ramp). |
+| `maintenance_dryback_percent`|`float`|No| `5.0`| Target dryback drop before triggering single maintenance shots. |
+| `shot_duration_seconds`|`integer`|No | `30` | Duration of each individual steering shot (seconds). |
+| `shot_interval_minutes`|`integer`|No | `15` | Minimum rest interval between steering shots. |
+
+### `growspace_manager.add_irrigation_time`
+
+Manually schedules a daily fixed-time watering event.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Growspace zone ID. |
+| `time` | `string` | Yes | - | Watering trigger time (HH:MM:SS). |
+| `duration` | `integer`| No | - | Run duration override (seconds). |
+
+### `growspace_manager.remove_irrigation_time`
+
+Removes a specific scheduled fixed watering time.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Growspace zone ID. |
+| `time` | `string` | Yes | - | Time to delete (HH:MM:SS). |
+
+### `growspace_manager.reset_water_tracking`
+
+Resets the cumulative water consumption counter (liters/gallons) to zero.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Target growspace zone ID. |
+
+---
+
+## Drainage & Runoff Monitoring
+
+### `growspace_manager.add_drain_time`
+
+Schedules a fixed time to trigger the drainage pump manually (useful for flushing).
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Growspace zone ID. |
+| `time` | `string` | Yes | - | Trigger time (HH:MM:SS). |
+| `duration` | `integer`| No | - | Pump run duration override (seconds). |
+
+### `growspace_manager.remove_drain_time`
+
+Removes a scheduled drain time.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Growspace zone. |
+| `time` | `string` | Yes | - | Time to delete (HH:MM:SS). |
+
+### `growspace_manager.log_drain_reading`
+
+Manually documents runoff chemistry and volumes to track root-zone dynamics.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Growspace ID. |
+| `feed_ec` | `float` | Yes | - | Electrical conductivity of the feed input water (mS/cm). |
+| `drain_ec` | `float` | Yes | - | Electrical conductivity of the runoff/drain output (mS/cm). |
+| `drain_volume_ml`| `integer`| No | - | Total volume of runoff collected (mL). |
+| `feed_volume_ml` | `integer`| No | - | Total volume of feed solution applied (mL). |
+
+*Example:*
+```yaml
+service: growspace_manager.log_drain_reading
+data:
+  growspace_id: "tent_1"
+  feed_ec: 1.8
+  drain_ec: 2.2
+  drain_volume_ml: 600
+  feed_volume_ml: 3000
+```
+
+### `growspace_manager.configure_drain_monitoring`
+
+Sets alarms and tracking guidelines for runoff performance.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Growspace zone ID. |
+| `enabled` | `boolean`| No | `true` | Toggle active runoff monitoring alerts. |
+| `max_ec_delta` | `float` | No | `1.0` | Maximum delta (Drain EC - Feed EC) allowed before salt buildup alert (mS/cm). |
+| `target_runoff_percent`|`integer`| No | `20` | Target runoff percentage (drainage volume / feed volume * 100). |
+
+---
+
+## Nutrition & Integrated Pest Management
+
+### `growspace_manager.save_nutrient_preset`
+
+Schedules a nutrient feeding recipe and binds it to a plant stage.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `name` | `string` | Yes | - | Name of the feeding preset (e.g. "Late Bloom Recipe"). |
+| `nutrients` | `object` | Yes | - | Dictionary mapping nutrients and volumes (e.g., `{"Base A": 5.0, "Base B": 5.0, "Bloom Boost": 2.5}`). |
+| `preset_id` | `string` | No | - | Preset ID to overwrite. |
+| `stage` | `string` | No | - | Stage constraint: `seedling`, `mother`, `clone`, `veg`, `flower`. |
+| `min_days_in_stage`|`integer`| No | `0` | Minimum growth phase days required before recommending this recipe. |
+
+### `growspace_manager.remove_nutrient_preset`
+
+Deletes a feeding recipe.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `preset_id` | `string` | Yes | - | Nutrient preset ID to delete. |
+
+### `growspace_manager.save_ec_ramp_curve`
+
+Saves an Electrical Conductivity ramp schedule to guide automate dosers as plants mature in a stage.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `name` | `string` | Yes | - | Ramp curve name (e.g., "9-Week Bloom Ramp"). |
+| `stage` | `string` | Yes | - | Targeted stage (e.g., `flower`). |
+| `points` | `list` | Yes | - | List of target EC boundaries per week (e.g. `[{"week": 1, "ec_min": 1.2, "ec_max": 1.5}]`). |
+| `curve_id` | `string` | No | - | Curve ID to update. |
+
+### `growspace_manager.remove_ec_ramp_curve`
+
+Deletes an EC ramp curve.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `curve_id` | `string` | Yes | - | EC ramp curve ID to remove. |
+
+### `growspace_manager.save_ipm_preset`
+
+Creates an Integrated Pest Management protocol preset.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `name` | `string` | Yes | - | Preset protocol name (e.g., "Weekly Preventive Foliar"). |
+| `type` | `string` | Yes | - | Type: `preventative`, `treatment`, `repopulation`. |
+| `items` | `list` | Yes | - | List of pest control ingredients or actions. |
+| `preset_id` | `string` | No | - | Overwrite target preset ID. |
+| `stage` | `string` | No | - | Safety restriction stage (e.g., `veg` - spray will block in bloom). |
+| `min_days_in_stage`|`integer`| No | `0` | Days elapsed restriction. |
+
+*Example:*
+```yaml
+service: growspace_manager.save_ipm_preset
+data:
+  name: "Spider Mite Treatment"
+  type: "treatment"
+  items:
+    - "Spinosad Spray at 10mL/gal"
+    - "Deploy Phytoseiulus persimilis"
+  stage: "veg"
+```
+
+### `growspace_manager.remove_ipm_preset`
+
+Deletes an IPM protocol preset.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `preset_id` | `string` | Yes | - | IPM preset ID. |
+
+### `growspace_manager.apply_ipm`
+
+Logs a physical IPM application at a growspace or specific plant coordinates.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `preset_id` | `string` | Yes | - | IPM preset ID applied. |
+| `growspace_id` | `string` | No | - | Target growspace zone ID. |
+| `plant_ids` | `list` | No | - | Specific array of plant IDs treated. |
+| `notes` | `string` | No | - | Rich notes regarding observation. |
+
+---
+
+## AI Assistant & Diagnostics
+
+### `growspace_manager.ask_grow_advice`
+
+Interrogates the Virtual Grow Master regarding environmental state or general cultivation strategies.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Target growspace zone ID. |
+| `user_query` | `string` | No | - | Question (e.g., "Why are my leaves yellowing?"). |
+| `context_type` | `string` | No | `"general"` | Options: `general`, `diagnostic`, `optimization`, `planning`. |
+| `max_length` | `integer` | No | `1000` | Character ceiling for returned advice text. |
+
+### `growspace_manager.strain_recommendation`
+
+Generates a context-aware strain recommendation based on your garden history and goals.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `user_query` | `string` | No | - | Natural language description of what you are looking for. |
+| `preferences` | `object` | No | - | Key-value pairs defining preferences. |
+| `growspace_id` | `string` | No | - | Specific growspace zone intended. |
+| `max_length` | `integer` | No | `1000` | Character ceiling for response. |
+
+### `growspace_manager.trigger_vision_checkup`
+
+Instructs your camera system to snap a photo and run deep visual diagnosis on the canopy.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `growspace_id` | `string` | Yes | - | Target growspace zone ID. |
+
+---
+
+## Genetics & Breeding Registry
+
+### `growspace_manager.add_seed_batch`
+
+Registers a new seed collection batch in the inventory.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `strain_name` | `string` | Yes | - | Name of the strain variety. |
+| `breeder` | `string` | Yes | - | Seed company/breeder. |
+| `quantity` | `integer` | Yes | - | Quantity of seeds. |
+| `acquisition_date`|`string`| Yes | - | Acquisition date (YYYY-MM-DD). |
+| `generation` | `string` | Yes | - | Genetic stage (e.g. F1, F3, S1, IBL). |
+| `lineage` | `string` | Yes | - | Parental cross lineage (e.g. "Sour Kush x Blueberry"). |
+| `notes` | `string` | No | - | Custom notes. |
+
+### `growspace_manager.update_seed_batch`
+
+Modifies inventory quantities or genetic parameters of an existing seed batch.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `batch_id` | `string` | Yes | - | Unique Seed Batch ID. |
+| `strain_name` | `string` | No | - | Name of the strain variety. |
+| `breeder` | `string` | No | - | Seed company/breeder. |
+| `quantity` | `integer` | No | - | Quantity of seeds. |
+| `acquisition_date`| `string` | No | - | Acquisition date (YYYY-MM-DD). |
+| `generation` | `string` | No | - | Genetic stage (e.g. F1, F3, S1, IBL). |
+| `lineage` | `string` | No | - | Parental cross lineage (e.g. "Sour Kush x Blueberry"). |
+| `notes` | `string` | No | - | Custom notes. |
+
+### `growspace_manager.log_pollination`
+
+Registers a pollination event between two active plants to establish pedigree tracking.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `date` | `string` | Yes | - | Pollination date (YYYY-MM-DD). |
+| `donor_plant_id` | `string` | Yes | - | Pollen donor plant ID (Male/Reversed). |
+| `receiver_plant_id`|`string` | Yes | - | Seed receiver plant ID (Female). |
+| `notes` | `string` | No | - | Cross details. |
+
+### `growspace_manager.score_phenotype`
+
+Evaluates a plant selection's characteristics on a 1-10 scale.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `plant_id` | `string` | Yes | - | Target plant ID. |
+| `vigor` | `integer` | No | - | Vigor score (1-10). |
+| `internodal_spacing`|`integer`|No | - | Internodal density score (1-10). |
+| `terpene_intensity`|`integer`| No | - | Aromatics score (1-10). |
+| `resin` | `integer` | No | - | Trichome coverage score (1-10). |
+| `mold_resistance`|`integer`| No | - | Humidity tolerance / rot resistance (1-10). |
+| `yield_potential`|`integer` | No | - | Yield productivity potential (1-10). |
+| `keeper` | `boolean`| No | `false` | Tag this selection as an elite keeper. |
+| `notes` | `string` | No | - | Descriptive traits. |
+
+### `growspace_manager.harvest_seeds`
+
+Converts a documented pollination event into a finalized seed batch inventory record.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `event_id` | `string` | Yes | - | Pollination event ID. |
+| `quantity` | `integer` | Yes | - | Number of viable seeds harvested. |
+| `notes` | `string` | No | - | Harvest information. |
+
+---
+
+## Post-Harvest Drying & Curing
+
+### `growspace_manager.log_drying_weight`
+
+Inputs daily weight checkpoints of a drying plant to calculate moisture decay curves.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `plant_id` | `string` | Yes | - | Drying plant ID. |
+| `weight_grams` | `float` | Yes | - | Current weight in grams. |
+| `date` | `string` | No | _Today_ | Reading date (ISO format YYYY-MM-DD). |
+
+*Example:*
+```yaml
+service: growspace_manager.log_drying_weight
+data:
+  plant_id: "dried_plant_01"
+  weight_grams: 420.5
+```
+
+### `growspace_manager.log_moisture_reading`
+
+Records stem-moisture percentage values using material meters to pinpoint cure windows.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `plant_id` | `string` | Yes | - | Plant ID. |
+| `moisture_percent`|`float` | Yes | - | Substrate or stem moisture (0 to 100%). |
+| `date` | `string` | No | _Today_ | Reading date. |
+
+---
+
+## Alerts & Utility
+
+### `growspace_manager.test_notification`
+
+Simulates a scheduled milestone notification event to verify correct push routing.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `plant_id` | `string` | Yes | - | Target plant ID. |
+| `stage` | `string` | Yes | - | Stage: `veg` or `flower`. |
+| `days` | `integer` | Yes | - | Simulated day index (matches specific triggers). |
+
+### `growspace_manager.print_label`
+
+Dispatches label files directly to a paired Niimbot bluetooth printer.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `plant_id` | `string` | No | - | Plant ID. If provided, prints individual tag. |
+| `strain` | `string` | No | - | Strain name (fallback if no plant ID). |
+| `phenotype` | `string` | No | - | Phenotype name. |
+| `breeder` | `string` | No | - | Breeder override. |
+| `lineage` | `string` | No | - | Genetic parents override. |
+| `breeder_logo` | `string` | No | - | Breeder logo image URL. |
+| `device_id` | `string` | No | - | Specific bluetooth MAC address override. |
+| `preview` | `boolean`| No | `false` | If `true`, returns base64 image preview in logs. |
+| `base_url` | `string` | No | - | Custom base URL for the QR code. |
+
+### `growspace_manager.log_training_event`
+
+Logs physical canopy modifications (e.g. topping, lollipopping, defoliating) to build a plant timeline.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `technique` | `string` | Yes | - | Technique (e.g. "Topped", "LST", "Defoliated"). |
+| `growspace_id` | `string` | No | - | Target growspace zone. |
+| `plant_ids` | `list` | No | - | Specific treated plant ID array. |
+| `notes` | `string` | No | - | Rich notes describing training. |
+
+---
+
+## Debugging & Maintenance Utilities
+
+### `growspace_manager.debug_cleanup_legacy`
+
+Utility to remove orphans and legacy data rows from state databases.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `dry_only` | `boolean`| No | `false` | Only purges dry logs. |
+| `cure_only` | `boolean`| No | `false` | Only purges cure logs. |
+
+### `growspace_manager.debug_list_growspaces`
+
+Dumps facility configurations and active registry maps directly into the Home Assistant system log for debugging.
+*No parameters required.*
+
+### `growspace_manager.debug_reset_special_growspaces`
+
+Resets system-managed physical zones (`drying`, `curing`, `clones`, `mothers`) back to standard state definitions.
+
+| Parameter | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `reset_dry` | `boolean`| No | `true` | Re-initializes dry overview zone. |
+| `reset_cure` | `boolean`| No | `true` | Re-initializes cure overview zone. |
+| `preserve_plants`|`boolean`| No | `true` | Preserves plant registers during reset. |

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Growspace Manager",
   "hacs": "2.0.5",
-  "homeassistant": "2025.12.5",
+  "homeassistant": "2026.5.4",
   "render_readme": true,
   "zip_release": true,
   "filename": "growspace_manager.zip"

--- a/tests/services/test_irrigation_coordinator.py
+++ b/tests/services/test_irrigation_coordinator.py
@@ -20,6 +20,23 @@ from homeassistant.exceptions import ServiceValidationError
 GROWSPACE_ID = "test_growspace"
 ENTRY_ID = "test_entry_id"
 
+_REAL_ASYNCIO_SLEEP = asyncio.sleep
+
+
+async def _await_settling_report(add_event_mock: MagicMock) -> None:
+    """Yield to the event loop until the deferred settling-report task fires.
+
+    The completion report runs in a background task after a settling delay
+    (see Sensor Settling Delay), so tests must yield control for it to run.
+    Uses the real asyncio.sleep — tests patch asyncio.sleep to resolve
+    instantly, and the autouse freeze_time fixture breaks wait_for() timeouts.
+    """
+    for _ in range(1000):
+        if add_event_mock.call_count:
+            return
+        await _REAL_ASYNCIO_SLEEP(0)
+    pytest.fail("Settling report task never completed")
+
 
 @pytest.fixture
 def mock_main_coordinator() -> MagicMock:
@@ -274,9 +291,10 @@ async def test_run_pump_cycle(
                 found_notify = True
                 break
         assert found_notify, "Notification service call not found"
-        mock_sleep.assert_awaited_once_with(30)
+        mock_sleep.assert_any_await(30)
 
-        # Verify event logging
+        # Verify event logging — fired from the deferred settling-report task
+        await _await_settling_report(mock_main_coordinator.add_event)
         mock_main_coordinator.add_event.assert_called_once()
         args, _ = mock_main_coordinator.add_event.call_args
         assert args[0] == GROWSPACE_ID
@@ -774,6 +792,7 @@ async def test_run_pump_cycle_with_moisture_logging(
     ):
         await coordinator._run_pump_cycle("irrigation", "switch.pump", 30, {})
 
+        await _await_settling_report(mock_main_coordinator.add_event)
         mock_main_coordinator.add_event.assert_called_once()
         _args, _ = mock_main_coordinator.add_event.call_args
         # Removed unused event = args[1]
@@ -815,12 +834,88 @@ async def test_run_pump_cycle_moisture_after_only(
     ):
         await coordinator._run_pump_cycle("irrigation", "switch.pump", 30, {})
 
+        await _await_settling_report(mock_main_coordinator.add_event)
         mock_main_coordinator.add_event.assert_called_once()
         args, _ = mock_main_coordinator.add_event.call_args
         event = args[1]
 
         # Verify moisture is in reasons (only after value)
         assert any("Moisture: 55.8%" in r for r in event.reasons)
+
+
+async def test_run_pump_cycle_defers_completion_report_until_sensor_settles(
+    mock_hass: MagicMock, mock_config_entry: MagicMock, mock_main_coordinator: MagicMock
+) -> None:
+    """Test that the completion report waits for the sensor to settle.
+
+    The "after" moisture reading and completion logbook/event must not be
+    captured the instant the cycle ends — they wait for the settling delay so
+    the sensor has time to physically catch up, then read the live value.
+    """
+    coordinator = IrrigationCoordinator(
+        mock_hass, mock_config_entry, GROWSPACE_ID, mock_main_coordinator
+    )
+
+    mock_main_coordinator.growspaces[GROWSPACE_ID].environment_config = MagicMock()
+    mock_main_coordinator.growspaces[
+        GROWSPACE_ID
+    ].environment_config.soil_moisture_sensor = "sensor.moisture"
+
+    mock_before_state = MagicMock(state="40.0")
+    mock_after_state = MagicMock(state="60.0")
+    mock_hass.states.get.side_effect = [mock_before_state, mock_after_state]
+
+    real_sleep = asyncio.sleep
+    settling_started = asyncio.Event()
+    settling_can_proceed = asyncio.Event()
+    sleep_calls: list[int] = []
+
+    async def fake_sleep(duration: int) -> None:
+        sleep_calls.append(duration)
+        if len(sleep_calls) == 1:
+            return  # the cycle's run duration — resolve instantly
+        settling_started.set()
+        await settling_can_proceed.wait()
+
+    with (
+        patch("asyncio.sleep", new_callable=AsyncMock, side_effect=fake_sleep),
+        patch.object(
+            coordinator,
+            "_async_wait_for_switch_state",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        await coordinator._run_pump_cycle(
+            "irrigation", "switch.irrigation_pump", 30, {}
+        )
+
+        # Time is frozen in this test suite (autouse freeze_time), so
+        # asyncio.wait_for()'s monotonic-clock timeout never elapses — poll
+        # with bare yields instead.
+        for _ in range(1000):
+            if settling_started.is_set():
+                break
+            await real_sleep(0)
+        else:
+            pytest.fail("Settling delay was never started")
+
+        # The cycle has ended and the pump is off, but the report must not
+        # have fired yet — it's waiting for the sensor to settle.
+        mock_main_coordinator.add_event.assert_not_called()
+
+        settling_can_proceed.set()
+
+        for _ in range(1000):
+            if mock_main_coordinator.add_event.call_count:
+                break
+            await real_sleep(0)
+        else:
+            pytest.fail("Completion report was never fired after settling delay")
+
+        args, _ = mock_main_coordinator.add_event.call_args
+        event = args[1]
+        assert any("Moisture: 40.0% -> 60.0%" in r for r in event.reasons)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
…pletion

Soil moisture sensors need time to physically catch up after a cycle ends — reading "after" the instant the pump stops produces misleading before/after comparisons (e.g. 46.2% -> 46.2%). Defer the completion report (logbook event
+ GrowspaceEvent) into a background task that waits min(cycle_duration, 15s), then reads live moisture, snapshotting everything else up front so a fast-following cycle can't corrupt the report. Shared by irrigation and drain via BaseIrrigationCoordinator (and thus VWCIrrigationCoordinator).

See ADR 0008 and the new "Sensor Settling Delay" CONTEXT.md entry.