### PR TITLE
Pore EC Target Band + bounded EC Modulation (#447)

### DIFF
--- a/custom_components/growspace_manager/config_handlers/irrigation_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/irrigation_config_handler.py
@@ -372,4 +372,36 @@ class IrrigationConfigHandler(BaseConfigHandler[dict[str, Any]]):
                     mode=selector.NumberSelectorMode.BOX,
                 )
             ),
+            # Pore EC Target Band — distinct from the per-stage *feed* EC ranges;
+            # pore EC legitimately runs above feed EC when stacking (CONTEXT.md).
+            vol.Optional(
+                "pore_ec_target_min",
+                description={
+                    "suggested_value": irrigation_options.get("pore_ec_target_min")
+                },
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.0,
+                    step=0.1,
+                    unit_of_measurement="mS/cm",
+                    mode=selector.NumberSelectorMode.BOX,
+                )
+            ),
+            vol.Optional(
+                "pore_ec_target_max",
+                description={
+                    "suggested_value": irrigation_options.get("pore_ec_target_max")
+                },
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.0,
+                    step=0.1,
+                    unit_of_measurement="mS/cm",
+                    mode=selector.NumberSelectorMode.BOX,
+                )
+            ),
+            vol.Optional(
+                "ec_modulation_enabled",
+                default=irrigation_options.get("ec_modulation_enabled", False),
+            ): selector.BooleanSelector(),
         }

--- a/custom_components/growspace_manager/const.py
+++ b/custom_components/growspace_manager/const.py
@@ -272,6 +272,25 @@ SUBSTRATE_NOISE_FLOOR_PCT = 0.5  # VWC change too small to move a peak/trough
 # below the typical day-to-day drift of substrate EC probes.
 SUBSTRATE_EC_TREND_DEADBAND = 0.2
 
+# EC Modulation bounds and response (see CONTEXT.md "EC Modulation",
+# "Pore EC Target Band", "Shot Size Composition"). The modulation factor scales
+# the P2 maintenance shot volume based on how far measured pore EC sits outside
+# the configured target band: above the band the factor rises (>1.0) to induce
+# runoff and flush; below the band it falls (<1.0) to stack EC. Within the band
+# the factor is exactly 1.0. This is the system's only EC actuation — there is
+# no dosing hardware (CONTEXT.md), so it is deliberately gentle and bounded.
+#
+# The response is proportional to the EC excursion past the nearest band edge,
+# normalised by EC_MODULATION_FULL_SCALE_DELTA: an excursion of that magnitude
+# (or more) saturates the factor at the bound. ±25% (0.75–1.25) keeps a single
+# shot from ever swinging volume hard enough to overrun a dryback or a cap.
+EC_MODULATION_MIN_FACTOR = 0.75
+EC_MODULATION_MAX_FACTOR = 1.25
+# Pore-EC excursion (mS/cm) past the band edge that saturates the factor at a
+# bound. 1.0 mS/cm is roughly one full feed-strength step, a sensible "this is
+# clearly out of band, react fully" scale for substrate EC probes.
+EC_MODULATION_FULL_SCALE_DELTA = 1.0
+
 
 # Multi-Device Config Keys
 CONF_LIGHT_SENSORS = "light_sensors"

--- a/custom_components/growspace_manager/models/irrigation.py
+++ b/custom_components/growspace_manager/models/irrigation.py
@@ -62,6 +62,19 @@ class IrrigationStrategy(BaseModel):
     auto_light_tracking: bool = False
     detected_lights_on_time: str | None = None
 
