### PR TITLE
Dryback = absolute VWC points: fix steering score convention and recalibrate thresholds

### DIFF
--- a/custom_components/growspace_manager/README.md
+++ b/custom_components/growspace_manager/README.md
@@ -49,8 +49,8 @@
 
 Growspace Manager implements professional **Crop Steering** principles by adjusting watering frequency and volume to influence plant behavior:
 
-- **Vegetative Steering**: Encourages structural biomass, root growth, and node density. It employs a higher frequency of smaller irrigation events (shots) during the day, maintaining higher Volumetric Water Content (VWC) in the substrate and keeping drybacks small (e.g., 10-15%).
-- **Generative Steering**: Signals the plant to focus energy on reproductive flower and resin production. It utilizes fewer, larger watering events with a significant overnight dryback (e.g., 25-30% dryback), prompting slight osmotic stress that increases flower formation.
+- **Vegetative Steering**: Encourages structural biomass, root growth, and node density. It employs a higher frequency of smaller irrigation events (shots) during the day, maintaining higher Volumetric Water Content (VWC) in the substrate and keeping drybacks small (e.g., under 8 VWC percentage points; a 55% -> 48% drop is a 7% dryback).
+- **Generative Steering**: Signals the plant to focus energy on reproductive flower and resin production. It utilizes fewer, larger watering events with a significant overnight dryback (e.g., more than 15 VWC percentage points), prompting slight osmotic stress that increases flower formation.
 - **Balanced Steering**: A middle-ground maintenance profile designed for transition stages or stable mother environments.
 - **Runoff & Drainage Control**: Link runoff sensors and a drain pump. The integration monitors feed EC versus drain EC to calculate salt buildup, triggers the drain pump automatically post-irrigation, and alerts you if runoff volume drifts from target percentages.
 
@@ -564,7 +564,7 @@ Configures high-level Volumetric Water Content (VWC) crop-steering automation sc
 | `p0_duration_minutes`|`integer`|No | `120` | Root warmup time post-sunrise before first irrigation. |
 | `p2_stop_before_lights_off_minutes`|`integer`|No| `120`| Stop irrigating before sunset to allow overnight dryback. |
 | `target_vwc_percent`|`float` | No | `65.0` | Target VWC percentage during Phase 1 (irrigation ramp). |
-| `maintenance_dryback_percent`|`float`|No| `5.0`| Target dryback drop before triggering single maintenance shots. |
+| `maintenance_dryback_percent`|`float`|No| `5.0`| Target dryback drop (absolute VWC percentage points below target) before triggering single maintenance shots. |
 | `shot_duration_seconds`|`integer`|No | `30` | Duration of each individual steering shot (seconds). |
 | `shot_interval_minutes`|`integer`|No | `15` | Minimum rest interval between steering shots. |
 

