### PR TITLE
Surface Substrate Profile + Volume Mode fields in the irrigation config-flow form (#455)

### DIFF
--- a/custom_components/growspace_manager/config_handlers/irrigation_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/irrigation_config_handler.py
@@ -9,6 +9,11 @@ from typing import Any
 
 import voluptuous as vol
 
+from custom_components.growspace_manager.const import ShotSizingMode, SubstrateMediaType
+from custom_components.growspace_manager.services.irrigation import (
+    _build_substrate_profile_update,
+    _validate_volume_mode_selection,
+)
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.helpers import selector
 
@@ -88,13 +93,27 @@ class IrrigationConfigHandler(BaseConfigHandler[dict[str, Any]]):
         if not growspace:
             return self.flow.async_abort(reason="growspace_not_found")
 
-        # Load ALL current irrigation options for the growspace from the Growspace object
-        irrigation_options = asdict(growspace.irrigation_config)
+        # Load ALL current irrigation options for the growspace. The strategy and
+        # config carry disjoint field names, so a flat merge seeds every form
+        # field from its stored value (config wins on the impossible collision).
+        # ``use_vwc_steering`` is the form's name for the strategy ``enabled`` flag.
+        irrigation_options = {
+            **asdict(growspace.irrigation_strategy),
+            **asdict(growspace.irrigation_config),
+            "use_vwc_steering": growspace.irrigation_strategy.enabled,
+        }
 
         if user_input is not None:
-            # Delegate update logic to coordinator
+            # Fold the flat substrate fields into the nested ``substrate_profile``
+            # and reject Volume Mode without its prerequisites — reusing the exact
+            # helpers the set_irrigation_strategy service uses, so the form and the
+            # service share one write path and one validation rule (ADR-0011).
+            _build_substrate_profile_update(user_input)
+            _validate_volume_mode_selection(
+                coordinator, self.flow.selected_growspace_id, user_input
+            )
             await coordinator.services.growspaces.update_irrigation_config(
-                self.flow.selected_growspace_id, **user_input
+                self.flow.selected_growspace_id, user_input
             )
 
             # This triggers async_update_listener in __init__.py, reloading the IrrigationCoordinator
@@ -247,6 +266,7 @@ class IrrigationConfigHandler(BaseConfigHandler[dict[str, Any]]):
         self, irrigation_options: dict[str, Any]
     ) -> dict[Any, Any]:
         """Build the VWC (Volumetric Water Content) crop steering schema."""
+        substrate_profile = irrigation_options.get("substrate_profile") or {}
         return {
             vol.Optional(
                 "lights_on_time",
@@ -404,4 +424,97 @@ class IrrigationConfigHandler(BaseConfigHandler[dict[str, Any]]):
                 "ec_modulation_enabled",
                 default=irrigation_options.get("ec_modulation_enabled", False),
             ): selector.BooleanSelector(),
+            # Shot Sizing Mode + Substrate Profile (Volume Mode, ADR-0011).
+            # Optional/suggested_value so untouched submissions round-trip the
+            # stored values idempotently and Seconds Mode users are unaffected.
+            # The flat substrate fields are folded into the nested profile on
+            # submit by the shared _build_substrate_profile_update helper.
+            vol.Optional(
+                "shot_sizing_mode",
+                description={
+                    "suggested_value": irrigation_options.get(
+                        "shot_sizing_mode", ShotSizingMode.SECONDS.value
+                    )
+                },
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        selector.SelectOptionDict(value=mode.value, label=mode.value)
+                        for mode in ShotSizingMode
+                    ],
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional(
+                "substrate_media_type",
+                description={
+                    "suggested_value": substrate_profile.get(
+                        "media_type", SubstrateMediaType.COCO.value
+                    )
+                },
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        selector.SelectOptionDict(value=media.value, label=media.value)
+                        for media in SubstrateMediaType
+                    ],
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional(
+                "substrate_liters_per_pot",
+                description={
+                    "suggested_value": substrate_profile.get("liters_per_pot")
+                },
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.0,
+                    step=0.1,
+                    unit_of_measurement="L",
+                    mode=selector.NumberSelectorMode.BOX,
+                )
+            ),
+            vol.Optional(
+                "pump_flow_rate_ml_per_sec",
+                description={
+                    "suggested_value": irrigation_options.get(
+                        "pump_flow_rate_ml_per_sec"
+                    )
+                },
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.0,
+                    step=0.1,
+                    unit_of_measurement="mL/s",
+                    mode=selector.NumberSelectorMode.BOX,
+                )
+            ),
+            vol.Optional(
+                "p1_shot_volume_percent",
+                description={
+                    "suggested_value": irrigation_options.get("p1_shot_volume_percent")
+                },
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.0,
+                    max=100.0,
+                    step=0.1,
+                    unit_of_measurement="%",
+                    mode=selector.NumberSelectorMode.BOX,
+                )
+            ),
+            vol.Optional(
+                "p2_shot_volume_percent",
+                description={
+                    "suggested_value": irrigation_options.get("p2_shot_volume_percent")
+                },
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.0,
+                    max=100.0,
+                    step=0.1,
+                    unit_of_measurement="%",
+                    mode=selector.NumberSelectorMode.BOX,
+                )
+            ),
         }

