### PR TITLE
feat(irrigation): surface measured steering readout in growspace payload

### DIFF
--- a/custom_components/growspace_manager/view_model_builder.py
+++ b/custom_components/growspace_manager/view_model_builder.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.util import dt as dt_util
 
+from .crop_steering import get_crop_steering_state
 from .domain.stage import StageDays
 from .models import Plant
 from .presentation import GrowspaceViewModelBuilder
@@ -188,6 +189,35 @@ class ViewModelBuilder:
         serialized["irrigation"]["projected_shot_window"] = projected_shot_window
         serialized["irrigation"]["cycles_today"] = cycles_today
         serialized["irrigation"]["volume_dispensed_today"] = volume_dispensed_today
+
+        # Surface the measured steering readout alongside the tracker-derived
+        # substrate metrics. The score, its Measured Classification, and the
+        # Intent Deviation live on the CropSteeringState (computed with the
+        # coordinator's live VWC) — not reachable from the presentation builder,
+        # which only has hass — so they are injected here next to the telemetry.
+        # None throughout when the strategy is disabled / no reading yet, so the
+        # card can lock the score panel rather than show a synthetic value.
+        steering_state = get_crop_steering_state(self.coordinator, growspace_id)
+        substrate = serialized["irrigation"]["substrate"]
+        substrate["score"] = (
+            round(steering_state.score, 2) if steering_state is not None else None
+        )
+        substrate["measured_classification"] = (
+            steering_state.measured_classification
+            if steering_state is not None
+            else None
+        )
+        substrate["intent_deviation"] = (
+            steering_state.intent_deviation if steering_state is not None else None
+        )
+
+        # Shot Size Composition is runtime state on the VWC coordinator (base ×
+        # VWC factor × EC modulation), absent on time-based irrigation.
+        substrate["shot_composition"] = (
+            irr_coord.shot_composition_payload()
+            if irr_coord is not None and hasattr(irr_coord, "shot_composition_payload")
+            else None
+        )
 
         # Top-level timestamp for efficient frontend equality checks (change detection)
         serialized["_ts"] = int(current_time * 1000)