+    # ── Pore EC Target Band + EC Modulation ─────────────────────────────────
+    # Explicit min/max pore-EC band (mS/cm) that EC Modulation steers toward.
+    # DELIBERATELY DISTINCT from the per-stage *feed* EC ranges (ECTargetRange):
+    # pore EC legitimately runs above feed EC when stacking, so the two must
+    # never be conflated (CONTEXT.md "Pore EC Target Band"). Both None => no
+    # band configured; combined with ``ec_modulation_enabled`` defaulting False,
+    # existing stored configs deserialize unchanged (modulation off, factor 1.0).
+    pore_ec_target_min: float | None = None
+    pore_ec_target_max: float | None = None
+    # Opt-in: when False (or the band/sensors are absent), EC Modulation is
+    # inert and the modulation factor is exactly 1.0.
+    ec_modulation_enabled: bool = False
+
     @classmethod
     def __pre_deserialize__(cls, data: dict[str, Any]) -> dict[str, Any]:
         """Migrate legacy shared shot fields by seeding both phases.

--- a/custom_components/growspace_manager/sensor/crop_steering.py
+++ b/custom_components/growspace_manager/sensor/crop_steering.py
@@ -92,4 +92,18 @@ class CropSteeringSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
                 round(avg, 1) if avg is not None else None
             )
 
+        # Shot Size Composition: base × VWC factor × EC modulation factor, with
+        # the configured pore-EC band and modulation capability. Surfaced here
+        # (not in the static strategy payload) because the factors are runtime
+        # state on the VWC coordinator. Absent on time-based irrigation.
+        irrigation_coord = (
+            self.coordinator.services.growspaces.get_irrigation_coordinator(
+                self._growspace_id
+            )
+        )
+        if irrigation_coord is not None and hasattr(
+            irrigation_coord, "shot_composition_payload"
+        ):
+            attributes["shot_composition"] = irrigation_coord.shot_composition_payload()
+
         return attributes

--- a/custom_components/growspace_manager/services/growspace_facade.py
+++ b/custom_components/growspace_manager/services/growspace_facade.py
@@ -262,6 +262,23 @@ class GrowspaceFacade:
         for pump_key in ("irrigation_pump_entity", "drain_pump_entity"):
             if pump_key in updated_settings and not updated_settings[pump_key]:
                 updated_settings[pump_key] = None
+
+        # Validate the Pore EC Target Band (min < max) using the effective
+        # post-update values so setting a single edge is checked against the
+        # already-stored other edge.
+        strategy = growspace.irrigation_strategy
+        band_min = updated_settings.get(
+            "pore_ec_target_min", strategy.pore_ec_target_min
+        )
+        band_max = updated_settings.get(
+            "pore_ec_target_max", strategy.pore_ec_target_max
+        )
+        if band_min is not None and band_max is not None and band_min >= band_max:
+            raise ServiceValidationError(
+                f"Pore EC target band invalid: min ({band_min}) must be below "
+                f"max ({band_max})"
+            )
+
         for k, v in updated_settings.items():
             if hasattr(growspace.irrigation_config, k):
                 setattr(growspace.irrigation_config, k, v)

--- a/custom_components/growspace_manager/vwc_irrigation_coordinator.py
+++ b/custom_components/growspace_manager/vwc_irrigation_coordinator.py
@@ -3,15 +3,21 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import date, datetime, timedelta
 import logging
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING, Any, override
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.dt import now, parse_datetime
+
+from .const import (
+    EC_MODULATION_FULL_SCALE_DELTA,
+    EC_MODULATION_MAX_FACTOR,
+    EC_MODULATION_MIN_FACTOR,
+)
 
 if TYPE_CHECKING:
     from .coordinator import GrowspaceCoordinator
@@ -29,6 +35,28 @@ class SteeringPhaseBoundaries:
     p0_end: datetime
     p2_stop: datetime
     lights_off: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ShotComposition:
+    """Fully-explained composition of the most recent fired steering shot.
+
+    Surfaced in diagnostics/payload so any shot is explainable end to end:
+    ``effective = base × vwc_factor × ec_factor``, then safety caps clamp the
+    delivered duration (``capped`` is True when a cap actually reduced it).
+    ``ec_modulation_available`` distinguishes "modulation off / no pore-EC
+    sensor / no reading → factor 1.0" from "within band → factor 1.0".
+    """
+
+    phase: str
+    base_seconds: int
+    vwc_factor: float
+    ec_factor: float
+    ec_modulation_available: bool
+    composed_seconds: int
+    effective_seconds: int
+    capped: bool
+    timestamp: str
 
 
 class VWCIrrigationCoordinator(BaseIrrigationCoordinator):
@@ -50,6 +78,10 @@ class VWCIrrigationCoordinator(BaseIrrigationCoordinator):
         self._target_reached_today = False
         self._last_reset_date: str | None = None
         self._shot_scale_factor = 1.0
+        # Last fired shot's full composition, exposed for diagnostics so any
+        # shot is explainable (base × VWC × EC, then caps). None until a shot
+        # has fired this session.
+        self._last_shot_composition: ShotComposition | None = None
 
         # We track if we have logged a "sensor missing" warning recently to avoid spam
         self._sensor_warning_logged = False
@@ -267,6 +299,7 @@ class VWCIrrigationCoordinator(BaseIrrigationCoordinator):
     def _handle_watering(self, strategy: IrrigationStrategy, phase: str) -> None:
         """Handle execution of a shot if the phase's interval permits."""
         now_dt = now()
+        growspace = self.growspace
         duration, interval_minutes = self._shot_params_for_phase(strategy, phase)
 
         last_shot = self._last_shot_dt()
@@ -278,15 +311,44 @@ class VWCIrrigationCoordinator(BaseIrrigationCoordinator):
         pump_entity = self._get_pump_entity()
         if not pump_entity:
             return
-        scaled_duration = max(1, int(round(duration * self._shot_scale_factor)))
+
+        # Shot Size Composition: effective = base × VWC factor × EC factor.
+        # The two factors are computed independently (they may pull opposite
+        # ways and partially cancel — physically sensible). EC modulation
+        # applies to P2 maintenance shots only (the issue's actuation point);
+        # P1 ramp-up keeps a neutral EC factor of 1.0. Safety caps are applied
+        # LAST, downstream in _run_pump_cycle, against this composed duration.
+        if phase == "P2":
+            ec_factor, ec_available = self._compute_ec_modulation(strategy, growspace)
+        else:
+            ec_factor, ec_available = 1.0, False
+        composed_factor = self._shot_scale_factor * ec_factor
+        scaled_duration = max(1, int(round(duration * composed_factor)))
+
+        # Caps are evaluated last and never exceeded: record whether they would
+        # block this composed shot so a fired (or skipped) shot is explainable.
+        capped = self._check_safety_guards(scaled_duration) is not None
+        self._last_shot_composition = ShotComposition(
+            phase=phase,
+            base_seconds=duration,
+            vwc_factor=round(self._shot_scale_factor, 3),
+            ec_factor=round(ec_factor, 3),
+            ec_modulation_available=ec_available,
+            composed_seconds=scaled_duration,
+            effective_seconds=0 if capped else scaled_duration,
+            capped=capped,
+            timestamp=now_dt.isoformat(),
+        )
 
         _LOGGER.info(
-            "Firing %s shot for growspace %s. Duration: %ss (scaled from %ss, factor: %.2f)",
+            "Firing %s shot for growspace %s. Duration: %ss "
+            "(base %ss × VWC %.2f × EC %.2f)",
             phase,
             self._growspace_id,
             scaled_duration,
             duration,
             self._shot_scale_factor,
+            ec_factor,
         )
 
         existing_task = self._running_tasks.get("irrigation")