--- a/custom_components/growspace_manager/services/irrigation.py
+++ b/custom_components/growspace_manager/services/irrigation.py
@@ -188,11 +188,18 @@ def _validate_volume_mode_selection(
     if growspace is None:
         return
 
-    # Effective per-pot volume: the incoming update wins over the stored profile.
+    # Effective values: an incoming update wins over the stored state for both
+    # the per-pot volume and the pump flow rate, so a single call (e.g. the
+    # config-flow form) may set the profile, the flow rate, and the mode at once.
+    # The service schema never carries ``pump_flow_rate_ml_per_sec`` (a config
+    # field), so for the service path this falls back to the stored value.
     stored_profile = growspace.irrigation_strategy.substrate_profile
     profile_update = strategy.get("substrate_profile", {})
     liters_per_pot = profile_update.get("liters_per_pot", stored_profile.liters_per_pot)
-    flow_rate = growspace.irrigation_config.pump_flow_rate_ml_per_sec
+    flow_rate = strategy.get(
+        "pump_flow_rate_ml_per_sec",
+        growspace.irrigation_config.pump_flow_rate_ml_per_sec,
+    )
 
     if liters_per_pot <= 0.0 or flow_rate <= 0.0:
         raise ServiceValidationError(

--- a/tests/config/test_config_flow.py
+++ b/tests/config/test_config_flow.py
@@ -36,6 +36,7 @@ from custom_components.growspace_manager.const import (
 from custom_components.growspace_manager.models import (
     EnvironmentConfig,
     IrrigationConfig,
+    IrrigationStrategy,
 )
 from homeassistant.config_entries import HANDLERS
 from homeassistant.core import HomeAssistant
@@ -2276,6 +2277,7 @@ async def test_options_flow_select_growspace_for_irrigation_submit(
         name="Growspace 1",
         environment_config=EnvironmentConfig(),
         irrigation_config=IrrigationConfig(),
+        irrigation_strategy=IrrigationStrategy(),
     )
     # mock_gs.irrigation_config = {} # REMOVED: Must use dataclass
     mock_coordinator.growspaces = {"gs1": mock_gs}
@@ -2304,7 +2306,11 @@ async def test_options_flow_configure_irrigation_show_form(
     config_entry = MockConfigEntry(domain=DOMAIN, data={"name": "Test"}, options={})
     config_entry.add_to_hass(hass)
     config_entry.runtime_data = mock_coordinator
-    mock_growspace = Mock(name="Growspace 1", irrigation_config=IrrigationConfig())
+    mock_growspace = Mock(
+        name="Growspace 1",
+        irrigation_config=IrrigationConfig(),
+        irrigation_strategy=IrrigationStrategy(),
+    )
     mock_coordinator.growspaces = {"gs1": mock_growspace}
     config_entry.runtime_data = mock_coordinator
 
@@ -2326,7 +2332,11 @@ async def test_options_flow_configure_irrigation_submit(
     config_entry = MockConfigEntry(domain=DOMAIN, data={"name": "Test"}, options={})
     config_entry.add_to_hass(hass)
     config_entry.runtime_data = mock_coordinator
-    mock_growspace = Mock(name="Growspace 1", irrigation_config=IrrigationConfig())
+    mock_growspace = Mock(
+        name="Growspace 1",
+        irrigation_config=IrrigationConfig(),
+        irrigation_strategy=IrrigationStrategy(),
+    )
     mock_coordinator.growspaces = {"gs1": mock_growspace}
     config_entry.runtime_data = mock_coordinator
 
@@ -2345,7 +2355,7 @@ async def test_options_flow_configure_irrigation_submit(
 
     assert result.get("type") == FlowResultType.CREATE_ENTRY
     mock_coordinator.services.growspaces.update_irrigation_config.assert_called_once_with(
-        "gs1", **user_input
+        "gs1", user_input
     )
 
 
@@ -2975,6 +2985,7 @@ async def test_options_flow_irrigation_save_clears_pumps(
     mock_gs = Mock(
         name="GS1",
         irrigation_config=mock_irrigation_config,
+        irrigation_strategy=IrrigationStrategy(),
         environment_config=EnvironmentConfig(),
     )
     mock_coordinator.growspaces = {"gs1": mock_gs}

--- a/tests/core/test_services_irrigation.py
+++ b/tests/core/test_services_irrigation.py
@@ -6,6 +6,7 @@ import pytest
 
 from custom_components.growspace_manager.services.irrigation import (
     _get_irrigation_coordinator,
+    _validate_volume_mode_selection,
     handle_add_drain_time,
     handle_add_irrigation_time,
     handle_remove_drain_time,
@@ -623,3 +624,27 @@ class TestVolumeModeStrategyValidation:
         await handle_set_irrigation_strategy(mock_hass, mock_coordinator, call)
 
         mock_coordinator.services.growspaces.set_irrigation_strategy.assert_awaited_once()
+
+    def test_incoming_flow_rate_satisfies_gate(
+        self, mock_coordinator: MagicMock
+    ) -> None:
+        """An incoming pump flow rate wins over the stored one (config-flow path).
+
+        The config-flow form sets the flow rate and the mode in one submission, so
+        the gate must evaluate the incoming value, not the (still-zero) stored one.
+        """
+        mock_coordinator.growspaces = {"gs1": self._make_growspace(6.0, 0.0)}
+
+        # No raise: incoming flow rate is positive even though stored is 0.0.
+        _validate_volume_mode_selection(
+            mock_coordinator,
+            "gs1",
+            {"shot_sizing_mode": "volume", "pump_flow_rate_ml_per_sec": 12.0},
+        )
+
+        with pytest.raises(ServiceValidationError, match="Volume Mode requires"):
+            _validate_volume_mode_selection(
+                mock_coordinator,
+                "gs1",
+                {"shot_sizing_mode": "volume", "pump_flow_rate_ml_per_sec": 0.0},
+            )

--- a/tests/integration/test_irrigation_config_handler_coverage.py
+++ b/tests/integration/test_irrigation_config_handler_coverage.py
@@ -1,6 +1,6 @@
 """Tests for the Irrigation Config Handler."""
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -40,10 +40,30 @@ class MockIrrigationConfig:
 
 
 @dataclass
+class MockSubstrateProfile:
+    media_type: str = "coco"
+    liters_per_pot: float = 0.0
+
+
+@dataclass
+class MockIrrigationStrategy:
+    enabled: bool = False
+    shot_sizing_mode: str = "seconds"
+    substrate_profile: MockSubstrateProfile = field(
+        default_factory=MockSubstrateProfile
+    )
+    p1_shot_volume_percent: float = 4.0
+    p2_shot_volume_percent: float = 4.0
+
+
+@dataclass
 class MockGrowspace:
     id: str
     name: str
     irrigation_config: MockIrrigationConfig
+    irrigation_strategy: MockIrrigationStrategy = field(
+        default_factory=MockIrrigationStrategy
+    )
 
 
 @pytest.fixture
@@ -180,7 +200,7 @@ async def test_async_step_irrigation_overview_post(
     result = await handler.async_step_irrigation_overview(user_input)
     assert result["type"] == "create_entry"
     coordinator.services.growspaces.update_irrigation_config.assert_called_once_with(
-        "gs1", **user_input
+        "gs1", user_input
     )
 
 
@@ -262,5 +282,5 @@ async def test_async_step_irrigation_overview_post_new_fields(
     result = await handler.async_step_irrigation_overview(user_input)
     assert result["type"] == "create_entry"
     coordinator.services.growspaces.update_irrigation_config.assert_called_once_with(
-        "gs1", **user_input
+        "gs1", user_input
     )

--- a/tests/integration/test_irrigation_config_volume_mode_flow.py
+++ b/tests/integration/test_irrigation_config_volume_mode_flow.py
@@ -1,0 +1,181 @@
+"""Volume Mode + Substrate Profile in the irrigation config-flow form (issue #455).
+
+These tests drive the real ``GrowspaceFacade`` (not a mock) so the form's write
+path and its Volume Mode gating are exercised exactly as production would, which
+is the only way to prove the values truly round-trip onto the model.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import voluptuous as vol
+
+from custom_components.growspace_manager.config_handlers.irrigation_config_handler import (
+    IrrigationConfigHandler,
+)
+from custom_components.growspace_manager.const import ShotSizingMode, SubstrateMediaType
+from custom_components.growspace_manager.models import (
+    Growspace,
+    IrrigationConfig,
+    IrrigationStrategy,
+    SubstrateProfile,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+
+
+def _suggested_value(schema: vol.Schema, key: str):
+    """Return the suggested_value seeded for a form field, or a sentinel."""
+    for marker in schema.schema:
+        if getattr(marker, "schema", None) == key:
+            return (marker.description or {}).get("suggested_value", "<<missing>>")
+    return "<<absent>>"
+
+
+@pytest.fixture
+def handler(mock_coordinator: MagicMock) -> IrrigationConfigHandler:
+    """Handler wired to a real ServiceFacade over a configurable coordinator."""
+    coordinator = mock_coordinator
+    coordinator.cache = MagicMock()
+    coordinator.async_commit = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+    # The facade's get_growspace delegates to the data repository.
+    coordinator._data_repository.get_growspace.side_effect = (  # noqa: SLF001
+        lambda gid: coordinator.growspaces.get(gid)
+    )
+
+    config_entry = MagicMock()
+    config_entry.runtime_data = coordinator
+    config_entry.options = {}
+
+    handler = IrrigationConfigHandler(MagicMock(spec=HomeAssistant), config_entry)
+    handler.flow = MagicMock()
+    handler.flow.selected_growspace_id = "gs1"
+    handler.flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+    handler.flow.async_show_form = MagicMock(
+        side_effect=lambda **kwargs: {"type": "form", **kwargs}
+    )
+    return handler
+
+
+def _add_growspace(
+    coordinator: MagicMock,
+    *,
+    strategy: IrrigationStrategy | None = None,
+    config: IrrigationConfig | None = None,
+) -> Growspace:
+    gs = Growspace(
+        id="gs1",
+        name="GS1",
+        irrigation_config=config or IrrigationConfig(),
+        irrigation_strategy=strategy or IrrigationStrategy(),
+    )
+    coordinator.growspaces = {"gs1": gs}
+    return gs
+
+
+async def test_volume_mode_fields_render(handler: IrrigationConfigHandler) -> None:
+    """All new Volume Mode fields appear in the steering schema."""
+    options = {"use_vwc_steering": True}
+    schema = handler.get_irrigation_overview_schema(options, "gs1")
+    keys = {getattr(m, "schema", m) for m in schema.schema}
+    assert {
+        "shot_sizing_mode",
+        "substrate_media_type",
+        "substrate_liters_per_pot",
+        "pump_flow_rate_ml_per_sec",
+        "p1_shot_volume_percent",
+        "p2_shot_volume_percent",
+    } <= keys
+
+
+async def test_new_fields_seeded_from_stored_strategy(
+    handler: IrrigationConfigHandler,
+) -> None:
+    """The form seeds defaults from the stored strategy/config, not hardcoded ones."""
+    coordinator = handler.config_entry.runtime_data
+    _add_growspace(
+        coordinator,
+        strategy=IrrigationStrategy(
+            enabled=True,
+            shot_sizing_mode=ShotSizingMode.VOLUME,
+            substrate_profile=SubstrateProfile(
+                media_type=SubstrateMediaType.ROCKWOOL, liters_per_pot=6.0
+            ),
+            p1_shot_volume_percent=3.0,
+            p2_shot_volume_percent=5.0,
+        ),
+        config=IrrigationConfig(pump_flow_rate_ml_per_sec=12.5),
+    )
+
+    result = await handler.async_step_irrigation_overview()
+    schema: vol.Schema = result["data_schema"]
+
+    assert _suggested_value(schema, "shot_sizing_mode") == ShotSizingMode.VOLUME
+    assert _suggested_value(schema, "substrate_media_type") == (
+        SubstrateMediaType.ROCKWOOL
+    )
+    assert _suggested_value(schema, "substrate_liters_per_pot") == 6.0
+    assert _suggested_value(schema, "pump_flow_rate_ml_per_sec") == 12.5
+    assert _suggested_value(schema, "p1_shot_volume_percent") == 3.0
+    assert _suggested_value(schema, "p2_shot_volume_percent") == 5.0
+
+
+async def test_volume_mode_round_trips_through_real_facade(
+    handler: IrrigationConfigHandler,
+) -> None:
+    """Submitting Volume Mode + profile + flow rate in one form persists on the model."""
+    coordinator = handler.config_entry.runtime_data
+    gs = _add_growspace(coordinator)
+
+    user_input = {
+        "shot_sizing_mode": ShotSizingMode.VOLUME.value,
+        "substrate_media_type": SubstrateMediaType.ROCKWOOL.value,
+        "substrate_liters_per_pot": 6.0,
+        "pump_flow_rate_ml_per_sec": 15.0,
+        "p1_shot_volume_percent": 3.0,
+        "p2_shot_volume_percent": 5.0,
+    }
+
+    result = await handler.async_step_irrigation_overview(user_input)
+
+    assert result["type"] == "create_entry"
+    assert gs.irrigation_strategy.shot_sizing_mode == ShotSizingMode.VOLUME
+    assert gs.irrigation_strategy.substrate_profile == SubstrateProfile(
+        media_type=SubstrateMediaType.ROCKWOOL, liters_per_pot=6.0
+    )
+    assert gs.irrigation_strategy.p1_shot_volume_percent == 3.0
+    assert gs.irrigation_strategy.p2_shot_volume_percent == 5.0
+    assert gs.irrigation_config.pump_flow_rate_ml_per_sec == 15.0
+
+
+async def test_volume_mode_rejected_without_prerequisites_in_flow(
+    handler: IrrigationConfigHandler,
+) -> None:
+    """Selecting Volume Mode with no profile/flow rate raises the shared error."""
+    coordinator = handler.config_entry.runtime_data
+    gs = _add_growspace(coordinator)
+
+    with pytest.raises(ServiceValidationError, match="Volume Mode requires"):
+        await handler.async_step_irrigation_overview(
+            {"shot_sizing_mode": ShotSizingMode.VOLUME.value}
+        )
+
+    # The rejected submission leaves the strategy untouched.
+    assert gs.irrigation_strategy.shot_sizing_mode == ShotSizingMode.SECONDS
+
+
+async def test_seconds_mode_submission_unaffected(
+    handler: IrrigationConfigHandler,
+) -> None:
+    """Seconds Mode users can submit without a profile and see no new behavior."""
+    coordinator = handler.config_entry.runtime_data
+    gs = _add_growspace(coordinator)
+
+    result = await handler.async_step_irrigation_overview(
+        {"shot_sizing_mode": ShotSizingMode.SECONDS.value, "irrigation_duration": 45}
+    )
+
+    assert result["type"] == "create_entry"
+    assert gs.irrigation_strategy.shot_sizing_mode == ShotSizingMode.SECONDS
+    assert gs.irrigation_config.irrigation_duration == 45

--- a/tests/issue_fixes/test_issue_drain_pump.py
+++ b/tests/issue_fixes/test_issue_drain_pump.py
@@ -7,7 +7,10 @@ from tests.common import MockConfigEntry
 
 from custom_components.growspace_manager.config_flow import OptionsFlowHandler
 from custom_components.growspace_manager.const import DOMAIN
-from custom_components.growspace_manager.models import IrrigationConfig
+from custom_components.growspace_manager.models import (
+    IrrigationConfig,
+    IrrigationStrategy,
+)
 from homeassistant.core import HomeAssistant
 
 
@@ -46,6 +49,7 @@ async def test_irrigation_config_optional_drain_pump(
         irrigation_pump_entity="switch.irrigation",
         drain_pump_entity="switch.drain_pump",
     )
+    mock_growspace.irrigation_strategy = IrrigationStrategy()
     mock_coordinator.growspaces = {"gs1": mock_growspace}
 
     # Initialize Options Flow
@@ -76,7 +80,7 @@ async def test_irrigation_config_optional_drain_pump(
     
     assert len(call_args.args) >= 1, "Expected growspace_id as positional arg"
     growspace_id = call_args.args[0]
-    data = call_args.kwargs
+    data = call_args.args[1]
 
     assert growspace_id == "gs1"
     assert data.get("drain_pump_entity") is None, "drain_pump_entity should be None"
@@ -99,6 +103,7 @@ async def test_irrigation_config_omitted_drain_pump(
     mock_growspace.irrigation_config = IrrigationConfig(
         irrigation_pump_entity="switch.irrigation", drain_pump_entity=None
     )
+    mock_growspace.irrigation_strategy = IrrigationStrategy()
     mock_coordinator.growspaces = {"gs1": mock_growspace}
 
     # Initialize Options Flow
@@ -122,7 +127,7 @@ async def test_irrigation_config_omitted_drain_pump(
 
     mock_coordinator.services.growspaces.update_irrigation_config.assert_called_once()
     call_args = mock_coordinator.services.growspaces.update_irrigation_config.call_args
-    data = call_args.kwargs
+    data = call_args.args[1]
 
     # Coordinator logic:
     # if "drain_pump_entity" not in updated_settings: updated_settings["drain_pump_entity"] = None
@@ -169,6 +174,7 @@ async def test_irrigation_config_empty_string_drain_pump(
     mock_growspace.irrigation_config = IrrigationConfig(
         irrigation_pump_entity="switch.irrigation", drain_pump_entity="switch.old_drain"
     )
+    mock_growspace.irrigation_strategy = IrrigationStrategy()
     mock_coordinator.growspaces = {"gs1": mock_growspace}
 
     # Initialize Options Flow
@@ -191,7 +197,7 @@ async def test_irrigation_config_empty_string_drain_pump(
 
     mock_coordinator.services.growspaces.update_irrigation_config.assert_called_once()
     call_args = mock_coordinator.services.growspaces.update_irrigation_config.call_args
-    data = call_args.kwargs
+    data = call_args.args[1]
 
     # This assumes the coordinator normalization logic works on the input dictionary inplace
     # OR that the arguments passed to it are what we check.


### PR DESCRIPTION
Closes #455.

## What

Adds the Volume Mode / Substrate Profile (ADR-0011) fields to the irrigation options form, the one remaining gap after #446 — a user could only set up Volume Mode by calling the `set_irrigation_strategy` service directly.

New fields (in the steering sub-schema, alongside #443's per-phase and #447's EC-band fields):

- `shot_sizing_mode` — `seconds` (default) / `volume`
- `substrate_media_type` — `coco` / `rockwool` / `soil`
- `substrate_liters_per_pot`
- `pump_flow_rate_ml_per_sec` (an `IrrigationConfig` field, a Volume Mode prerequisite — previously not in the form at all)
- `p1_shot_volume_percent` / `p2_shot_volume_percent`

## How (shared logic, no duplication)

- On submit, the form reuses the service's own `_build_substrate_profile_update` (folds the flat substrate keys into the nested `substrate_profile`) and `_validate_volume_mode_selection`, then the shared `update_irrigation_config` / `_merge_substrate_profile` write path. One write path, one validation rule.
- `_validate_volume_mode_selection` now reads the pump flow rate **incoming-wins** (mirroring how it already treats `liters_per_pot`), so a single form submission can set the profile, the flow rate, and the mode together. The service path is unchanged: `SET_IRRIGATION_STRATEGY_SCHEMA` never carries `pump_flow_rate_ml_per_sec`, so it falls back to the stored value as before.
- Fields are optional (`suggested_value`), so untouched submissions round-trip stored values idempotently and Seconds Mode users see no behavioral change.

## Decision to flag for review

The new fields live in the **steering sub-schema**, which renders once VWC steering is enabled — exactly like the EC-band fields this issue asked me to mirror. So on a fresh/Seconds-mode growspace they don't appear until steering is enabled. This matches the EC-band precedent but is worth a conscious sign-off; happy to make them always-visible (or visible whenever `shot_sizing_mode == volume`) if preferred.

## Incidental fixes (were masked by mocked-facade tests)

- The handler called `update_irrigation_config(gid, **user_input)` but the facade takes a dict positionally — real submissions would `TypeError`. Now passes the dict.
- The form seeded defaults only from `irrigation_config`; strategy fields (incl. the existing #443/#447 fields) never reflected stored values. Now merges `irrigation_strategy` + `irrigation_config`.

## Tests

New `tests/integration/test_irrigation_config_volume_mode_flow.py` drives the **real** `GrowspaceFacade` (not a mock) to prove: fields render, defaults seed from stored state, values persist (incl. nested `substrate_profile`), and Volume-Mode-without-prerequisites is rejected in the flow. Plus a shared-validator regression test and updated existing mocks/assertions. Full suite: 4364 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)