--- a/tests/integration/test_growspace_view_model_coverage.py
+++ b/tests/integration/test_growspace_view_model_coverage.py
@@ -736,3 +736,96 @@ def test_view_model_builder_serializes_subareas_for_websocket_payload(
 
     assert [s["id"] for s in result["subareas"]] == ["sa1", "sa2"]
     assert all("environment_config" in s for s in result["subareas"])
+
+
+def test_substrate_payload_surfaces_measured_steering_readout(
+    hass: HomeAssistant,
+) -> None:
+    """The substrate block carries the measured steering readout.
+
+    Score, Measured Classification, and Intent Deviation come from the computed
+    CropSteeringState.
+    """
+    from custom_components.growspace_manager.models.irrigation import CropSteeringState
+
+    gs = Growspace(id="gs1", name="GS1")
+    coordinator = _make_mock_coordinator(hass, gs, {})
+
+    state = CropSteeringState(
+        score=0.6,
+        measured_classification="generative",
+        intent_deviation="more_generative",
+    )
+    with patch(
+        "custom_components.growspace_manager.view_model_builder.get_crop_steering_state",
+        return_value=state,
+    ):
+        result = ViewModelBuilder(coordinator).build_serialized_growspace("gs1")
+
+    substrate = result["irrigation"]["substrate"]
+    assert substrate["score"] == pytest.approx(0.6)
+    assert substrate["measured_classification"] == "generative"
+    assert substrate["intent_deviation"] == "more_generative"
+
+
+def test_substrate_payload_steering_readout_null_when_no_state(
+    hass: HomeAssistant,
+) -> None:
+    """Measured readout fields are present but null when no state is available.
+
+    This is the strategy-disabled / no-reading-yet case.
+    """
+    gs = Growspace(id="gs1", name="GS1")
+    coordinator = _make_mock_coordinator(hass, gs, {})
+
+    with patch(
+        "custom_components.growspace_manager.view_model_builder.get_crop_steering_state",
+        return_value=None,
+    ):
+        result = ViewModelBuilder(coordinator).build_serialized_growspace("gs1")
+
+    substrate = result["irrigation"]["substrate"]
+    assert substrate["score"] is None
+    assert substrate["measured_classification"] is None
+    assert substrate["intent_deviation"] is None
+
+
+def test_substrate_payload_includes_shot_composition(hass: HomeAssistant) -> None:
+    """The substrate block carries the irrigation coordinator's shot composition."""
+    gs = Growspace(id="gs1", name="GS1")
+    coordinator = _make_mock_coordinator(hass, gs, {})
+
+    irr_coord = MagicMock()
+    irr_coord.active_events = {}
+    irr_coord.last_cycle_timestamp = None
+    irr_coord.next_scheduled_cycle = None
+    irr_coord.projected_shot_window = None
+    irr_coord.cycles_today = 0
+    irr_coord.volume_dispensed_today = 0.0
+    composition = {"ec_modulation_enabled": True, "last_shot": None}
+    irr_coord.shot_composition_payload.return_value = composition
+    coordinator.services.growspaces.get_irrigation_coordinator.return_value = irr_coord
+
+    with patch(
+        "custom_components.growspace_manager.view_model_builder.get_crop_steering_state",
+        return_value=None,
+    ):
+        result = ViewModelBuilder(coordinator).build_serialized_growspace("gs1")
+
+    assert result["irrigation"]["substrate"]["shot_composition"] == composition
+
+
+def test_substrate_payload_shot_composition_null_without_irrigation_coordinator(
+    hass: HomeAssistant,
+) -> None:
+    """Time-based irrigation (no VWC coordinator) leaves shot_composition null."""
+    gs = Growspace(id="gs1", name="GS1")
+    coordinator = _make_mock_coordinator(hass, gs, {})
+
+    with patch(
+        "custom_components.growspace_manager.view_model_builder.get_crop_steering_state",
+        return_value=None,
+    ):
+        result = ViewModelBuilder(coordinator).build_serialized_growspace("gs1")
+
+    assert result["irrigation"]["substrate"]["shot_composition"] is None


### PR DESCRIPTION
## What

Surfaces the measured crop-steering readout in the growspace WebSocket payload's `irrigation.substrate` block so the frontend can render it via slice atoms instead of reading the `crop_steering` sensor entity directly.

`ViewModelBuilder.build_serialized_growspace` now injects, alongside the existing tracker-derived dryback / EC fields:

- `score` — the measured −1…+1 steering score (rounded to 2dp)
- `measured_classification` — the score-derived bucket (vegetative / balanced / generative)
- `intent_deviation` — the measured classification vs the declared mode (`on_target` / `more_generative` / `more_vegetative`, or `null`)
- `shot_composition` — the VWC coordinator's shot composition (base × VWC × EC factors)

These come from the computed `CropSteeringState` (which uses the coordinator's live VWC) and the VWC coordinator — neither is reachable from the presentation builder, so they are injected next to the existing irrigation telemetry. All fields are `null` when the strategy is disabled or no reading exists yet, so the card can lock the panel rather than show a synthetic value.

## Why

The Command Center **Overview tab** (Venosta-web/lovelace-growspace-manager-card#279) must render measured steering diagnostics from the payload only — no `hass.states` reads in the component. The drybacks / EC trend were already in the payload; the score, classification, deviation, and shot composition lived only on the sensor entity. This closes that gap.

## Tests

4 new unit tests in `test_growspace_view_model_coverage.py` (readout present, null when no state, shot composition present, null without coordinator). View-model + substrate-tracker suites pass.

## Pairs with

- Frontend consumer: Venosta-web/lovelace-growspace-manager-card#279 (Command Center Overview tab) — ships together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)