--- a/custom_components/growspace_manager/crop_steering.py
+++ b/custom_components/growspace_manager/crop_steering.py
@@ -24,7 +24,8 @@ def calculate_crop_steering_score(
     """Calculate the crop steering score from component metrics.
 
     Args:
-        dryback_percent: Today's dryback percentage (peak - trough) / peak * 100.
+        dryback_percent: Today's dryback in absolute VWC percentage points
+            (peak - trough; a 55% -> 45% VWC drop is 10.0).
         ec_trend: EC trend direction ("rising", "falling", "stable").
         shot_count: Number of irrigation shots today (None if unknown).
 
@@ -33,14 +34,14 @@ def calculate_crop_steering_score(
     """
     score = 0.0
 
-    # Dryback component: >30% = generative, <10% = vegetative
-    if dryback_percent > 30:
+    # Dryback component (absolute VWC points): >15 = generative, <8 = vegetative
+    if dryback_percent > 20:
         score += 0.4
-    elif dryback_percent > 20:
+    elif dryback_percent > 15:
         score += 0.2
-    elif dryback_percent < 10:
+    elif dryback_percent < 5:
         score -= 0.4
-    elif dryback_percent < 15:
+    elif dryback_percent < 8:
         score -= 0.2
 
     # EC trend component
@@ -103,9 +104,9 @@ def get_crop_steering_state(
         strategy.target_vwc_percent - strategy.maintenance_dryback_percent,
     )
 
-    dryback_percent = (
-        (peak_vwc - trough_vwc) / peak_vwc * 100 if peak_vwc > 0 else 0.0
-    )
+    # Dryback is always absolute VWC points (peak - trough), never relative
+    # to the peak — the single canonical convention (see CONTEXT.md "Dryback")
+    dryback_percent = peak_vwc - trough_vwc
 
     ec_trend = "stable"
     score = calculate_crop_steering_score(dryback_percent, ec_trend)

--- a/custom_components/growspace_manager/models/irrigation.py
+++ b/custom_components/growspace_manager/models/irrigation.py
@@ -136,7 +136,11 @@ class DrainConfig(BaseModel):
 
 @dataclass(slots=True)
 class CropSteeringState(BaseModel):
-    """Tracks crop steering metrics for a growspace."""
+    """Tracks crop steering metrics for a growspace.
+
+    ``dryback_percent`` is expressed in absolute VWC percentage points
+    (peak - trough), never relative to the peak.
+    """
 
     score: float = 0.0
     dryback_percent: float = 0.0

--- a/custom_components/growspace_manager/services.yaml
+++ b/custom_components/growspace_manager/services.yaml
@@ -1010,7 +1010,7 @@ set_irrigation_strategy:
           step: 0.1
           unit_of_measurement: "%"
     maintenance_dryback_percent:
-      description: Dryback percentage threshold before maintenance shot during Phase 2.
+      description: Dryback threshold in absolute VWC percentage points below target before maintenance shot during Phase 2.
       required: false
       selector:
         number:

--- a/tests/logic/test_crop_steering.py
+++ b/tests/logic/test_crop_steering.py
@@ -12,6 +12,10 @@ from custom_components.growspace_manager.crop_steering import (
 )
 from custom_components.growspace_manager.models import CropSteeringState
 
+# Dryback value (absolute VWC points) inside the neutral band (8-15),
+# used when a test exercises a non-dryback component.
+NEUTRAL_DRYBACK = 10.0
+
 
 # ---------------------------------------------------------------------------
 # calculate_crop_steering_score
@@ -21,124 +25,85 @@ from custom_components.growspace_manager.models import CropSteeringState
 class TestCalculateCropSteeringScore:
     """Tests for calculate_crop_steering_score."""
 
-    # Dryback component branches
+    # Dryback component branches (absolute VWC points: peak - trough)
 
-    def test_high_dryback_generative(self):
-        """Dryback >30% adds +0.4 (generative)."""
-        score = calculate_crop_steering_score(35.0, "stable")
-        assert score == pytest.approx(0.4)
-
-    def test_medium_high_dryback(self):
-        """Dryback >20% and <=30% adds +0.2."""
-        score = calculate_crop_steering_score(25.0, "stable")
-        assert score == pytest.approx(0.2)
-
-    def test_low_dryback_vegetative(self):
-        """Dryback <10% subtracts 0.4 (vegetative)."""
-        score = calculate_crop_steering_score(5.0, "stable")
-        assert score == pytest.approx(-0.4)
-
-    def test_medium_low_dryback(self):
-        """Dryback >=10% and <15% subtracts 0.2."""
-        score = calculate_crop_steering_score(12.0, "stable")
-        assert score == pytest.approx(-0.2)
-
-    def test_neutral_dryback(self):
-        """Dryback between 15% and 20% (inclusive) contributes 0."""
-        score = calculate_crop_steering_score(17.0, "stable")
-        assert score == pytest.approx(0.0)
-
-    def test_dryback_boundary_30(self):
-        """Dryback exactly 30% falls into medium-high bucket (+0.2, not +0.4)."""
-        score = calculate_crop_steering_score(30.0, "stable")
-        assert score == pytest.approx(0.2)
-
-    def test_dryback_boundary_20(self):
-        """Dryback exactly 20% falls into neutral bucket (0)."""
-        score = calculate_crop_steering_score(20.0, "stable")
-        assert score == pytest.approx(0.0)
-
-    def test_dryback_boundary_10(self):
-        """Dryback exactly 10% falls into the medium-low bucket (-0.2), not -0.4."""
-        # < 10 is false for exactly 10, so it falls into the elif < 15 branch.
-        score = calculate_crop_steering_score(10.0, "stable")
-        assert score == pytest.approx(-0.2)
-
-    def test_dryback_boundary_15(self):
-        """Dryback exactly 15% falls into neutral bucket (0), not -0.2."""
-        score = calculate_crop_steering_score(15.0, "stable")
-        assert score == pytest.approx(0.0)
+    @pytest.mark.parametrize(
+        ("dryback_points", "expected"),
+        [
+            pytest.param(25.0, 0.4, id="high-dryback-generative"),
+            pytest.param(18.0, 0.2, id="medium-high-dryback"),
+            pytest.param(3.0, -0.4, id="low-dryback-vegetative"),
+            pytest.param(6.0, -0.2, id="medium-low-dryback"),
+            pytest.param(10.0, 0.0, id="neutral-dryback"),
+            pytest.param(20.0, 0.2, id="boundary-20-medium-high"),
+            pytest.param(15.0, 0.0, id="boundary-15-neutral"),
+            pytest.param(8.0, 0.0, id="boundary-8-neutral"),
+            pytest.param(5.0, -0.2, id="boundary-5-medium-low"),
+        ],
+    )
+    def test_dryback_component(self, dryback_points: float, expected: float) -> None:
+        """Dryback in absolute VWC points maps to the expected score band."""
+        score = calculate_crop_steering_score(dryback_points, "stable")
+        assert score == pytest.approx(expected)
 
     # EC trend component branches
 
-    def test_ec_trend_rising(self):
-        """Rising EC adds +0.3."""
-        score = calculate_crop_steering_score(17.0, "rising")
-        assert score == pytest.approx(0.3)
-
-    def test_ec_trend_falling(self):
-        """Falling EC subtracts 0.3."""
-        score = calculate_crop_steering_score(17.0, "falling")
-        assert score == pytest.approx(-0.3)
-
-    def test_ec_trend_stable(self):
-        """Stable EC contributes 0."""
-        score = calculate_crop_steering_score(17.0, "stable")
-        assert score == pytest.approx(0.0)
+    @pytest.mark.parametrize(
+        ("ec_trend", "expected"),
+        [
+            pytest.param("rising", 0.3, id="rising"),
+            pytest.param("falling", -0.3, id="falling"),
+            pytest.param("stable", 0.0, id="stable"),
+        ],
+    )
+    def test_ec_trend_component(self, ec_trend: str, expected: float) -> None:
+        """EC trend direction maps to the expected score contribution."""
+        score = calculate_crop_steering_score(NEUTRAL_DRYBACK, ec_trend)
+        assert score == pytest.approx(expected)
 
     # Shot count component branches
 
-    def test_shot_count_none(self):
-        """No shot count does not affect score."""
-        score_with = calculate_crop_steering_score(17.0, "stable", shot_count=5)
-        score_without = calculate_crop_steering_score(17.0, "stable", shot_count=None)
-        assert score_without == pytest.approx(0.0)
-        assert score_with == pytest.approx(0.0)  # 5 shots is in neutral band too
+    @pytest.mark.parametrize(
+        ("shot_count", "expected"),
+        [
+            pytest.param(None, 0.0, id="none-unknown"),
+            pytest.param(0, 0.3, id="zero-shots-generative"),
+            pytest.param(3, 0.3, id="three-shots-generative"),
+            pytest.param(4, 0.0, id="four-shots-neutral"),
+            pytest.param(5, 0.0, id="five-shots-neutral"),
+            pytest.param(6, 0.0, id="six-shots-neutral"),
+            pytest.param(7, 0.0, id="seven-shots-neutral"),
+            pytest.param(8, -0.3, id="eight-shots-vegetative"),
+            pytest.param(20, -0.3, id="many-shots-vegetative"),
+        ],
+    )
+    def test_shot_count_component(
+        self, shot_count: int | None, expected: float
+    ) -> None:
+        """Shot count maps to the expected score contribution."""
+        score = calculate_crop_steering_score(
+            NEUTRAL_DRYBACK, "stable", shot_count=shot_count
+        )
+        assert score == pytest.approx(expected)
 
-    def test_shot_count_low_generative(self):
-        """<=3 shots adds +0.3 (generative)."""
-        score = calculate_crop_steering_score(17.0, "stable", shot_count=3)
-        assert score == pytest.approx(0.3)
+    # Clamping and combinations
 
-    def test_shot_count_zero(self):
-        """0 shots is <=3, adds +0.3."""
-        score = calculate_crop_steering_score(17.0, "stable", shot_count=0)
-        assert score == pytest.approx(0.3)
-
-    def test_shot_count_high_vegetative(self):
-        """>=8 shots subtracts 0.3 (vegetative)."""
-        score = calculate_crop_steering_score(17.0, "stable", shot_count=8)
-        assert score == pytest.approx(-0.3)
-
-    def test_shot_count_very_high(self):
-        """Many shots (>8) subtracts 0.3."""
-        score = calculate_crop_steering_score(17.0, "stable", shot_count=20)
-        assert score == pytest.approx(-0.3)
-
-    def test_shot_count_neutral_band(self):
-        """4-7 shots do not affect score."""
-        for shots in (4, 5, 6, 7):
-            score = calculate_crop_steering_score(17.0, "stable", shot_count=shots)
-            assert score == pytest.approx(0.0), f"shot_count={shots} should be neutral"
-
-    # Clamping
-
-    def test_score_clamped_at_positive_one(self):
+    def test_score_clamped_at_positive_one(self) -> None:
         """Maximum generative scenario is clamped to 1.0."""
         # high dryback (+0.4) + rising EC (+0.3) + low shots (+0.3) = 1.0
-        score = calculate_crop_steering_score(35.0, "rising", shot_count=1)
+        score = calculate_crop_steering_score(25.0, "rising", shot_count=1)
         assert score == pytest.approx(1.0)
 
-    def test_score_clamped_at_negative_one(self):
+    def test_score_clamped_at_negative_one(self) -> None:
         """Maximum vegetative scenario is clamped to -1.0."""
         # low dryback (-0.4) + falling EC (-0.3) + many shots (-0.3) = -1.0
-        score = calculate_crop_steering_score(5.0, "falling", shot_count=10)
+        score = calculate_crop_steering_score(3.0, "falling", shot_count=10)
         assert score == pytest.approx(-1.0)
 
-    def test_combined_mixed_signals(self):
+    def test_combined_mixed_signals(self) -> None:
         """Mixed signals produce intermediate score."""
         # high dryback (+0.4) + falling EC (-0.3) = 0.1
-        score = calculate_crop_steering_score(35.0, "falling")
+        score = calculate_crop_steering_score(25.0, "falling")
         assert score == pytest.approx(0.1)
 
 
@@ -170,9 +135,11 @@ def _make_coordinator(
 
     # Irrigation coordinator
     if has_vwc_coord:
-        coordinator._subsystem_manager.irrigation_coordinators.get.return_value = MagicMock()
+        coordinator.services.growspaces.get_irrigation_coordinator.return_value = (
+            MagicMock()
+        )
     else:
-        coordinator._subsystem_manager.irrigation_coordinators.get.return_value = None
+        coordinator.services.growspaces.get_irrigation_coordinator.return_value = None
 
     # HA state
     state_mock = MagicMock()
@@ -185,48 +152,50 @@ def _make_coordinator(
 class TestGetCropSteeringState:
     """Tests for get_crop_steering_state."""
 
-    def test_returns_none_when_growspace_missing(self):
+    def test_returns_none_when_growspace_missing(self) -> None:
         """Returns None if growspace does not exist."""
         coordinator = MagicMock()
         coordinator.growspaces.get.return_value = None
         result = get_crop_steering_state(coordinator, "missing")
         assert result is None
 
-    def test_returns_none_when_irrigation_disabled(self):
+    def test_returns_none_when_irrigation_disabled(self) -> None:
         """Returns None if irrigation strategy is not enabled."""
         coordinator = _make_coordinator(irrigation_enabled=False)
         result = get_crop_steering_state(coordinator, "tent1")
         assert result is None
 
-    def test_returns_empty_state_when_no_vwc_coord(self):
+    def test_returns_empty_state_when_no_vwc_coord(self) -> None:
         """Returns default CropSteeringState when no VWC coordinator is active."""
         coordinator = _make_coordinator(has_vwc_coord=False)
         result = get_crop_steering_state(coordinator, "tent1")
         assert isinstance(result, CropSteeringState)
         assert result.score == 0.0
+        assert result.dryback_percent == 0.0
 
-    def test_returns_empty_state_when_no_soil_sensor(self):
+    def test_returns_empty_state_when_no_soil_sensor(self) -> None:
         """Returns default CropSteeringState when soil moisture sensor is not configured."""
         coordinator = _make_coordinator(soil_moisture_sensor=None)
         result = get_crop_steering_state(coordinator, "tent1")
         assert isinstance(result, CropSteeringState)
         assert result.score == 0.0
 
-    def test_returns_empty_state_when_sensor_unavailable(self):
-        """Returns default CropSteeringState when sensor state is 'unavailable'."""
-        coordinator = _make_coordinator(sensor_state="unavailable")
+    @pytest.mark.parametrize(
+        "sensor_state",
+        [
+            pytest.param("unavailable", id="unavailable"),
+            pytest.param("unknown", id="unknown"),
+            pytest.param("not_a_number", id="non-numeric"),
+        ],
+    )
+    def test_returns_empty_state_when_sensor_unusable(self, sensor_state: str) -> None:
+        """Returns default CropSteeringState when the sensor state is unusable."""
+        coordinator = _make_coordinator(sensor_state=sensor_state)
         result = get_crop_steering_state(coordinator, "tent1")
         assert isinstance(result, CropSteeringState)
         assert result.score == 0.0
 
-    def test_returns_empty_state_when_sensor_unknown(self):
-        """Returns default CropSteeringState when sensor state is 'unknown'."""
-        coordinator = _make_coordinator(sensor_state="unknown")
-        result = get_crop_steering_state(coordinator, "tent1")
-        assert isinstance(result, CropSteeringState)
-        assert result.score == 0.0
-
-    def test_returns_empty_state_when_sensor_state_missing(self):
+    def test_returns_empty_state_when_sensor_state_missing(self) -> None:
         """Returns default CropSteeringState when hass.states.get returns None."""
         coordinator = _make_coordinator()
         coordinator.hass.states.get.return_value = None
@@ -234,17 +203,13 @@ class TestGetCropSteeringState:
         assert isinstance(result, CropSteeringState)
         assert result.score == 0.0
 
-    def test_returns_empty_state_when_sensor_not_numeric(self):
-        """Returns default CropSteeringState when sensor state is non-numeric."""
-        coordinator = _make_coordinator(sensor_state="not_a_number")
-        result = get_crop_steering_state(coordinator, "tent1")
-        assert isinstance(result, CropSteeringState)
-        assert result.score == 0.0
+    def test_returns_full_state_with_valid_sensor(self) -> None:
+        """Returns populated CropSteeringState when all data is available.
 
-    def test_returns_full_state_with_valid_sensor(self):
-        """Returns populated CropSteeringState when all data is available."""
-        # current_vwc=45, target=55 → peak=55, trough=min(45, 55-5)=min(45,50)=45
-        # dryback = (55-45)/55*100 ≈ 18.18%  → neutral band, score=0.0
+        Dryback is absolute VWC points: peak 55, trough 45 yields 10.0,
+        which sits in the neutral band (8-15) so the score is 0.0.
+        """
+        # current_vwc=45, target=55 → peak=55, trough=min(45, 55-5)=45
         coordinator = _make_coordinator(
             sensor_state="45.0",
             target_vwc=55.0,
@@ -254,13 +219,14 @@ class TestGetCropSteeringState:
         assert isinstance(result, CropSteeringState)
         assert result.peak_vwc == pytest.approx(55.0)
         assert result.trough_vwc == pytest.approx(45.0)
-        assert result.dryback_percent == pytest.approx((55.0 - 45.0) / 55.0 * 100)
+        assert result.dryback_percent == pytest.approx(10.0)
         assert result.ec_trend == "stable"
         assert result.score == pytest.approx(0.0)
 
-    def test_peak_vwc_uses_current_when_above_target(self):
+    def test_peak_vwc_uses_current_when_above_target(self) -> None:
         """Peak VWC is current_vwc when it exceeds target_vwc."""
         # current=70 > target=55 → peak=70, trough=min(70,55-5)=50
+        # dryback = 70 - 50 = 20.0 absolute points → +0.2 (mildly generative)
         coordinator = _make_coordinator(
             sensor_state="70.0",
             target_vwc=55.0,
@@ -270,9 +236,11 @@ class TestGetCropSteeringState:
         assert result is not None
         assert result.peak_vwc == pytest.approx(70.0)
         assert result.trough_vwc == pytest.approx(50.0)
+        assert result.dryback_percent == pytest.approx(20.0)
+        assert result.score == pytest.approx(0.2)
 
-    def test_dryback_zero_when_peak_is_zero(self):
-        """Dryback percent is 0.0 when peak VWC is 0 (no division by zero)."""
+    def test_dryback_zero_when_no_spread(self) -> None:
+        """Dryback is 0.0 absolute points when peak and trough coincide."""
         coordinator = _make_coordinator(
             sensor_state="0.0",
             target_vwc=0.0,


### PR DESCRIPTION
## Summary

Makes **Dryback** mean one thing everywhere: **absolute VWC percentage points** (peak − trough; a 55% → 45% drop is a 10% dryback), per the CONTEXT.md "Dryback" entry. The P2 maintenance trigger in `vwc_irrigation_coordinator.py` already used this convention (`trigger = target − maintenance_dryback_percent`); the steering score path was the lone holdout, computing dryback relative to peak.

### Convention fix

- `get_crop_steering_state` no longer computes `(peak − trough) / peak × 100`; it reports `peak − trough` directly. The division-by-zero guard is gone with the division. This was the only relative-to-peak formula in the integration.
- The sensor's `dryback_percent` attribute (and `CropSteeringState.dryback_percent`) now carry absolute points; the model docstring, `services.yaml` field description, and README prose spell the convention out.

### Threshold recalibration (`calculate_crop_steering_score`)

Banding retuned for the absolute-points scale, keeping the four-band structure and the [−1.0, 1.0] clamp:

| Dryback (absolute VWC points) | Score contribution | Reading |
| --- | --- | --- |
| > 20 | +0.4 | strongly generative |
| > 15 | +0.2 | mildly generative |
| 8 – 15 | 0.0 | neutral |
| < 8 | −0.2 | mildly vegetative |
| < 5 | −0.4 | strongly vegetative |

### Tests

- Dryback band tests parametrized over the new thresholds, including every boundary (20 / 15 / 8 / 5).
- `get_crop_steering_state` tests assert the convention directly: peak 55, trough 45 → `dryback_percent == 10.0`.
- Fixed a stale mock in `_make_coordinator`: it stubbed `_subsystem_manager.irrigation_coordinators`, but the code calls `coordinator.services.growspaces.get_irrigation_coordinator` — the no-VWC-coordinator test now exercises the real code path.
- Full suite: 4218 passed; ruff and mypy clean on the changed files.

This is the foundational slice for #444 (SubstrateTracker), whose events store dryback in this convention.

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)