### PR TITLE
feat(websocket): include subareas in the serialized growspace payload

### DIFF
--- a/custom_components/growspace_manager/presentation/growspace_view_model.py
+++ b/custom_components/growspace_manager/presentation/growspace_view_model.py
@@ -270,6 +270,7 @@ class GrowspaceViewModelBuilder:
             },
             "environment": env_attrs,
             "sensors": sensors,
+            "subareas": [asdict(s) for s in growspace.subareas],
             "irrigation": {
                 "irrigation_config": irrigation_options,
                 "irrigation_strategy": irrigation_strategy_dict,

--- a/tests/core/snapshots/test_presentation_snapshots.ambr
+++ b/tests/core/snapshots/test_presentation_snapshots.ambr
@@ -246,6 +246,8 @@
         'switch.pump': 'irrigation_pump',
       }),
     }),
+    'subareas': list([
+    ]),
   })
 # ---
 # name: test_plant_view_model_snapshot

--- a/tests/integration/test_growspace_view_model_coverage.py
+++ b/tests/integration/test_growspace_view_model_coverage.py
@@ -11,6 +11,7 @@ from custom_components.growspace_manager.models import (
     IrrigationTank,
     Plant,
     SensorGroup,
+    Subarea,
     WaterUsageData,
 )
 from custom_components.growspace_manager.presentation.growspace_view_model import (
@@ -629,3 +630,60 @@ def test_vpd_optimal_overrides_round_trips_in_environment_attributes(
 
     assert attrs["vpd_optimal_overrides"] == overrides
     assert attrs["vpd_optimal_overrides"]["flower_mid"]["day"]["low"] == 0.5
+
+
+def test_build_includes_subareas(
+    hass: HomeAssistant, builder: GrowspaceViewModelBuilder
+) -> None:
+    """The growspace payload carries subareas in the get_subareas wire shape."""
+    subarea_env = EnvironmentConfig(
+        temperature_sensors=["sensor.shelf_temp"],
+        humidity_sensors=["sensor.shelf_hum"],
+    )
+    growspace = Growspace(
+        id="gs1",
+        name="Test Room",
+        subareas=[Subarea(id="sa1", name="Veg Shelf", environment_config=subarea_env)],
+    )
+
+    result = builder.build(growspace=growspace, plants=[], biological_metrics={})
+
+    assert len(result["subareas"]) == 1
+    serialized = result["subareas"][0]
+    assert serialized["id"] == "sa1"
+    assert serialized["name"] == "Veg Shelf"
+    assert serialized["environment_config"]["temperature_sensors"] == [
+        "sensor.shelf_temp"
+    ]
+    assert serialized["environment_config"]["humidity_sensors"] == ["sensor.shelf_hum"]
+
+
+def test_build_subareas_empty_when_none_configured(
+    hass: HomeAssistant, builder: GrowspaceViewModelBuilder
+) -> None:
+    """Growspaces without subareas serialize an empty list, not a missing key."""
+    growspace = Growspace(id="gs1", name="Test Room")
+
+    result = builder.build(growspace=growspace, plants=[], biological_metrics={})
+
+    assert result["subareas"] == []
+
+
+def test_view_model_builder_serializes_subareas_for_websocket_payload(
+    hass: HomeAssistant,
+) -> None:
+    """build_serialized_growspace (the get_growspace_data path) carries subareas."""
+    gs = Growspace(
+        id="gs1",
+        name="GS1",
+        subareas=[
+            Subarea(id="sa1", name="Veg Shelf"),
+            Subarea(id="sa2", name="Flower Shelf"),
+        ],
+    )
+    coordinator = _make_mock_coordinator(hass, gs, {})
+
+    result = ViewModelBuilder(coordinator).build_serialized_growspace("gs1")
+
+    assert [s["id"] for s in result["subareas"]] == ["sa1", "sa2"]
+    assert all("environment_config" in s for s in result["subareas"])


### PR DESCRIPTION
## What changed

- `GrowspaceViewModelBuilder.build()` now emits a top-level `subareas` key — `[asdict(s) for s in growspace.subareas]`, the exact wire shape (`{id, name, environment_config}`) the `get_subareas` WS command already sends. It flows through `build_serialized_growspace` → `get_growspace_data` → the `get_growspace_data` WS automatically, including the 30s payload cache.
- Growspaces without subareas serialize `subareas: []` (default factory), so the key is always present.

## Why

The card's subarea env/device snapshot sync (lovelace card ADR-0018, PRs #271/#273 there) reads subareas during its hass-update pass, but the growspace payload never carried them — subareas were only fetchable on demand via `get_subareas`, leaving the card's sync wiring dormant. This closes that gap from the backend side.

## Tests

TDD, three vertical slices in `tests/integration/test_growspace_view_model_coverage.py`:
1. payload carries subareas with serialized `environment_config` (red → green)
2. no subareas → `subareas: []`
3. full `ViewModelBuilder.build_serialized_growspace` path (what the WS facade calls)

Presentation snapshot regenerated (+2 lines: the empty `subareas` key) and re-verified without `--snapshot-update`.

## Gate

- Full suite: **4215 passed, 0 failed** (1:52)
- `ruff check` on touched files: 11 findings, byte-identical to baseline (zero new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)