### PR TITLE
Real EC Trend from pore-EC readings (#445)

### DIFF
--- a/custom_components/growspace_manager/const.py
+++ b/custom_components/growspace_manager/const.py
@@ -121,7 +121,9 @@ STAGE_PHOTOPERIOD_KEYS: Final[dict[PlantStage, str]] = {
 # Trend Analysis Constants
 CONF_TREND_VPD_THRESHOLD = "trend_vpd_threshold"
 CONF_TREND_TEMPERATURE_THRESHOLD = "trend_temperature_threshold"
-CONF_TREND_TEMP_THRESHOLD = CONF_TREND_TEMPERATURE_THRESHOLD  # Alias for backward compatibility
+CONF_TREND_TEMP_THRESHOLD = (
+    CONF_TREND_TEMPERATURE_THRESHOLD  # Alias for backward compatibility
+)
 CONF_TREND_HUMIDITY_THRESHOLD = "trend_humidity_threshold"
 CONF_TREND_VPD_DURATION = "trend_vpd_duration"
 CONF_TREND_TEMPERATURE_DURATION = "trend_temperature_duration"
@@ -264,6 +266,11 @@ TANK_NOISE_FLOOR_PCT = 1.0  # % change too small to record
 # Substrate tracker thresholds (measured dryback detection)
 SUBSTRATE_MAX_EVENTS = 200  # rolling dryback event window
 SUBSTRATE_NOISE_FLOOR_PCT = 0.5  # VWC change too small to move a peak/trough
+# Deadband for the daily pore-EC trend: a day-start-to-current EC delta whose
+# magnitude is at or below this many EC units (mS/cm) reads "stable" rather than
+# flapping rising<->falling on sensor noise. 0.2 mS/cm is a conservative default
+# below the typical day-to-day drift of substrate EC probes.
+SUBSTRATE_EC_TREND_DEADBAND = 0.2
 
 
 # Multi-Device Config Keys

--- a/custom_components/growspace_manager/crop_steering.py
+++ b/custom_components/growspace_manager/crop_steering.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 def calculate_crop_steering_score(
     dryback_percent: float,
-    ec_trend: str,
+    ec_trend: str | None,
     shot_count: int | None = None,
 ) -> float:
     """Calculate the crop steering score from component metrics.
@@ -26,7 +26,11 @@ def calculate_crop_steering_score(
     Args:
         dryback_percent: Today's dryback in absolute VWC percentage points
             (peak - trough; a 55% -> 45% VWC drop is 10.0).
-        ec_trend: EC trend direction ("rising", "falling", "stable").
+        ec_trend: Measured EC trend direction ("rising", "falling", "stable"),
+            or None when no pore-EC sensors are configured / no reading yet. A
+            None or "stable" trend contributes nothing to the score, but the two
+            are distinct upstream: None means *unavailable* (capability locked),
+            "stable" means *measured and flat*.
         shot_count: Number of irrigation shots today (None if unknown).
 
     Returns:
@@ -97,7 +101,6 @@ def get_crop_steering_state(
         return CropSteeringState()
 
     strategy = growspace.irrigation_strategy
-    ec_trend = "stable"
 
     # Prefer the SubstrateTracker's measured peak/trough/dryback over a synthetic
     # target-derived value, so the steering score is honest (see ADR-0010). The
@@ -105,6 +108,14 @@ def get_crop_steering_state(
     tracker = coordinator.services.growspaces.get_substrate_tracker(growspace_id)
     measured = tracker.get_measured_peak_trough() if tracker is not None else None
     shot_count = tracker.get_shot_count_today() if tracker is not None else None
+
+    # Measured pore-EC trend from the tracker. None means unavailable (no
+    # pore-EC sensors / no reading yet) — the score's EC component then stays
+    # neutral, distinct from a measured "stable". The hardcoded placeholder is
+    # gone: an absent trend is never silently reported as "stable".
+    ec_trend_info = tracker.get_ec_trend() if tracker is not None else None
+    ec_trend = ec_trend_info["trend"] if ec_trend_info is not None else None
+    ec_trend_available = ec_trend_info is not None
 
     if measured is not None:
         peak_vwc, trough_vwc, dryback_percent = measured
@@ -131,4 +142,7 @@ def get_crop_steering_state(
         peak_vwc=peak_vwc,
         trough_vwc=trough_vwc,
         ec_trend=ec_trend,
+        ec_trend_available=ec_trend_available,
+        ec_day_start=ec_trend_info["day_start_ec"] if ec_trend_info else None,
+        ec_current=ec_trend_info["current_ec"] if ec_trend_info else None,
     )

--- a/custom_components/growspace_manager/models/irrigation.py
+++ b/custom_components/growspace_manager/models/irrigation.py
@@ -188,6 +188,18 @@ class SubstrateHistory(BaseModel):
     # Whether any shot fired during current_day (drives the zero-shot fallback).
     shots_today: int = 0
 
+    # ── Daily pore-EC trend state ───────────────────────────────────────────
+    # Day-start (earliest) and latest averaged pore-EC readings for the current
+    # local day, the inputs to the rising/stable/falling EC trend. Persisted so
+    # a mid-day restart resumes the day's baseline rather than restarting it.
+    # ``ec_trend_day`` guards the daily reset (mirrors ``current_day`` but is
+    # driven by pore-EC readings, which may arrive independently of VWC).
+    ec_trend_day: str | None = None
+    ec_day_start_value: float | None = None
+    ec_day_start_ts: str | None = None
+    ec_latest_value: float | None = None
+    ec_latest_ts: str | None = None
+
 
 @dataclass(slots=True)
 class IrrigationTank(BaseModel):
@@ -274,7 +286,14 @@ class CropSteeringState(BaseModel):
     dryback_percent: float = 0.0
     peak_vwc: float = 0.0
     trough_vwc: float = 0.0
-    ec_trend: str = "stable"
+    # Measured pore-EC trend: "rising"/"stable"/"falling" when sensors report,
+    # else None (unavailable). ``ec_trend_available`` distinguishes a measured
+    # "stable" from "no pore-EC sensors", so the card shows its unlock hint only
+    # in the latter case. ``ec_day_start``/``ec_current`` are the trend inputs.
+    ec_trend: str | None = None
+    ec_trend_available: bool = False
+    ec_day_start: float | None = None
+    ec_current: float | None = None
     last_updated: str = ""
 
 

--- a/custom_components/growspace_manager/presentation/growspace_view_model.py
+++ b/custom_components/growspace_manager/presentation/growspace_view_model.py
@@ -309,6 +309,7 @@ class GrowspaceViewModelBuilder:
         tracker = SubstrateTracker(growspace)
         latest_overnight = tracker.get_latest_overnight_dryback()
         avg = tracker.get_average_incycle_dryback_today()
+        ec_trend = tracker.get_ec_trend()
         return {
             "overnight_dryback": (
                 round(latest_overnight["dryback"], 1)
@@ -318,6 +319,11 @@ class GrowspaceViewModelBuilder:
             "latest_overnight_event": latest_overnight,
             "incycle_dryback_count": tracker.get_shot_count_today(),
             "incycle_dryback_avg": round(avg, 1) if avg is not None else None,
+            # Measured daily pore-EC trend. None => no pore-EC sensors yet, so
+            # the card renders its unlock hint instead of a "stable" reading.
+            "ec_trend": ec_trend["trend"] if ec_trend is not None else None,
+            "ec_trend_available": ec_trend is not None,
+            "ec_trend_detail": ec_trend,
         }
 
     def _build_rich_plant_grid(

--- a/custom_components/growspace_manager/sensor/crop_steering.py
+++ b/custom_components/growspace_manager/sensor/crop_steering.py
@@ -65,7 +65,13 @@ class CropSteeringSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
             "peak_vwc": round(state.peak_vwc, 1),
             "trough_vwc": round(state.trough_vwc, 1),
             "steering_mode": mode,
+            # ec_trend is None when no pore-EC sensors are configured (or no
+            # reading yet). ec_trend_available distinguishes that from a
+            # measured "stable" so the card can show its unlock hint.
             "ec_trend": state.ec_trend,
+            "ec_trend_available": state.ec_trend_available,
+            "ec_day_start": state.ec_day_start,
+            "ec_current": state.ec_current,
         }
 
         # Measured substrate metrics from the SubstrateTracker (see ADR-0010).

--- a/custom_components/growspace_manager/substrate_tracker.py
+++ b/custom_components/growspace_manager/substrate_tracker.py
@@ -29,7 +29,11 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.util import dt as dt_util
 
-from .const import SUBSTRATE_MAX_EVENTS, SUBSTRATE_NOISE_FLOOR_PCT
+from .const import (
+    SUBSTRATE_EC_TREND_DEADBAND,
+    SUBSTRATE_MAX_EVENTS,
+    SUBSTRATE_NOISE_FLOOR_PCT,
+)
 
 if TYPE_CHECKING:
     from .models import Growspace, SubstrateHistory
@@ -60,6 +64,7 @@ class SubstrateTracker:
     Public API:
 
     * :meth:`record_reading` — feed one VWC reading from the minute loop.
+    * :meth:`record_pore_ec` — feed one averaged pore-EC reading from the loop.
     * :meth:`record_shot` — signal that a P1/P2 shot fired this tick.
     * :meth:`get_latest_overnight_dryback` — most recent overnight event, or None.
     * :meth:`get_incycle_drybacks_today` — today's in-cycle events.
@@ -208,6 +213,32 @@ class SubstrateTracker:
             ):
                 history.pending_incycle_trough = vwc
                 history.pending_incycle_trough_ts = timestamp
+
+    def record_pore_ec(self, ec: float, timestamp: str) -> None:
+        """Feed one averaged pore-EC reading for the daily EC-trend.
+
+        The first reading of a local day fixes the day-start baseline; every
+        reading updates the latest value. Comparing baseline against latest
+        (with a deadband, see :meth:`get_ec_trend`) yields the day's EC trend.
+        State is persisted on ``SubstrateHistory`` so a mid-day restart resumes
+        the same baseline instead of resetting it.
+
+        ``ec`` is the average of the configured pore-EC sensors; callers skip
+        unknown/unavailable/non-numeric sensor states before averaging, so this
+        method only ever sees a valid measured value.
+        """
+        history = self._history
+        day = _local_date(timestamp)
+
+        if history.ec_trend_day != day:
+            # New local day: re-baseline. (A sensor that drops out mid-day and
+            # returns later keeps the same baseline because the day is unchanged.)
+            history.ec_trend_day = day
+            history.ec_day_start_value = ec
+            history.ec_day_start_ts = timestamp
+
+        history.ec_latest_value = ec
+        history.ec_latest_ts = timestamp
 
     # ── day rollover ────────────────────────────────────────────────────────────
 
@@ -365,3 +396,46 @@ class SubstrateTracker:
         if latest is not None:
             return (latest["peak_vwc"], latest["trough_vwc"], latest["dryback"])
         return None
+
+    def get_ec_trend(self) -> dict[str, Any] | None:
+        """Return the current day's pore-EC trend, or None when unavailable.
+
+        Returns ``None`` when no pore-EC reading has been ingested yet (no
+        sensors configured, or none have produced a valid value today) — the
+        caller must treat this as *unavailable*, distinct from ``"stable"``, so
+        the steering score's EC component stays neutral and the payload can flag
+        the metric for the card's unlock hint.
+
+        Otherwise returns a dict with the trend direction and its inputs::
+
+            {
+                "trend": "rising" | "stable" | "falling",
+                "day_start_ec": float,   # earliest reading of the local day
+                "current_ec": float,     # latest reading
+                "delta": float,          # current - day_start (signed)
+            }
+
+        A ``delta`` whose magnitude is at or below
+        :data:`SUBSTRATE_EC_TREND_DEADBAND` reads ``"stable"`` so noise does not
+        flap the trend between rising and falling.
+        """
+        history = self._history
+        start = history.ec_day_start_value
+        current = history.ec_latest_value
+        if start is None or current is None:
+            return None
+
+        delta = round(current - start, 4)
+        if abs(delta) <= SUBSTRATE_EC_TREND_DEADBAND:
+            trend = "stable"
+        elif delta > 0:
+            trend = "rising"
+        else:
+            trend = "falling"
+
+        return {
+            "trend": trend,
+            "day_start_ec": round(start, 4),
+            "current_ec": round(current, 4),
+            "delta": delta,
+        }

--- a/custom_components/growspace_manager/vwc_irrigation_coordinator.py
+++ b/custom_components/growspace_manager/vwc_irrigation_coordinator.py
@@ -335,6 +335,31 @@ class VWCIrrigationCoordinator(BaseIrrigationCoordinator):
         lit = boundaries.lights_on <= current_dt < boundaries.lights_off
         tracker.record_reading(current_vwc, current_dt.isoformat(), lit=lit)
 
+        # Feed the averaged pore-EC reading for the daily EC trend. Absent
+        # pore-EC sensors, the trend stays unavailable (never "stable").
+        pore_ec = self._average_pore_ec(growspace)
+        if pore_ec is not None:
+            tracker.record_pore_ec(pore_ec, current_dt.isoformat())
+
+    def _average_pore_ec(self, growspace: Growspace) -> float | None:
+        """Average the configured pore-EC sensors, or None if none are usable.
+
+        Skips ``unknown``/``unavailable``/non-numeric states exactly like the
+        VWC reading path, so a partial sensor dropout still yields a value from
+        the remaining sensors and a full dropout yields None (unavailable).
+        """
+        sensors = growspace.environment_config.pore_ec_sensors
+        if not sensors:
+            return None
+        values = [
+            value
+            for sensor in sensors
+            if (value := self._get_sensor_value(sensor)) is not None
+        ]
+        if not values:
+            return None
+        return sum(values) / len(values)
+
     def _record_substrate_shot(self, phase: str) -> None:
         """Signal a fired shot to the SubstrateTracker for dryback bounding."""
         tracker = self._main_coordinator.services.growspaces.get_substrate_tracker(

--- a/tests/core/snapshots/test_models_snapshots.ambr
+++ b/tests/core/snapshots/test_models_snapshots.ambr
@@ -326,6 +326,11 @@
     ]),
     'substrate_history': dict({
       'current_day': None,
+      'ec_day_start_ts': None,
+      'ec_day_start_value': None,
+      'ec_latest_ts': None,
+      'ec_latest_value': None,
+      'ec_trend_day': None,
       'events': list([
       ]),
       'lit_period_max': None,

--- a/tests/core/snapshots/test_presentation_snapshots.ambr
+++ b/tests/core/snapshots/test_presentation_snapshots.ambr
@@ -213,6 +213,9 @@
         'target_vwc_percent': 55.0,
       }),
       'substrate': dict({
+        'ec_trend': None,
+        'ec_trend_available': False,
+        'ec_trend_detail': None,
         'incycle_dryback_avg': None,
         'incycle_dryback_count': 0,
         'latest_overnight_event': None,

--- a/tests/core/test_substrate_tracker.py
+++ b/tests/core/test_substrate_tracker.py
@@ -239,3 +239,107 @@ def test_event_history_is_bounded() -> None:
     t.record_reading(49.0, _ts(DAY1, 12, 45), lit=True)
     t.record_shot("P2", _ts(DAY1, 13), 49.0)
     assert len(history.events) == SUBSTRATE_MAX_EVENTS
+
+
+# ── daily pore-EC trend ─────────────────────────────────────────────────────────
+
+
+def test_ec_trend_unavailable_with_no_readings() -> None:
+    """No pore-EC reading ingested → trend is unavailable (None), never stable."""
+    t = _tracker()
+    assert t.get_ec_trend() is None
+
+
+def test_ec_trend_rising() -> None:
+    """Pore EC climbing well past the deadband reads rising."""
+    t = _tracker()
+    t.record_pore_ec(2.0, _ts(DAY1, 8))
+    t.record_pore_ec(2.4, _ts(DAY1, 12))
+    t.record_pore_ec(3.0, _ts(DAY1, 16))
+
+    trend = t.get_ec_trend()
+    assert trend is not None
+    assert trend["trend"] == "rising"
+    assert trend["day_start_ec"] == 2.0
+    assert trend["current_ec"] == 3.0
+    assert trend["delta"] == 1.0
+
+
+def test_ec_trend_falling() -> None:
+    """Pore EC dropping well past the deadband reads falling."""
+    t = _tracker()
+    t.record_pore_ec(3.0, _ts(DAY1, 8))
+    t.record_pore_ec(2.2, _ts(DAY1, 16))
+
+    trend = t.get_ec_trend()
+    assert trend is not None
+    assert trend["trend"] == "falling"
+    assert trend["delta"] == -0.8
+
+
+def test_ec_trend_stable_within_deadband() -> None:
+    """A small EC change within the deadband reads stable, not rising/falling."""
+    t = _tracker()
+    t.record_pore_ec(2.50, _ts(DAY1, 8))
+    # +0.15 is within the 0.2 deadband → stable, not rising.
+    t.record_pore_ec(2.65, _ts(DAY1, 16))
+
+    trend = t.get_ec_trend()
+    assert trend is not None
+    assert trend["trend"] == "stable"
+    assert trend["delta"] == 0.15
+
+
+def test_ec_trend_survives_sensor_dropout_midday() -> None:
+    """A mid-day gap in readings keeps the same day-start baseline.
+
+    The coordinator simply stops feeding readings while sensors are
+    unavailable; when they return the same local day, the baseline persists and
+    the trend resumes from it (no spurious re-baseline).
+    """
+    t = _tracker()
+    t.record_pore_ec(2.0, _ts(DAY1, 8))
+    t.record_pore_ec(2.3, _ts(DAY1, 10))
+    # ── sensor dropout 10:00 → 15:00: no readings fed ──
+    t.record_pore_ec(2.9, _ts(DAY1, 15))
+
+    trend = t.get_ec_trend()
+    assert trend is not None
+    # Baseline is still the 08:00 value, not the post-dropout 15:00 reading.
+    assert trend["day_start_ec"] == 2.0
+    assert trend["current_ec"] == 2.9
+    assert trend["trend"] == "rising"
+
+
+def test_ec_trend_rebaselines_on_new_day() -> None:
+    """The day-start baseline resets on a new local day."""
+    t = _tracker()
+    t.record_pore_ec(3.0, _ts(DAY1, 16))
+    # New day: the first reading becomes the new baseline.
+    t.record_pore_ec(2.0, _ts(DAY2, 8))
+    t.record_pore_ec(2.5, _ts(DAY2, 16))
+
+    trend = t.get_ec_trend()
+    assert trend is not None
+    assert trend["day_start_ec"] == 2.0
+    assert trend["current_ec"] == 2.5
+    assert trend["trend"] == "rising"
+
+
+def test_ec_trend_resumes_after_restart() -> None:
+    """Persisted EC-trend state on SubstrateHistory survives a tracker rebuild."""
+    growspace = Growspace(id="tent1", name="Tent 1")
+    t1 = SubstrateTracker(growspace)
+    t1.record_pore_ec(2.0, _ts(DAY1, 8))
+    t1.record_pore_ec(2.4, _ts(DAY1, 12))
+
+    # Simulate a restart: a fresh tracker over the same persisted history.
+    t2 = SubstrateTracker(growspace)
+    t2.record_pore_ec(3.1, _ts(DAY1, 16))
+
+    trend = t2.get_ec_trend()
+    assert trend is not None
+    # Baseline carried across the restart.
+    assert trend["day_start_ec"] == 2.0
+    assert trend["current_ec"] == 3.1
+    assert trend["trend"] == "rising"

--- a/tests/integration/snapshots/test_services_growspace_coverage.ambr
+++ b/tests/integration/snapshots/test_services_growspace_coverage.ambr
@@ -181,6 +181,11 @@
     ]),
     'substrate_history': dict({
       'current_day': None,
+      'ec_day_start_ts': None,
+      'ec_day_start_value': None,
+      'ec_latest_ts': None,
+      'ec_latest_value': None,
+      'ec_trend_day': None,
       'events': list([
       ]),
       'lit_period_max': None,

--- a/tests/integration/test_vwc_irrigation_coordinator.py
+++ b/tests/integration/test_vwc_irrigation_coordinator.py
@@ -1421,3 +1421,62 @@ async def test_projected_shot_window_uses_active_phase_interval(
         "start": expected_start.isoformat(),
         "end": datetime(2023, 1, 1, 18, 0, 0, tzinfo=dt_util.UTC).isoformat(),
     }
+
+
+def _state(value: str) -> MagicMock:
+    """Build a mock HA state with a given string state."""
+    state = MagicMock()
+    state.state = value
+    return state
+
+
+def test_average_pore_ec_no_sensors_returns_none(
+    vwc_coordinator, mock_growspace
+) -> None:
+    """With no pore-EC sensors configured the average is None (unavailable)."""
+    mock_growspace.environment_config.pore_ec_sensors = []
+    assert vwc_coordinator._average_pore_ec(mock_growspace) is None
+
+
+def test_average_pore_ec_averages_valid_sensors(
+    vwc_coordinator, mock_hass, mock_growspace
+) -> None:
+    """Pore-EC sensors are averaged across their valid numeric states."""
+    mock_growspace.environment_config.pore_ec_sensors = [
+        "sensor.ec_a",
+        "sensor.ec_b",
+    ]
+    mock_hass.states.get.side_effect = lambda eid: {
+        "sensor.ec_a": _state("2.0"),
+        "sensor.ec_b": _state("3.0"),
+    }[eid]
+    assert vwc_coordinator._average_pore_ec(mock_growspace) == pytest.approx(2.5)
+
+
+def test_average_pore_ec_skips_unusable_states(
+    vwc_coordinator, mock_hass, mock_growspace
+) -> None:
+    """Unavailable/unknown/non-numeric sensors are skipped before averaging."""
+    mock_growspace.environment_config.pore_ec_sensors = [
+        "sensor.ec_a",
+        "sensor.ec_b",
+        "sensor.ec_c",
+        "sensor.ec_d",
+    ]
+    mock_hass.states.get.side_effect = lambda eid: {
+        "sensor.ec_a": _state("2.0"),
+        "sensor.ec_b": _state("unavailable"),
+        "sensor.ec_c": _state("unknown"),
+        "sensor.ec_d": _state("not_a_number"),
+    }[eid]
+    # Only the single valid 2.0 reading survives.
+    assert vwc_coordinator._average_pore_ec(mock_growspace) == pytest.approx(2.0)
+
+
+def test_average_pore_ec_all_unusable_returns_none(
+    vwc_coordinator, mock_hass, mock_growspace
+) -> None:
+    """A full sensor dropout yields None (unavailable), not a stale value."""
+    mock_growspace.environment_config.pore_ec_sensors = ["sensor.ec_a"]
+    mock_hass.states.get.return_value = _state("unavailable")
+    assert vwc_coordinator._average_pore_ec(mock_growspace) is None

--- a/tests/logic/test_crop_steering.py
+++ b/tests/logic/test_crop_steering.py
@@ -54,9 +54,10 @@ class TestCalculateCropSteeringScore:
             pytest.param("rising", 0.3, id="rising"),
             pytest.param("falling", -0.3, id="falling"),
             pytest.param("stable", 0.0, id="stable"),
+            pytest.param(None, 0.0, id="unavailable-neutral"),
         ],
     )
-    def test_ec_trend_component(self, ec_trend: str, expected: float) -> None:
+    def test_ec_trend_component(self, ec_trend: str | None, expected: float) -> None:
         """EC trend direction maps to the expected score contribution."""
         score = calculate_crop_steering_score(NEUTRAL_DRYBACK, ec_trend)
         assert score == pytest.approx(expected)
@@ -223,7 +224,9 @@ class TestGetCropSteeringState:
         assert result.peak_vwc == pytest.approx(55.0)
         assert result.trough_vwc == pytest.approx(45.0)
         assert result.dryback_percent == pytest.approx(10.0)
-        assert result.ec_trend == "stable"
+        # No pore-EC sensors / tracker → trend unavailable, never "stable".
+        assert result.ec_trend is None
+        assert result.ec_trend_available is False
         assert result.score == pytest.approx(0.0)
 
     def test_peak_vwc_uses_current_when_above_target(self) -> None:
@@ -269,3 +272,44 @@ class TestGetCropSteeringState:
         assert result.dryback_percent == pytest.approx(22.0)
         # High measured dryback + few shots drives a generative score.
         assert result.score == pytest.approx(0.7)
+
+    def test_measured_ec_trend_rising_feeds_score(self) -> None:
+        """A measured rising EC trend adds +0.3 and is reported in the state."""
+        coordinator = _make_coordinator(sensor_state="45.0", target_vwc=55.0)
+        tracker = MagicMock()
+        tracker.get_measured_peak_trough.return_value = None
+        tracker.get_shot_count_today.return_value = None
+        tracker.get_ec_trend.return_value = {
+            "trend": "rising",
+            "day_start_ec": 2.0,
+            "current_ec": 2.8,
+            "delta": 0.8,
+        }
+        coordinator.services.growspaces.get_substrate_tracker.return_value = tracker
+
+        result = get_crop_steering_state(coordinator, "tent1")
+        assert result is not None
+        assert result.ec_trend == "rising"
+        assert result.ec_trend_available is True
+        assert result.ec_day_start == pytest.approx(2.0)
+        assert result.ec_current == pytest.approx(2.8)
+        # neutral dryback (10.0) + rising EC (+0.3) → 0.3
+        assert result.score == pytest.approx(0.3)
+
+    def test_unavailable_ec_trend_keeps_ec_component_neutral(self) -> None:
+        """No pore-EC sensors → trend None, unavailable, EC contributes zero."""
+        coordinator = _make_coordinator(sensor_state="45.0", target_vwc=55.0)
+        tracker = MagicMock()
+        tracker.get_measured_peak_trough.return_value = None
+        tracker.get_shot_count_today.return_value = None
+        tracker.get_ec_trend.return_value = None
+        coordinator.services.growspaces.get_substrate_tracker.return_value = tracker
+
+        result = get_crop_steering_state(coordinator, "tent1")
+        assert result is not None
+        assert result.ec_trend is None
+        assert result.ec_trend_available is False
+        assert result.ec_day_start is None
+        assert result.ec_current is None
+        # neutral dryback (10.0) + unavailable EC (0) → 0.0
+        assert result.score == pytest.approx(0.0)


### PR DESCRIPTION
Closes #445

> **Stacked on #451** (`feat-substrateTracker`). Review/merge #451 first; this PR's base will retarget automatically when #444 merges.

## What this does

Replaces the hardcoded `ec_trend = "stable"` placeholder fed to the steering score with a **real daily pore-EC trend** computed by the SubstrateTracker (its home per ADR-0010), averaged across configured `pore_ec_sensors`.

## Behaviour

- **Trend:** day-start pore-EC baseline vs latest reading over the current local day → `rising` / `stable` / `falling`.
- **Deadband:** `SUBSTRATE_EC_TREND_DEADBAND = 0.2 mS/cm` — within = `stable`, beyond = directional. Prevents rising↔falling flapping on noise.
- **Sensor-Gated Capability:** no pore-EC reading → `get_ec_trend()` returns `None`, `ec_trend_available=False`, and the score's EC component stays neutral (0) so the card can show its unlock hint. A measured flat day is `stable` with `available=True` — the two are kept distinct.
- **Restart-safe:** day-start baseline persists on `SubstrateHistory`; resumes after a mid-day restart.

## Acceptance criteria → tests

| AC | Test |
|----|------|
| Rising | `test_ec_trend_rising` |
| Falling | `test_ec_trend_falling` |
| Stable within deadband | `test_ec_trend_stable_within_deadband` |
| Sensor dropout mid-day | `test_ec_trend_survives_sensor_dropout_midday`, `test_average_pore_ec_skips_unusable_states` |
| No-sensor gating | `test_ec_trend_unavailable_with_no_readings`, `test_average_pore_ec_no_sensors_returns_none`, `test_unavailable_ec_trend_keeps_ec_component_neutral` |
| Score consumes measured trend; placeholder removed | `test_measured_ec_trend_rising_feeds_score`, `test_returns_full_state_with_valid_sensor` |
| Restart safety | `test_ec_trend_resumes_after_restart` |

## Key files

- `substrate_tracker.py` — `record_pore_ec()` + `get_ec_trend()`
- `models/irrigation.py` — persisted EC-trend state on `SubstrateHistory`; `ec_trend`/availability/inputs on `CropSteeringState`
- `vwc_irrigation_coordinator.py` — `_average_pore_ec()` fed per tick
- `crop_steering.py` — consumes measured trend; `"stable"` placeholder removed
- `sensor/crop_steering.py`, `presentation/growspace_view_model.py` — expose trend + inputs + availability flag
- `const.py` — deadband constant

## Testing

Full suite green: **4264 passed**. Ruff clean on production source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)