@@ -359,6 +421,73 @@ class VWCIrrigationCoordinator(BaseIrrigationCoordinator):
         if not values:
             return None
         return sum(values) / len(values)
+
+    def shot_composition_payload(self) -> dict[str, Any]:
+        """Return the frontend/diagnostics view of the last shot composition.
+
+        Always carries the current modulation *capability* (whether opt-in,
+        band, and a pore-EC reading are all present) plus the configured band,
+        so the card can explain modulation even before the first shot fires.
+        ``last_shot`` is None until a P2/P1 shot has fired this session.
+        """
+        growspace = self.growspace
+        strategy = growspace.irrigation_strategy
+        _, ec_available = self._compute_ec_modulation(strategy, growspace)
+        composition = self._last_shot_composition
+        return {
+            "ec_modulation_enabled": strategy.ec_modulation_enabled,
+            "ec_modulation_available": ec_available,
+            "pore_ec_target_min": strategy.pore_ec_target_min,
+            "pore_ec_target_max": strategy.pore_ec_target_max,
+            "current_vwc_factor": round(self._shot_scale_factor, 3),
+            "last_shot": asdict(composition) if composition is not None else None,
+        }
+
+    @staticmethod
+    def _ec_modulation_factor_for_reading(
+        measured_ec: float, band_min: float, band_max: float
+    ) -> float:
+        """Map a measured pore EC against the band to a bounded shot factor.
+
+        Pure helper: above the band → factor > 1.0 (flush), below → < 1.0
+        (stack), within → exactly 1.0. The response is proportional to the
+        excursion past the nearest band edge, normalised so an excursion of
+        ``EC_MODULATION_FULL_SCALE_DELTA`` saturates at the bound, then clamped
+        to ``[EC_MODULATION_MIN_FACTOR, EC_MODULATION_MAX_FACTOR]``.
+        """
+        if measured_ec > band_max:
+            excursion = measured_ec - band_max
+            span = EC_MODULATION_MAX_FACTOR - 1.0
+            factor = 1.0 + span * (excursion / EC_MODULATION_FULL_SCALE_DELTA)
+            return min(EC_MODULATION_MAX_FACTOR, factor)
+        if measured_ec < band_min:
+            excursion = band_min - measured_ec
+            span = 1.0 - EC_MODULATION_MIN_FACTOR
+            factor = 1.0 - span * (excursion / EC_MODULATION_FULL_SCALE_DELTA)
+            return max(EC_MODULATION_MIN_FACTOR, factor)
+        return 1.0
+
+    def _compute_ec_modulation(
+        self, strategy: IrrigationStrategy, growspace: Growspace
+    ) -> tuple[float, bool]:
+        """Return ``(factor, available)`` for EC modulation on a P2 shot.
+
+        ``available`` is the modulation *capability* flag: True only when the
+        feature is opted in, a valid band is configured, and a measured pore EC
+        exists. When unavailable the factor is exactly 1.0 — distinct in the
+        payload from a measured "within band → 1.0" (available True, factor 1.0).
+        """
+        if not strategy.ec_modulation_enabled:
+            return 1.0, False
+        band_min = strategy.pore_ec_target_min
+        band_max = strategy.pore_ec_target_max
+        if band_min is None or band_max is None or band_min >= band_max:
+            return 1.0, False
+        measured_ec = self._average_pore_ec(growspace)
+        if measured_ec is None:
+            return 1.0, False
+        factor = self._ec_modulation_factor_for_reading(measured_ec, band_min, band_max)
+        return factor, True
 
     def _record_substrate_shot(self, phase: str) -> None:
         """Signal a fired shot to the SubstrateTracker for dryback bounding."""

--- a/tests/core/snapshots/test_models_snapshots.ambr
+++ b/tests/core/snapshots/test_models_snapshots.ambr
@@ -305,6 +305,7 @@
     'irrigation_strategy': dict({
       'auto_light_tracking': False,
       'detected_lights_on_time': None,
+      'ec_modulation_enabled': False,
       'enabled': False,
       'lights_on_time': '06:00:00',
       'maintenance_dryback_percent': 2.0,
@@ -314,6 +315,8 @@
       'p2_shot_duration_seconds': 10,
       'p2_shot_interval_minutes': 15,
       'p2_stop_before_lights_off_minutes': 120,
+      'pore_ec_target_max': None,
+      'pore_ec_target_min': None,
       'shot_duration_seconds': 10,
       'shot_interval_minutes': 15,
       'target_vwc_percent': 55.0,

--- a/tests/core/snapshots/test_presentation_snapshots.ambr
+++ b/tests/core/snapshots/test_presentation_snapshots.ambr
@@ -199,6 +199,7 @@
       'irrigation_strategy': dict({
         'auto_light_tracking': False,
         'detected_lights_on_time': None,
+        'ec_modulation_enabled': False,
         'enabled': False,
         'lights_on_time': '06:00:00',
         'maintenance_dryback_percent': 2.0,
@@ -208,6 +209,8 @@
         'p2_shot_duration_seconds': 10,
         'p2_shot_interval_minutes': 15,
         'p2_stop_before_lights_off_minutes': 120,
+        'pore_ec_target_max': None,
+        'pore_ec_target_min': None,
         'shot_duration_seconds': 10,
         'shot_interval_minutes': 15,
         'target_vwc_percent': 55.0,

--- a/tests/integration/snapshots/test_services_growspace_coverage.ambr
+++ b/tests/integration/snapshots/test_services_growspace_coverage.ambr
@@ -160,6 +160,7 @@
     'irrigation_strategy': dict({
       'auto_light_tracking': False,
       'detected_lights_on_time': None,
+      'ec_modulation_enabled': False,
       'enabled': False,
       'lights_on_time': '06:00:00',
       'maintenance_dryback_percent': 2.0,
@@ -169,6 +170,8 @@
       'p2_shot_duration_seconds': 10,
       'p2_shot_interval_minutes': 15,
       'p2_stop_before_lights_off_minutes': 120,
+      'pore_ec_target_max': None,
+      'pore_ec_target_min': None,
       'shot_duration_seconds': 10,
       'shot_interval_minutes': 15,
       'target_vwc_percent': 55.0,

--- a/tests/integration/test_facade_comprehensive.py
+++ b/tests/integration/test_facade_comprehensive.py
@@ -252,10 +252,14 @@ def test_get_sorted_growspace_options(mock_coordinator) -> None:
 
 def test_properties(mock_coordinator) -> None:
     """ServiceFacade should expose four domain sub-facades."""
-    from custom_components.growspace_manager.services.growspace_facade import GrowspaceFacade
+    from custom_components.growspace_manager.services.growspace_facade import (
+        GrowspaceFacade,
+    )
     from custom_components.growspace_manager.services.plant_facade import PlantFacade
     from custom_components.growspace_manager.services.config_facade import ConfigFacade
-    from custom_components.growspace_manager.services.notifications_facade import NotificationsFacade
+    from custom_components.growspace_manager.services.notifications_facade import (
+        NotificationsFacade,
+    )
 
     facade = ServiceFacade(mock_coordinator)
     assert isinstance(facade.growspaces, GrowspaceFacade)
@@ -516,6 +520,65 @@ async def test_update_irrigation_config_sets_fields(mock_coordinator) -> None:
     assert gs.irrigation_config.irrigation_pump_entity is None
 
 
+@pytest.mark.asyncio
+async def test_update_irrigation_config_sets_pore_ec_band(mock_coordinator) -> None:
+    """A valid pore-EC band and opt-in flag land on the strategy."""
+    facade = ServiceFacade(mock_coordinator)
+    gs = Growspace(id="gs1", name="GS1")
+    mock_coordinator.growspaces = {"gs1": gs}
+    mock_coordinator.async_commit = AsyncMock()
+    mock_coordinator.async_request_refresh = AsyncMock()
+    mock_coordinator.cache = MagicMock()
+
+    await facade.growspaces.update_irrigation_config(
+        "gs1",
+        {
+            "pore_ec_target_min": 2.0,
+            "pore_ec_target_max": 3.5,
+            "ec_modulation_enabled": True,
+        },
+    )
+    assert gs.irrigation_strategy.pore_ec_target_min == 2.0
+    assert gs.irrigation_strategy.pore_ec_target_max == 3.5
+    assert gs.irrigation_strategy.ec_modulation_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_update_irrigation_config_rejects_inverted_band(mock_coordinator) -> None:
+    """A pore-EC band with min >= max is rejected with a validation error."""
+    facade = ServiceFacade(mock_coordinator)
+    gs = Growspace(id="gs1", name="GS1")
+    mock_coordinator.growspaces = {"gs1": gs}
+    mock_coordinator.async_commit = AsyncMock()
+    mock_coordinator.async_request_refresh = AsyncMock()
+    mock_coordinator.cache = MagicMock()
+
+    with pytest.raises(ServiceValidationError, match="Pore EC target band"):
+        await facade.growspaces.update_irrigation_config(
+            "gs1",
+            {"pore_ec_target_min": 3.0, "pore_ec_target_max": 2.0},
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_irrigation_config_band_single_edge_vs_stored(
+    mock_coordinator,
+) -> None:
+    """Setting one edge is validated against the already-stored other edge."""
+    facade = ServiceFacade(mock_coordinator)
+    gs = Growspace(id="gs1", name="GS1")
+    gs.irrigation_strategy.pore_ec_target_max = 3.0
+    mock_coordinator.growspaces = {"gs1": gs}
+    mock_coordinator.async_commit = AsyncMock()
+    mock_coordinator.async_request_refresh = AsyncMock()
+    mock_coordinator.cache = MagicMock()
+
+    with pytest.raises(ServiceValidationError, match="Pore EC target band"):
+        await facade.growspaces.update_irrigation_config(
+            "gs1", {"pore_ec_target_min": 4.0}
+        )
+
+
 # ---------------------------------------------------------------------------
 # take_clones / promote_clone
 # ---------------------------------------------------------------------------
@@ -573,7 +636,9 @@ async def test_add_irrigation_schedule_item_with_duration(mock_coordinator) -> N
     irr_coord.async_add_schedule_item = AsyncMock()
     mock_coordinator._subsystem_manager.irrigation_coordinators = {"gs1": irr_coord}
 
-    await facade.growspaces.add_irrigation_schedule_item("gs1", "irrigation_times", "08:00", 15)
+    await facade.growspaces.add_irrigation_schedule_item(
+        "gs1", "irrigation_times", "08:00", 15
+    )
     irr_coord.async_add_schedule_item.assert_awaited_once_with(
         "irrigation_times", "08:00", 15
     )
@@ -588,7 +653,9 @@ async def test_add_irrigation_schedule_item_default_duration(mock_coordinator) -
     irr_coord.async_add_schedule_item = AsyncMock()
     mock_coordinator._subsystem_manager.irrigation_coordinators = {"gs1": irr_coord}
 
-    await facade.growspaces.add_irrigation_schedule_item("gs1", "irrigation_times", "09:00")
+    await facade.growspaces.add_irrigation_schedule_item(
+        "gs1", "irrigation_times", "09:00"
+    )
     irr_coord.get_default_duration.assert_called_once_with("irrigation")
     irr_coord.async_add_schedule_item.assert_awaited_once_with(
         "irrigation_times", "09:00", 20
@@ -602,7 +669,9 @@ async def test_remove_irrigation_schedule_item(mock_coordinator) -> None:
     irr_coord.async_remove_schedule_item = AsyncMock()
     mock_coordinator._subsystem_manager.irrigation_coordinators = {"gs1": irr_coord}
 
-    await facade.growspaces.remove_irrigation_schedule_item("gs1", "irrigation_times", "08:00")
+    await facade.growspaces.remove_irrigation_schedule_item(
+        "gs1", "irrigation_times", "08:00"
+    )
     irr_coord.async_remove_schedule_item.assert_awaited_once_with(
         "irrigation_times", "08:00"
     )
@@ -626,11 +695,11 @@ async def test_get_irrigation_coordinator_lazy_init(mock_coordinator) -> None:
         mock_coordinator._subsystem_manager.irrigation_coordinators[gs_id] = irr_coord
 
     mock_coordinator._subsystem_manager.irrigation_coordinators = {}
-    mock_coordinator._subsystem_manager.async_setup_growspace_sub_coordinators.side_effect = (
-        _setup_side_effect
-    )
+    mock_coordinator._subsystem_manager.async_setup_growspace_sub_coordinators.side_effect = _setup_side_effect
 
-    await facade.growspaces.add_irrigation_schedule_item("gs1", "irrigation_times", "10:00")
+    await facade.growspaces.add_irrigation_schedule_item(
+        "gs1", "irrigation_times", "10:00"
+    )
     mock_coordinator._subsystem_manager.async_setup_growspace_sub_coordinators.assert_awaited_once()
 
 
@@ -642,7 +711,9 @@ async def test_get_irrigation_coordinator_missing_raises(mock_coordinator) -> No
     mock_coordinator.growspaces = {}
 
     with pytest.raises(ServiceValidationError):
-        await facade.growspaces.add_irrigation_schedule_item("gs1", "irrigation_times", "08:00")
+        await facade.growspaces.add_irrigation_schedule_item(
+            "gs1", "irrigation_times", "08:00"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -725,7 +796,9 @@ async def test_save_nutrient_preset(mock_coordinator) -> None:
     mock_coordinator._nutrient_manager.async_save_nutrient_preset = AsyncMock(
         return_value=preset
     )
-    result = await facade.config.save_nutrient_preset("Bloom", [{"name": "N", "amount": 2.0}])
+    result = await facade.config.save_nutrient_preset(
+        "Bloom", [{"name": "N", "amount": 2.0}]
+    )
     assert result is preset
 
 
@@ -894,7 +967,9 @@ async def test_configure_tank_updates_volume(mock_coordinator) -> None:
     mock_coordinator._data_repository.get_growspace = MagicMock(return_value=gs)
     mock_coordinator.async_commit = AsyncMock()
 
-    await facade.growspaces.configure_tank("gs1", "sensor.tank_level", volume_liters=200.0)
+    await facade.growspaces.configure_tank(
+        "gs1", "sensor.tank_level", volume_liters=200.0
+    )
     assert tank.volume_liters == 200.0
     mock_coordinator.async_commit.assert_awaited_once()
 
@@ -905,7 +980,9 @@ async def test_configure_tank_unknown_growspace(mock_coordinator) -> None:
     facade = ServiceFacade(mock_coordinator)
     mock_coordinator._data_repository.get_growspace = MagicMock(return_value=None)
     mock_coordinator.async_commit = AsyncMock()
-    await facade.growspaces.configure_tank("missing", "sensor.tank", volume_liters=100.0)
+    await facade.growspaces.configure_tank(
+        "missing", "sensor.tank", volume_liters=100.0
+    )
     mock_coordinator.async_commit.assert_not_awaited()
 
 
@@ -916,7 +993,9 @@ async def test_configure_tank_unknown_entity(mock_coordinator) -> None:
     gs = Growspace(id="gs1", name="GS1")
     mock_coordinator._data_repository.get_growspace = MagicMock(return_value=gs)
     mock_coordinator.async_commit = AsyncMock()
-    await facade.growspaces.configure_tank("gs1", "sensor.unknown_tank", volume_liters=100.0)
+    await facade.growspaces.configure_tank(
+        "gs1", "sensor.unknown_tank", volume_liters=100.0
+    )
     mock_coordinator.async_commit.assert_not_awaited()
 
 
@@ -1466,7 +1545,9 @@ async def test_save_ipm_preset_items_in_kwargs(mock_coordinator) -> None:
     preset = MagicMock()
     mock_coordinator.ipm_service.async_save_ipm_preset = AsyncMock(return_value=preset)
     # Pass items via kwargs, not as the named parameter
-    result = await facade.config.save_ipm_preset("Test", preset_type="Foliar", items=[{"name": "Neem"}])
+    result = await facade.config.save_ipm_preset(
+        "Test", preset_type="Foliar", items=[{"name": "Neem"}]
+    )
     assert result is preset
 
 
@@ -1501,7 +1582,9 @@ async def test_remove_ipm_preset(mock_coordinator: MagicMock) -> None:
     facade = ServiceFacade(mock_coordinator)
     mock_coordinator.ipm_service.async_remove_ipm_preset = AsyncMock()
     await facade.config.remove_ipm_preset("preset_123")
-    mock_coordinator.ipm_service.async_remove_ipm_preset.assert_awaited_once_with("preset_123")
+    mock_coordinator.ipm_service.async_remove_ipm_preset.assert_awaited_once_with(
+        "preset_123"
+    )
 
 
 @pytest.mark.asyncio
@@ -1668,7 +1751,9 @@ async def test_async_add_timed_notification(mock_coordinator: MagicMock) -> None
     mock_coordinator.config_entry = MagicMock()
     mock_coordinator.config_entry.options = {}
 
-    await facade.notifications.async_add_timed_notification("Water time!", "day", 7, ["gs1"])
+    await facade.notifications.async_add_timed_notification(
+        "Water time!", "day", 7, ["gs1"]
+    )
     mock_coordinator.notification_settings.create_timed_notification.assert_called_once_with(
         "Water time!", "day", 7, ["gs1"]
     )
@@ -1688,7 +1773,9 @@ async def test_async_update_timed_notification(mock_coordinator: MagicMock) -> N
     mock_coordinator.config_entry = MagicMock()
     mock_coordinator.config_entry.options = {}
 
-    await facade.notifications.async_update_timed_notification("n1", "Updated", "day", 7, ["gs1"])
+    await facade.notifications.async_update_timed_notification(
+        "n1", "Updated", "day", 7, ["gs1"]
+    )
     mock_coordinator.notification_settings.update_timed_notification_in_list.assert_called_once_with(
         [{"id": "n1"}], "n1", "Updated", "day", 7, ["gs1"]
     )
@@ -1722,7 +1809,9 @@ def test_config_get_applicable_presets(mock_coordinator: MagicMock) -> None:
         return_value=presets
     )
     assert facade.config.get_applicable_presets("p1") is presets
-    mock_coordinator._nutrient_manager.get_applicable_presets.assert_called_once_with("p1")
+    mock_coordinator._nutrient_manager.get_applicable_presets.assert_called_once_with(
+        "p1"
+    )
 
 
 def test_config_get_nutrient_serialization_data(mock_coordinator: MagicMock) -> None:
@@ -1734,5 +1823,3 @@ def test_config_get_nutrient_serialization_data(mock_coordinator: MagicMock) -> 
     )
     assert facade.config.get_nutrient_serialization_data() == serial_data
     mock_coordinator._nutrient_manager.get_serialization_data.assert_called_once()
-
-

--- a/tests/integration/test_vwc_irrigation_coordinator.py
+++ b/tests/integration/test_vwc_irrigation_coordinator.py
@@ -1480,3 +1480,228 @@ def test_average_pore_ec_all_unusable_returns_none(
     mock_growspace.environment_config.pore_ec_sensors = ["sensor.ec_a"]
     mock_hass.states.get.return_value = _state("unavailable")
     assert vwc_coordinator._average_pore_ec(mock_growspace) is None
+
+
+# ── EC Modulation factor (pure mapping) ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("measured_ec", "expected_factor"),
+    [
+        # Within band → exactly 1.0 (band 2.0–3.0).
+        (2.0, 1.0),
+        (2.5, 1.0),
+        (3.0, 1.0),
+        # Above band → >1.0, proportional to excursion, full-scale delta 1.0.
+        (3.5, 1.125),  # 0.5 past max → 1 + 0.25*0.5
+        (4.0, 1.25),  # 1.0 past max → saturates at max bound
+        (10.0, 1.25),  # far above → clamped to max bound
+        # Below band → <1.0.
+        (1.5, 0.875),  # 0.5 below min → 1 - 0.25*0.5
+        (1.0, 0.75),  # 1.0 below min → saturates at min bound
+        (0.0, 0.75),  # far below → clamped to min bound
+    ],
+)
+def test_ec_modulation_factor_for_reading(
+    measured_ec: float, expected_factor: float
+) -> None:
+    """The pure factor map responds above/within/below the band, bounded ±25%."""
+    factor = VWCIrrigationCoordinator._ec_modulation_factor_for_reading(
+        measured_ec, 2.0, 3.0
+    )
+    assert factor == pytest.approx(expected_factor)
+
+
+# ── EC Modulation gating (capability) ────────────────────────────────────────
+
+
+def _set_band(growspace: Growspace, enabled: bool) -> None:
+    """Configure a 2.0–3.0 pore-EC band with the given opt-in flag."""
+    growspace.irrigation_strategy.pore_ec_target_min = 2.0
+    growspace.irrigation_strategy.pore_ec_target_max = 3.0
+    growspace.irrigation_strategy.ec_modulation_enabled = enabled
+
+
+def test_ec_modulation_disabled_factor_one_unavailable(
+    vwc_coordinator, mock_hass, mock_growspace
+) -> None:
+    """Opt-in off → factor exactly 1.0 and capability False, even with sensors."""
+    _set_band(mock_growspace, enabled=False)
+    mock_growspace.environment_config.pore_ec_sensors = ["sensor.ec_a"]
+    mock_hass.states.get.return_value = _state("5.0")  # well above band
+
+    factor, available = vwc_coordinator._compute_ec_modulation(
+        mock_growspace.irrigation_strategy, mock_growspace
+    )
+    assert factor == 1.0
+    assert available is False
+
+
+def test_ec_modulation_no_sensors_factor_one_unavailable(
+    vwc_coordinator, mock_growspace
+) -> None:
+    """Enabled but no pore-EC sensors → factor 1.0, capability False (gated)."""
+    _set_band(mock_growspace, enabled=True)
+    mock_growspace.environment_config.pore_ec_sensors = []
+
+    factor, available = vwc_coordinator._compute_ec_modulation(
+        mock_growspace.irrigation_strategy, mock_growspace
+    )
+    assert factor == 1.0
+    assert available is False
+
+
+def test_ec_modulation_no_band_factor_one_unavailable(
+    vwc_coordinator, mock_hass, mock_growspace
+) -> None:
+    """Enabled with sensors but no band configured → factor 1.0, capability False."""
+    mock_growspace.irrigation_strategy.ec_modulation_enabled = True
+    mock_growspace.irrigation_strategy.pore_ec_target_min = None
+    mock_growspace.irrigation_strategy.pore_ec_target_max = None
+    mock_growspace.environment_config.pore_ec_sensors = ["sensor.ec_a"]
+    mock_hass.states.get.return_value = _state("5.0")
+
+    factor, available = vwc_coordinator._compute_ec_modulation(
+        mock_growspace.irrigation_strategy, mock_growspace
+    )
+    assert factor == 1.0
+    assert available is False
+
+
+@pytest.mark.parametrize(
+    ("measured", "expected_factor"),
+    [("2.5", 1.0), ("4.0", 1.25), ("1.0", 0.75)],
+)
+def test_ec_modulation_available_within_above_below(
+    vwc_coordinator, mock_hass, mock_growspace, measured: str, expected_factor: float
+) -> None:
+    """Enabled + band + reading → capability True; within band still factor 1.0.
+
+    Distinguishes "within band → 1.0" (available True) from the gated cases
+    above where 1.0 comes with available False.
+    """
+    _set_band(mock_growspace, enabled=True)
+    mock_growspace.environment_config.pore_ec_sensors = ["sensor.ec_a"]
+    mock_hass.states.get.return_value = _state(measured)
+
+    factor, available = vwc_coordinator._compute_ec_modulation(
+        mock_growspace.irrigation_strategy, mock_growspace
+    )
+    assert factor == pytest.approx(expected_factor)
+    assert available is True
+
+
+# ── Shot Size Composition (VWC × EC) and caps last ───────────────────────────
+
+
+async def test_ec_modulation_only_applies_to_p2(
+    vwc_coordinator, mock_hass, mock_growspace, mock_sleep
+) -> None:
+    """EC modulation applies to P2 shots only; P1 keeps a neutral EC factor."""
+    _set_band(mock_growspace, enabled=True)
+    mock_growspace.environment_config.pore_ec_sensors = ["sensor.ec_a"]
+    mock_hass.states.get.return_value = _state("4.0")  # above band → EC 1.25
+    strategy = mock_growspace.irrigation_strategy
+    strategy.p1_shot_duration_seconds = 20
+    vwc_coordinator._last_cycle_timestamp = None
+
+    vwc_coordinator._handle_watering(strategy, "P1")
+    await await_pump_task()
+
+    comp = vwc_coordinator._last_shot_composition
+    assert comp.ec_factor == 1.0
+    assert comp.ec_modulation_available is False
+    mock_sleep.assert_any_call(20)
+
+
+async def test_shot_composition_multiplies_vwc_and_ec(
+    vwc_coordinator, mock_hass, mock_growspace, mock_sleep
+) -> None:
+    """P2 effective duration = base × VWC factor × EC factor (partial cancel)."""
+    _set_band(mock_growspace, enabled=True)
+    mock_growspace.environment_config.pore_ec_sensors = ["sensor.ec_a"]
+    mock_hass.states.get.return_value = _state("4.0")  # above band → EC 1.25
+    strategy = mock_growspace.irrigation_strategy
+    strategy.p2_shot_duration_seconds = 100
+    # VWC feedback factor pulls down while EC pulls up: 100 × 0.85 × 1.25 = 106.
+    vwc_coordinator._shot_scale_factor = 0.85
+    vwc_coordinator._last_cycle_timestamp = None
+
+    vwc_coordinator._handle_watering(strategy, "P2")
+    await await_pump_task()
+
+    comp = vwc_coordinator._last_shot_composition
+    assert comp.base_seconds == 100
+    assert comp.vwc_factor == pytest.approx(0.85)
+    assert comp.ec_factor == pytest.approx(1.25)
+    assert comp.ec_modulation_available is True
+    assert comp.effective_seconds == 106  # round(100 * 0.85 * 1.25)
+    assert comp.capped is False
+    mock_sleep.assert_any_call(106)
+
+
+async def test_shot_composition_below_band_stacks_down(
+    vwc_coordinator, mock_hass, mock_growspace, mock_sleep
+) -> None:
+    """Below-band pore EC scales the P2 shot DOWN (stacking)."""
+    _set_band(mock_growspace, enabled=True)
+    mock_growspace.environment_config.pore_ec_sensors = ["sensor.ec_a"]
+    mock_hass.states.get.return_value = _state("1.0")  # below band → EC 0.75
+    strategy = mock_growspace.irrigation_strategy
+    strategy.p2_shot_duration_seconds = 100
+    vwc_coordinator._last_cycle_timestamp = None
+
+    vwc_coordinator._handle_watering(strategy, "P2")
+    await await_pump_task()
+
+    comp = vwc_coordinator._last_shot_composition
+    assert comp.ec_factor == pytest.approx(0.75)
+    assert comp.effective_seconds == 75
+    mock_sleep.assert_any_call(75)
+
+
+async def test_composed_shot_blocked_by_volume_cap_never_exceeds(
+    vwc_coordinator, mock_hass, mock_growspace, mock_sleep
+) -> None:
+    """A composed (EC-amplified) shot that would breach the daily volume cap is
+    clamped LAST: the safety guard blocks the cycle, no pump runs, and the
+    composition records capped=True with effective_seconds 0.
+    """
+    _set_band(mock_growspace, enabled=True)
+    mock_growspace.environment_config.pore_ec_sensors = ["sensor.ec_a"]
+    mock_hass.states.get.return_value = _state("4.0")  # above band → EC 1.25
+    strategy = mock_growspace.irrigation_strategy
+    strategy.p2_shot_duration_seconds = 100
+    # Flow rate so the composed 125 s shot pushes past a tiny daily cap.
+    mock_growspace.irrigation_config.pump_flow_rate_ml_per_sec = 10.0  # 1.25 L
+    mock_growspace.irrigation_config.daily_volume_cap_liters = 0.5
+    vwc_coordinator._last_cycle_timestamp = None
+
+    vwc_coordinator._handle_watering(strategy, "P2")
+    await await_pump_task()
+
+    comp = vwc_coordinator._last_shot_composition
+    assert comp.composed_seconds == 125  # base 100 × EC 1.25
+    assert comp.capped is True
+    assert comp.effective_seconds == 0
+    # Caps are applied last and never exceeded: the pump never ran its on-cycle
+    # for the composed 125 s duration, and the switch was never turned on.
+    pump_durations = [c.args[0] for c in mock_sleep.call_args_list if c.args]
+    assert 125 not in pump_durations
+    mock_hass.services.async_call.assert_not_called()
+
+
+def test_shot_composition_payload_capability_and_band(
+    vwc_coordinator, mock_hass, mock_growspace
+) -> None:
+    """The payload carries the band, opt-in, and live capability flag."""
+    _set_band(mock_growspace, enabled=True)
+    mock_growspace.environment_config.pore_ec_sensors = ["sensor.ec_a"]
+    mock_hass.states.get.return_value = _state("2.5")
+
+    payload = vwc_coordinator.shot_composition_payload()
+    assert payload["ec_modulation_enabled"] is True
+    assert payload["ec_modulation_available"] is True
+    assert payload["pore_ec_target_min"] == 2.0
+    assert payload["pore_ec_target_max"] == 3.0
+    assert payload["last_shot"] is None  # no shot fired yet


### PR DESCRIPTION
Closes #447

> **Stacked on #452 → #451.** Merge order: #451 (#444) → #452 (#445) → this. GitHub auto-retargets the base as each parent merges.

## What this does

Adds a **Pore EC Target Band** on the irrigation strategy and opt-in, bounded **EC Modulation** that scales the P2 shot size toward the band — the system's only EC actuation (no dosing hardware). Composes multiplicatively with the existing VWC feedback factor; safety caps stay last.

## Behaviour

- **Band:** `pore_ec_target_min` / `pore_ec_target_max` on `IrrigationStrategy` (mS/cm) — deliberately distinct from per-stage *feed*-EC `ECTargetRange` (pore EC runs above feed when stacking; never conflated). Validated `min < max`.
- **Modulation:** opt-in `ec_modulation_enabled`. Measured pore EC (averaged across sensors, reusing #445's `_average_pore_ec`) above band → factor >1.0 (flush); below → <1.0 (stack); within → exactly 1.0. Bounded 0.75–1.25, proportional to excursion past the nearest edge. **P2 only** (P1 stays 1.0).
- **Composition:** `effective = base × VWC_factor × EC_factor`, then existing safety caps (daily volume cap, max cycles, low tank, dark period) applied **last** and never exceeded.
- **Sensor-Gated:** opt-in off / no sensors / no band / no reading → factor exactly 1.0, capability flag false (distinct from within-band 1.0).
- **Explainable:** a `ShotComposition` record (base / VWC / EC / composed / effective seconds / capped / capability) exposed via the crop-steering sensor payload.

## Acceptance criteria → tests

| AC | Test |
|----|------|
| Band fields serialized + payload, min < max | `test_shot_composition_payload_capability_and_band` + 3 facade validation tests |
| Opt-in / prereqs unmet → factor 1.0 | 4 gating tests |
| Factor bounded, responds above/below/within | `test_ec_modulation_factor_for_reading` (parametrized) |
| Multiplicative w/ VWC; caps last & never exceeded | `test_shot_composition_multiplies_vwc_and_ec`, `test_composed_shot_blocked_by_volume_cap_never_exceeds` |
| Both factors + effective size in payload | `test_shot_composition_payload_capability_and_band` |
| Below-band stacking; P2-only | `test_shot_composition_below_band_stacks_down`, `test_ec_modulation_only_applies_to_p2` |

## Key files

- `models/irrigation.py` — band fields + opt-in flag (migration-safe)
- `const.py` — factor bounds + full-scale delta
- `vwc_irrigation_coordinator.py` — `_compute_ec_modulation`, composition in `_handle_watering`, `ShotComposition`
- `services/growspace_facade.py` — min < max validation
- `config_handlers/irrigation_config_handler.py` — UI fields
- `sensor/crop_steering.py` — `shot_composition` attribute

## Testing

Full suite green: **4287 passed**. Ruff clean on production source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)