### PR TITLE
fix: lifecycle dates are datetime through one write seam

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,6 +14,9 @@ An individual cannabis plant tracked from seedling through cure. The atomic unit
 **PlantStage**
 The lifecycle phase of a Plant. Ordered stages: `seedling → clone → mother → veg → flower → dry → cure`. The `dry` and `cure` stages are fully-fledged lifecycle stages, not post-harvest metadata.
 
+**Lifecycle Timestamp**
+The recorded moment a Plant entered a stage: the `seedling_start`, `mother_start`, `clone_start`, `veg_start`, `flower_start`, `dry_start`, `cure_start` fields on `Plant`. Represented end-to-end as a timezone-aware **ISO 8601 datetime string** (date *and* time), never date-only — see [[ADR-0013]]. The model fields are typed `str | None` and store the ISO string; readers normalise via `parse_date_field` (which promotes any legacy date-only value to midnight-local on read). All write sites — create, stage transitions, cloning, WebSocket update — route through the `to_lifecycle_timestamp()` writer in `domain/date_logic.py`, the single owner of the representation: it preserves a supplied time or defaults to `dt_util.now()` and always returns an ISO string. Distinct from `WeightEntry`/`MoistureEntry` `date` fields (drying observations), which remain date-only.
+
 **Photoperiod Flip**
 The calendar day on which a Plant transitions from vegetative to flower stage — specifically, the day `flower_start == today`. The grower must change the light schedule to 12 hours on this day. When `IrrigationStrategy.auto_light_tracking` is enabled on the growspace, the integration will auto-adapt the light schedule from sensor data; otherwise the grower must update it manually. A notification is sent once per day per growspace when any plant's Photoperiod Flip day arrives.
 

--- a/custom_components/growspace_manager/config_handlers/plant_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/plant_config_handler.py
@@ -40,7 +40,9 @@ class PlantConfigHandler(BaseConfigHandler[dict[str, Any]]):
                 return await self.async_step_update_plant()
             if action == "remove" and user_input.get("plant_id"):
                 try:
-                    plant = coordinator.services.plants.get_plant(user_input["plant_id"])
+                    plant = coordinator.services.plants.get_plant(
+                        user_input["plant_id"]
+                    )
                     if plant:
                         await self.async_destroy_plant(plant.plant_id)
                 except Exception:
@@ -71,7 +73,9 @@ class PlantConfigHandler(BaseConfigHandler[dict[str, Any]]):
             self.flow.selected_growspace_id = user_input["growspace_id"]
             return await self.async_step_add_plant()
 
-        growspace_options = coordinator.services.growspaces.get_sorted_growspace_options()
+        growspace_options = (
+            coordinator.services.growspaces.get_sorted_growspace_options()
+        )
         if not growspace_options:
             return self.flow.async_abort(reason="no_growspaces")
 
@@ -218,7 +222,9 @@ class PlantConfigHandler(BaseConfigHandler[dict[str, Any]]):
                     break
 
             if growspace_id:
-                growspace_obj = coordinator.services.growspaces.get_growspace(growspace_id)
+                growspace_obj = coordinator.services.growspaces.get_growspace(
+                    growspace_id
+                )
                 rows = getattr(growspace_obj, "rows", "?")
                 plants_per_row = getattr(growspace_obj, "plants_per_row", "?")
 
@@ -289,8 +295,8 @@ class PlantConfigHandler(BaseConfigHandler[dict[str, Any]]):
                         min=1, max=max_col, mode=selector.NumberSelectorMode.BOX
                     )
                 ),
-                vol.Optional("veg_start"): selector.DateSelector(),
-                vol.Optional("flower_start"): selector.DateSelector(),
+                vol.Optional("veg_start"): selector.DateTimeSelector(),
+                vol.Optional("flower_start"): selector.DateTimeSelector(),
             }
         )
 
@@ -299,7 +305,9 @@ class PlantConfigHandler(BaseConfigHandler[dict[str, Any]]):
     ) -> vol.Schema:
         """Build the schema for the update plant form."""
         growspace = (
-            coordinator.services.growspaces.get_growspace(plant.growspace_id) if plant else None
+            coordinator.services.growspaces.get_growspace(plant.growspace_id)
+            if plant
+            else None
         )
 
         # Ensure rows and plants_per_row are integers
@@ -353,8 +361,8 @@ class PlantConfigHandler(BaseConfigHandler[dict[str, Any]]):
                         min=1, max=max_col, mode=selector.NumberSelectorMode.BOX
                     )
                 ),
-                vol.Optional("veg_start"): selector.DateSelector(),
-                vol.Optional("flower_start"): selector.DateSelector(),
+                vol.Optional("veg_start"): selector.DateTimeSelector(),
+                vol.Optional("flower_start"): selector.DateTimeSelector(),
             }
         )
 
@@ -365,7 +373,9 @@ class PlantConfigHandler(BaseConfigHandler[dict[str, Any]]):
         coordinator = self.config_entry.runtime_data
         if coordinator is None:
             raise ValueError("Coordinator not found")
-        await coordinator.services.plants.transition_plant(plant_id, wet_weight=harvest_weight)
+        await coordinator.services.plants.transition_plant(
+            plant_id, wet_weight=harvest_weight
+        )
 
     async def async_destroy_plant(self, plant_id: str) -> None:
         """Destroy a plant."""

--- a/custom_components/growspace_manager/domain/date_logic.py
+++ b/custom_components/growspace_manager/domain/date_logic.py
@@ -35,7 +35,7 @@ def parse_date_field(date_value: DateInput) -> datetime | None:
                 try:
                     # Fallback to slower, more robust parser
                     dt = parser.isoparse(date_value)
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     return None
 
     if dt is None:
@@ -44,6 +44,22 @@ def parse_date_field(date_value: DateInput) -> datetime | None:
     if dt.tzinfo is None:
         return as_local(dt)
     return dt
+
+
+def to_lifecycle_timestamp(supplied: DateInput = None) -> str:
+    """Return the ISO datetime string to store for a Lifecycle Timestamp.
+
+    The single owner of how a plant stage-start (`seedling_start … cure_start`)
+    is represented on write (see CONTEXT.md "Lifecycle Timestamp", ADR-0013).
+    A supplied value preserves its moment; ``None`` defaults to the current
+    time. Always returns a full timezone-aware ISO 8601 datetime string — never
+    a date-only value — so no write site truncates with ``.date()``. A bare
+    `date` (or a date-only string) is promoted to midnight-local.
+    """
+    parsed = parse_date_field(supplied) if supplied is not None else now()
+    if parsed is None:
+        parsed = now()
+    return parsed.isoformat()
 
 
 def calculate_days_since(start_date: DateInput, end_date: DateInput = None) -> int:

--- a/custom_components/growspace_manager/managers/plant.py
+++ b/custom_components/growspace_manager/managers/plant.py
@@ -33,6 +33,7 @@ from custom_components.growspace_manager.exceptions import (
     PlantNotFoundError,
     ValidationChangeError,
 )
+from custom_components.growspace_manager.integration_types import DateInput
 from custom_components.growspace_manager.models import (
     GrowspaceEvent,
     Plant,
@@ -42,7 +43,10 @@ from custom_components.growspace_manager.services.context import (
     BaseService,
     ServiceContext,
 )
-from custom_components.growspace_manager.utils import calculate_plant_stage, format_date
+from custom_components.growspace_manager.utils import (
+    calculate_plant_stage,
+    to_lifecycle_timestamp,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
@@ -143,7 +147,13 @@ class PlantManager(BaseService):
             date_fields = {}
             for field in DATE_FIELDS:
                 if field in kwargs:
-                    date_fields[field] = format_date(kwargs[field])
+                    # Lifecycle Timestamp: store full datetime, never date-only
+                    # (ADR-0013). None stays None (field absent/cleared) — only a
+                    # real value is promoted to a datetime string.
+                    value = kwargs[field]
+                    date_fields[field] = (
+                        to_lifecycle_timestamp(value) if value is not None else None
+                    )
 
             final_plant_id = plant_id or str(uuid.uuid4())
 
@@ -200,7 +210,10 @@ class PlantManager(BaseService):
 
             for key in DATE_FIELDS:
                 if key in updates:
-                    updates[key] = format_date(updates[key])
+                    # Lifecycle Timestamp: store full datetime, never date-only
+                    # (ADR-0013). None means "clear the field", so it is left as-is.
+                    if updates[key] is not None:
+                        updates[key] = to_lifecycle_timestamp(updates[key])
 
             # Handle genetics updates
             if "strain" in updates:
@@ -330,7 +343,7 @@ class PlantManager(BaseService):
         # I used 'plant_type' in add_plant signature above.
 
         if mother_start is None:
-            mother_start = dt_util.now().date()
+            mother_start = dt_util.now()
 
         # Override plant_type via kwargs?
         # The add_plant signature has plant_type="normal".
@@ -372,7 +385,7 @@ class PlantManager(BaseService):
 
         new_plants: list[Plant] = []
         if transition_date is None:
-            transition_date = dt_util.now().date()
+            transition_date = dt_util.now()
 
         for _ in range(num_clones):
             # This logic was in Service calling Lifecycle.handle_clone_creation.
@@ -422,7 +435,7 @@ class PlantManager(BaseService):
         self,
         plant_id: str,
         new_stage: str | PlantStage,
-        transition_date: date | None = None,
+        transition_date: DateInput = None,
     ) -> None:
         """Execute a plant stage transition."""
         if isinstance(new_stage, PlantStage):
@@ -431,12 +444,8 @@ class PlantManager(BaseService):
         if new_stage not in PLANT_STAGES:
             raise ValidationChangeError(f"Invalid stage: {new_stage}")
 
-        transition_date_obj = transition_date or dt_util.now().date()
-        trans_date_str = (
-            transition_date_obj.isoformat()
-            if hasattr(transition_date_obj, "isoformat")
-            else str(transition_date_obj)
-        )
+        # Lifecycle Timestamp: preserve a supplied time, default to now (ADR-0013).
+        trans_date_str = to_lifecycle_timestamp(transition_date)
 
         updates: dict[str, Any] = {"stage": new_stage}
         stage_map = {
@@ -491,7 +500,9 @@ class PlantManager(BaseService):
                 duration_sec=0,
                 severity=1.0,
                 category=CATEGORY_MILESTONE,
-                reasons=[f"{(plant.genetics.strain_name if plant.genetics else None) or plant_id} entered {stage_label}"],
+                reasons=[
+                    f"{(plant.genetics.strain_name if plant.genetics else None) or plant_id} entered {stage_label}"
+                ],
             )
             self._emit(plant.growspace_id, event)
 
@@ -547,7 +558,7 @@ class PlantManager(BaseService):
         else:
             stage_before = calculate_plant_stage(plant)
 
-        transition_date_str = transition_date or dt_util.now().date().isoformat()
+        transition_date_str = to_lifecycle_timestamp(transition_date)
 
         # Store yield/lab metrics on the plant before analytics recording
         if hasattr(plant, "harvest_metrics"):
@@ -748,24 +759,19 @@ class PlantManager(BaseService):
         )
 
     async def start_flowering(self, plant_id: str) -> Plant:
-        """Transition a plant to the 'flower' stage, starting today."""
-        await self.transition_plant_stage(
-            plant_id, PlantStage.FLOWER, dt_util.now().date()
-        )
+        """Transition a plant to the 'flower' stage, starting now."""
+        # No explicit date: the transition seam defaults to now() with its time.
+        await self.transition_plant_stage(plant_id, PlantStage.FLOWER)
         return self.repository.require_plant(plant_id)
 
     async def start_drying(self, plant_id: str) -> Plant:
-        """Transition a plant to the 'drying' stage, starting today."""
-        await self.transition_plant_stage(
-            plant_id, PlantStage.DRY, dt_util.now().date()
-        )
+        """Transition a plant to the 'drying' stage, starting now."""
+        await self.transition_plant_stage(plant_id, PlantStage.DRY)
         return self.repository.require_plant(plant_id)
 
     async def start_curing(self, plant_id: str) -> Plant:
-        """Transition a plant to the 'curing' stage, starting today."""
-        await self.transition_plant_stage(
-            plant_id, PlantStage.CURE, dt_util.now().date()
-        )
+        """Transition a plant to the 'curing' stage, starting now."""
+        await self.transition_plant_stage(plant_id, PlantStage.CURE)
         return self.repository.require_plant(plant_id)
 
     async def harvest(self, plant_id: str) -> Plant:
@@ -816,7 +822,7 @@ class PlantManager(BaseService):
             row=row,
             col=col,
             stage=PlantStage.VEG,
-            veg_start=transition_date or dt_util.now().date(),
+            veg_start=transition_date or dt_util.now(),
         )
 
     async def _record_analytics(self, plant: Plant) -> None:
@@ -843,7 +849,7 @@ class PlantManager(BaseService):
                     cbd_percentage=metrics.cbd_percentage if metrics else None,
                     terpene_profile=metrics.terpene_profile if metrics else None,
                 )
-            except Exception as e :  # noqa: BLE001
+            except Exception as e:  # noqa: BLE001
                 _LOGGER.warning(
                     "Failed to record harvest analytics for %s: %s",
                     plant.plant_id,

--- a/custom_components/growspace_manager/services/plant_cloning.py
+++ b/custom_components/growspace_manager/services/plant_cloning.py
@@ -43,8 +43,8 @@ async def handle_take_clone(
     """Handle taking clones from a plant."""
     mother_plant_id = call.data[ATTR_MOTHER_PLANT_ID]
     transition_date_raw = call.data.get(ATTR_TRANSITION_DATE)
-    transition_datetime = parse_date_field(transition_date_raw) or dt_util.utcnow()
-    transition_date = transition_datetime.date()
+    # Keep the full datetime (no .date() truncation) — ADR-0013.
+    transition_date = parse_date_field(transition_date_raw) or dt_util.utcnow()
 
     target_growspace_id = call.data.get(ATTR_TARGET_GROWSPACE_ID)
 
@@ -100,8 +100,8 @@ async def handle_move_clone(
     target_growspace_id = call.data.get(ATTR_TARGET_GROWSPACE_ID)
 
     transition_date_str = call.data.get(ATTR_TRANSITION_DATE)
-    transition_datetime = parse_date_field(transition_date_str) or dt_util.utcnow()
-    transition_date = transition_datetime.date()
+    # Keep the full datetime (no .date() truncation) — ADR-0013.
+    transition_date = parse_date_field(transition_date_str) or dt_util.utcnow()
 
     if not plant_id or not target_growspace_id:
         _LOGGER.error(

--- a/custom_components/growspace_manager/utils.py
+++ b/custom_components/growspace_manager/utils.py
@@ -15,6 +15,7 @@ from .domain.date_logic import (
     calculate_days_since as calculate_days_since_logic,
     format_date as format_date_logic,
     parse_date_field,
+    to_lifecycle_timestamp as to_lifecycle_timestamp_logic,
 )
 from .domain.stage import (
     SPECIAL_GROWSPACE_STAGES,
@@ -48,6 +49,11 @@ def calculate_days_since(
 def format_date(date_value: DateInput) -> str | None:
     """Format a date for display."""
     return format_date_logic(date_value)
+
+
+def to_lifecycle_timestamp(supplied: DateInput = None) -> str:
+    """Return the ISO datetime string to store for a Lifecycle Timestamp."""
+    return to_lifecycle_timestamp_logic(supplied)
 
 
 def days_to_week(days: int) -> int:
@@ -224,7 +230,6 @@ def _get_stage_from_growspace(plant: Plant) -> str | None:
     return None
 
 
-
 def interpolate_value(val_a: float, val_b: float, factor: float) -> float:
     """Linearly interpolate between two values based on a factor."""
     if factor <= 0:
@@ -248,7 +253,7 @@ def read_sensor_value(hass: HomeAssistant, sensor_id: str | None) -> float | Non
         return None
     try:
         return float(state.state)
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return None
 
 
@@ -309,9 +314,7 @@ def read_environment_vpd(
 
     sensor_ids = list(
         dict.fromkeys(
-            s
-            for s in [env_config.vpd_sensor, *env_config.vpd_sensors]
-            if s is not None
+            s for s in [env_config.vpd_sensor, *env_config.vpd_sensors] if s is not None
         )
     )
     vpd = read_aggregated_sensor_value(hass, sensor_ids)
@@ -323,7 +326,10 @@ def read_environment_vpd(
         list(
             dict.fromkeys(
                 s
-                for s in [env_config.temperature_sensor, *env_config.temperature_sensors]
+                for s in [
+                    env_config.temperature_sensor,
+                    *env_config.temperature_sensors,
+                ]
                 if s is not None
             )
         ),

--- a/custom_components/growspace_manager/websocket/plant.py
+++ b/custom_components/growspace_manager/websocket/plant.py
@@ -217,7 +217,9 @@ SCHEMA_WS_LOG_MOISTURE_READING = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.exten
     {
         vol.Required("type"): WS_TYPE_LOG_MOISTURE_READING,
         vol.Required(ATTR_PLANT_ID): str,
-        vol.Required("moisture_percent"): vol.All(vol.Any(float, int), vol.Range(min=0, max=100)),
+        vol.Required("moisture_percent"): vol.All(
+            vol.Any(float, int), vol.Range(min=0, max=100)
+        ),
         vol.Optional("date"): _OPT_DATE,
     }
 )
@@ -342,7 +344,9 @@ async def websocket_add_plants(
     if growspace_id not in coordinator.growspaces:
         raise ServiceValidationError(f"Growspace '{growspace_id}' not found")
 
-    free_row, free_col = coordinator.validator.find_first_available_position(growspace_id)
+    free_row, free_col = coordinator.validator.find_first_available_position(
+        growspace_id
+    )
     if free_row is None or free_col is None:
         raise ServiceValidationError(f"Growspace '{growspace_id}' is full")
 
@@ -371,7 +375,9 @@ async def websocket_add_plants(
         row, col = coordinator.validator.find_first_available_position(growspace_id)
         if row is None or col is None:
             _LOGGER.warning(
-                "Growspace %s full after %d plants; stopping batch", growspace_id, plants_added
+                "Growspace %s full after %d plants; stopping batch",
+                growspace_id,
+                plants_added,
             )
             break
         try:
@@ -457,9 +463,11 @@ async def websocket_harvest_plant(
     if transition_date_str:
         parsed = parse_date_field(transition_date_str)
         if parsed:
-            transition_date = parsed.date().isoformat()
+            transition_date = parsed.isoformat()
         else:
-            raise ServiceValidationError(f"Invalid transition_date: {transition_date_str}")
+            raise ServiceValidationError(
+                f"Invalid transition_date: {transition_date_str}"
+            )
 
     await coordinator.services.plants.transition_plant(
         plant_id=plant_id,
@@ -495,7 +503,7 @@ async def websocket_move_plant(
     if transition_date_str:
         parsed = parse_date_field(transition_date_str)
         if parsed:
-            transition_date = parsed.date().isoformat()
+            transition_date = parsed.isoformat()
 
     await coordinator.services.plants.transition_plant(
         plant_id=plant_id,
@@ -518,10 +526,12 @@ async def websocket_move_clone(
     target_growspace_id: str = msg[ATTR_TARGET_GROWSPACE_ID]
 
     transition_date_str: str | None = msg.get(ATTR_TRANSITION_DATE)
+    # Keep the full datetime (no .date() truncation): the manager's Lifecycle
+    # Timestamp seam stores it with its time preserved (ADR-0013).
     transition_date = (
-        (parse_date_field(transition_date_str) or dt_util.utcnow()).date()
+        (parse_date_field(transition_date_str) or dt_util.utcnow())
         if transition_date_str
-        else dt_util.utcnow().date()
+        else dt_util.utcnow()
     )
 
     await coordinator.services.plants.promote_clone(
@@ -566,10 +576,12 @@ async def websocket_take_clone(
         raise ServiceValidationError(f"Mother plant '{mother_plant_id}' not found")
 
     transition_date_str: str | None = msg.get(ATTR_TRANSITION_DATE)
+    # Keep the full datetime (no .date() truncation): the manager's Lifecycle
+    # Timestamp seam stores it with its time preserved (ADR-0013).
     transition_date = (
-        (parse_date_field(transition_date_str) or dt_util.utcnow()).date()
+        (parse_date_field(transition_date_str) or dt_util.utcnow())
         if transition_date_str
-        else dt_util.utcnow().date()
+        else dt_util.utcnow()
     )
 
     await coordinator.services.plants.take_clones(
@@ -704,9 +716,24 @@ COMMANDS: list[tuple[str, Any, Any, bool]] = [
     (WS_TYPE_SWITCH_PLANTS, websocket_switch_plants, SCHEMA_WS_SWITCH_PLANTS, False),
     (WS_TYPE_TAKE_CLONE, websocket_take_clone, SCHEMA_WS_TAKE_CLONE, False),
     (WS_TYPE_SCORE_PLANT, websocket_score_plant, SCHEMA_WS_SCORE_PLANT, False),
-    (WS_TYPE_LOG_DRYING_WEIGHT, websocket_log_drying_weight, SCHEMA_WS_LOG_DRYING_WEIGHT, False),
-    (WS_TYPE_LOG_MOISTURE_READING, websocket_log_moisture_reading, SCHEMA_WS_LOG_MOISTURE_READING, False),
+    (
+        WS_TYPE_LOG_DRYING_WEIGHT,
+        websocket_log_drying_weight,
+        SCHEMA_WS_LOG_DRYING_WEIGHT,
+        False,
+    ),
+    (
+        WS_TYPE_LOG_MOISTURE_READING,
+        websocket_log_moisture_reading,
+        SCHEMA_WS_LOG_MOISTURE_READING,
+        False,
+    ),
     (WS_TYPE_SET_VISUAL_TAG, websocket_set_visual_tag, SCHEMA_WS_SET_VISUAL_TAG, False),
-    (WS_TYPE_UPDATE_HARVEST_METRICS, websocket_update_harvest_metrics, SCHEMA_WS_UPDATE_HARVEST_METRICS, False),
+    (
+        WS_TYPE_UPDATE_HARVEST_METRICS,
+        websocket_update_harvest_metrics,
+        SCHEMA_WS_UPDATE_HARVEST_METRICS,
+        False,
+    ),
     (WS_TYPE_PRINT_LABEL, websocket_print_label, SCHEMA_WS_PRINT_LABEL, False),
 ]

--- a/docs/adr/0013-lifecycle-dates-are-datetime-through-one-write-seam.md
+++ b/docs/adr/0013-lifecycle-dates-are-datetime-through-one-write-seam.md
@@ -1,0 +1,24 @@
+# Lifecycle dates are datetime, written through one seam
+
+A [[Lifecycle Timestamp]] (`seedling_start … cure_start` on `Plant`) is a timezone-aware **ISO 8601 datetime string** — date *and* time — at every layer: config-flow create, stage transitions, cloning, WebSocket update, and storage. Date-only (`YYYY-MM-DD`) is no longer a representation the system *produces*.
+
+The decision the system makes about that representation lives in exactly one place: `to_lifecycle_timestamp(supplied)` in `domain/date_logic.py`. Given a supplied value (str / `date` / `datetime`) it preserves the moment; given `None` it defaults to `dt_util.now()`. It always returns an ISO datetime **string**. Every write site calls it instead of formatting inline.
+
+## Why
+
+The representation decision was duplicated across ~9 sites in two repos, each choosing independently — and they disagreed. The card rendered a `datetime-local` picker, validated that a time was present, then **truncated the time away** in `formatDateForBackend` before sending. The backend stored date-only from `DateSelector` create and `.date().isoformat()` transitions, but full datetime from the `mother_start` auto-set and from the WebSocket update path (`parse_date_field` → `setattr`). The result was a plant whose `*_start` fields mixed date-only and datetime depending on which code path last touched them, and a false "Set both date and time for lifecycle dates before saving" toast when the edit dialog re-validated untouched date-only fields against a stricter contract than create/transitions produced.
+
+The `transition_date: date | None` parameter type made truncation structural, not incidental — the `date` type cannot carry a time, so every signature using it discarded one. Widening these to `DateInput` (str / `date` / `datetime`) and routing through the seam is what makes "datetime throughout" expressible.
+
+## Decisions
+
+- **Write seam.** All lifecycle-date writes go through `to_lifecycle_timestamp()`. Deleting it would re-scatter the `.date().isoformat()` choice across create / transition / clone / facade / WebSocket sites — which is exactly the bug surface it replaces.
+- **Create flow captures time.** The config-flow `DateSelector()` for `veg_start` / `flower_start` becomes `DateTimeSelector()`, so datetime is captured at the first entry point rather than promoted later.
+- **Model fields stay `str | None`.** The seam returns an ISO string and the update path stores the string (not a `datetime` object), closing the prior type-truth gap where fields annotated `str` held a `datetime` after an update. Storage stays JSON-clean.
+- **No migration for existing data.** `parse_date_field` already promotes a legacy date-only value to midnight-local on read, and every consumer (day counts, calendar, sensors) reads through it. Old plants keep their date-only `*_start` string until next edited; new writes are full datetime. This is graceful read-time promotion — no migration pass, no downtime.
+
+## Consequences
+
+- `WeightEntry` / `MoistureEntry` `date` fields (drying observations) are deliberately **out of scope** — they remain date-only.
+- A plant's stored `*_start` values may be mixed-representation during the transition period (old date-only, new datetime). This is intentional and safe because reads normalise; assertions in tests must not assume a uniform format for pre-existing fixtures.
+- Paired with the card-side seam (`lovelace-growspace-manager-card` ADR-0018), which stops truncating and removes the now-impossible "set both date and time" validation.

--- a/tests/core/test_coordinator.py
+++ b/tests/core/test_coordinator.py
@@ -151,7 +151,9 @@ async def test_async_create_mum(coordinator: GrowspaceCoordinator) -> None:
             "Pheno1", "StrainC", 1, 1, start_time_date
         )
 
-    assert mother.mother_start == start_time_iso
+    # Lifecycle Timestamp (ADR-0013): a supplied date is stored as a midnight
+    # datetime; the date portion matches the supplied value.
+    assert mother.mother_start.startswith(start_time_iso)
     assert mother.plant_id in coordinator.plants
     assert mother.type == "mother"
     assert mother.strain == "StrainC"
@@ -190,7 +192,7 @@ async def test_async_take_clones(coordinator: GrowspaceCoordinator) -> None:
         assert clone.stage == "clone"
         assert clone.source_mother == mother.plant_id
         assert clone.strain == mother.strain
-        assert clone.clone_start == clone_time_iso
+        assert clone.clone_start.startswith(clone_time_iso)
 
 
 @pytest.mark.asyncio
@@ -987,7 +989,7 @@ async def test_async_transition_clone_to_veg(coordinator: GrowspaceCoordinator) 
     clone = coordinator.plants[clone_id]
     assert clone.stage == PlantStage.VEG
     assert clone.growspace_id == "veg"
-    assert clone.veg_start == "2025-11-03"
+    assert clone.veg_start.startswith("2025-11-03")
 
     coordinator.async_commit.assert_awaited()
 
@@ -1050,7 +1052,7 @@ async def test_async_start_flowering(coordinator: GrowspaceCoordinator) -> None:
     updated_plant = coordinator.plants.get(plant.plant_id)
     assert updated_plant is not None
     assert updated_plant.stage == PlantStage.FLOWER
-    assert updated_plant.flower_start == date.today().isoformat()
+    assert updated_plant.flower_start.startswith(date.today().isoformat())
     assert updated_plant.updated_at == date.today().isoformat()
 
 
@@ -1067,7 +1069,7 @@ async def test_async_start_drying(coordinator: GrowspaceCoordinator) -> None:
     updated_plant = coordinator.plants.get(plant.plant_id)
     assert updated_plant is not None
     assert updated_plant.stage == PlantStage.DRY
-    assert updated_plant.dry_start == date.today().isoformat()
+    assert updated_plant.dry_start.startswith(date.today().isoformat())
     assert updated_plant.updated_at == date.today().isoformat()
 
 
@@ -1084,7 +1086,9 @@ async def test_async_start_curing(coordinator: GrowspaceCoordinator) -> None:
     updated_plant = coordinator.plants.get(plant.plant_id)
     assert updated_plant is not None
     assert updated_plant.stage == PlantStage.CURE
-    assert updated_plant.cure_start == date.today().isoformat()
+    # Lifecycle Timestamp (ADR-0013): cure_start is a full datetime; the date
+    # portion is today.
+    assert updated_plant.cure_start.startswith(date.today().isoformat())
     assert updated_plant.updated_at == date.today().isoformat()
 
 
@@ -1101,7 +1105,7 @@ async def test_async_harvest(coordinator: GrowspaceCoordinator) -> None:
     updated_plant = coordinator.plants.get(plant.plant_id)
     assert updated_plant is not None
     assert updated_plant.stage == PlantStage.DRY
-    assert updated_plant.dry_start == date.today().isoformat()
+    assert updated_plant.dry_start.startswith(date.today().isoformat())
     assert updated_plant.updated_at == date.today().isoformat()
 
 
@@ -1215,7 +1219,9 @@ async def test_async_transition_plant_auto_flow_to_cure(
     assert updated_plant is not None
     assert updated_plant.growspace_id == "cure"
     assert updated_plant.stage == PlantStage.CURE
-    assert updated_plant.cure_start == date.today().isoformat()
+    # Lifecycle Timestamp (ADR-0013): cure_start is a full datetime; the date
+    # portion is today.
+    assert updated_plant.cure_start.startswith(date.today().isoformat())
 
 
 @pytest.mark.asyncio
@@ -1691,8 +1697,10 @@ async def test_handle_transition_logic_explicit_target(hass: HomeAssistant) -> N
             transition_date="2025-01-01",
         )
 
+        # transition_plant promotes the date to a datetime via the Lifecycle
+        # Timestamp seam before delegating (ADR-0013).
         mock_harvest.assert_awaited_once_with(
-            "p1", plant, "target_gs", "Target GS", "2025-01-01"
+            "p1", plant, "target_gs", "Target GS", "2025-01-01T00:00:00+00:00"
         )
 
 
@@ -1714,7 +1722,9 @@ async def test_handle_transition_logic_auto_flow(hass: HomeAssistant) -> None:
             "p1", transition_date="2025-01-01"
         )
 
-        mock_auto.assert_awaited_once_with("p1", plant, None, "2025-01-01")
+        mock_auto.assert_awaited_once_with(
+            "p1", plant, None, "2025-01-01T00:00:00+00:00"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/domain/test_date_logic.py
+++ b/tests/domain/test_date_logic.py
@@ -13,6 +13,7 @@ from custom_components.growspace_manager.domain.date_logic import (
     get_days_since_training,
     get_days_since_watering,
     parse_date_field,
+    to_lifecycle_timestamp,
 )
 from custom_components.growspace_manager.domain.stage import PlantStage
 from homeassistant.util.dt import as_local, set_default_time_zone
@@ -25,6 +26,42 @@ DEFAULT_TZ = UTC
 def setup_tz():
     """Set up default timezone for tests."""
     set_default_time_zone(DEFAULT_TZ)
+
+
+def test_to_lifecycle_timestamp_preserves_supplied_time():
+    """A supplied datetime keeps its time, returned as an ISO string."""
+    result = to_lifecycle_timestamp("2026-03-01T14:30:00+00:00")
+    # Round-trips through parse_date_field, so the moment is preserved.
+    assert parse_date_field(result) == datetime(2026, 3, 1, 14, 30, tzinfo=UTC)
+    assert isinstance(result, str)
+
+
+def test_to_lifecycle_timestamp_promotes_date_only_to_datetime():
+    """A date-only value becomes a midnight-local datetime string, not truncated."""
+    result = to_lifecycle_timestamp("2026-01-15")
+    assert isinstance(result, str)
+    parsed = parse_date_field(result)
+    assert parsed.date() == date(2026, 1, 15)
+    assert parsed.tzinfo is not None
+    # The result is a full datetime string, never a bare date.
+    assert "T" in result
+
+
+def test_to_lifecycle_timestamp_accepts_date_object():
+    """A datetime.date object is accepted and promoted to a datetime string."""
+    result = to_lifecycle_timestamp(date(2026, 1, 15))
+    assert parse_date_field(result).date() == date(2026, 1, 15)
+    assert "T" in result
+
+
+def test_to_lifecycle_timestamp_defaults_to_now_when_none():
+    """None defaults to the current moment (full datetime, not date-only)."""
+    result = to_lifecycle_timestamp(None)
+    assert isinstance(result, str)
+    parsed = parse_date_field(result)
+    assert parsed is not None
+    # Carries a real time component, not midnight from a .date() truncation.
+    assert "T" in result
 
 
 def test_parse_date_field_none():

--- a/tests/integration/test_services_plant_coverage.py
+++ b/tests/integration/test_services_plant_coverage.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.growspace_manager.const import PlantStage
 from custom_components.growspace_manager.managers.plant import PlantManager
 from custom_components.growspace_manager.services.context import ServiceContext
 from custom_components.growspace_manager.models import Plant, PlantGenetics
@@ -325,17 +326,19 @@ async def test_convenience_methods(service, repository_mock) -> None:
     with patch.object(
         service, "transition_plant_stage", return_value=None
     ) as mock_trans:
+        # Convenience methods no longer pass an explicit date — the transition
+        # seam defaults to now() with its time (ADR-0013).
         await service.start_flowering("p1")
-        mock_trans.assert_called_with("p1", "flower", date.today())
+        mock_trans.assert_called_with("p1", PlantStage.FLOWER)
 
         await service.start_drying("p1")
-        mock_trans.assert_called_with("p1", "dry", date.today())
+        mock_trans.assert_called_with("p1", PlantStage.DRY)
 
         await service.start_curing("p1")
-        mock_trans.assert_called_with("p1", "cure", date.today())
+        mock_trans.assert_called_with("p1", PlantStage.CURE)
 
         await service.harvest("p1")
-        mock_trans.assert_called_with("p1", "dry", date.today())
+        mock_trans.assert_called_with("p1", PlantStage.DRY)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_services_plant_simple_coverage.py
+++ b/tests/integration/test_services_plant_simple_coverage.py
@@ -129,13 +129,13 @@ async def test_transition_closes_existing_history(
     assert "stage_history" in plant.to_dict()  # Wait, to_dict/asdict might be used
     history = plant.stage_history
 
-    # Verify previous item closed
+    # Verify previous item closed (Lifecycle Timestamp is a full datetime, ADR-0013)
     assert history[1]["stage"] == "veg"
-    assert history[1]["end"] == today
+    assert history[1]["end"].startswith(today)
 
     # Verify new item added
     assert history[2]["stage"] == PlantStage.FLOWER
-    assert history[2]["start"] == today
+    assert history[2]["start"].startswith(today)
     assert history[2]["end"] is None
 
 

--- a/tests/integration/test_websocket_plant.py
+++ b/tests/integration/test_websocket_plant.py
@@ -400,7 +400,7 @@ async def test_harvest_plant_success_with_valid_transition_date(
     ):
         await websocket_harvest_plant(hass, mock_connection, msg)
     call_kwargs = mock_coordinator.services.plants.transition_plant.call_args[1]
-    assert call_kwargs["transition_date"] == "2026-01-10"
+    assert call_kwargs["transition_date"] == _FIXED_DT.isoformat()
 
 
 async def test_harvest_plant_invalid_transition_date_sends_error(
@@ -460,7 +460,7 @@ async def test_move_clone_success_with_transition_date(
     mock_coordinator.services.plants.promote_clone.assert_awaited_once_with(
         clone_id="clone1",
         target_growspace_id="veg",
-        transition_date=_FIXED_DT.date(),
+        transition_date=_FIXED_DT,
     )
     mock_connection.send_result.assert_called_once_with(40)
 
@@ -475,7 +475,7 @@ async def test_move_clone_success_no_transition_date_uses_utcnow(
     ):
         await websocket_move_clone(hass, mock_connection, msg)
     call_kwargs = mock_coordinator.services.plants.promote_clone.call_args[1]
-    assert call_kwargs["transition_date"] == _FIXED_NOW.date()
+    assert call_kwargs["transition_date"] == _FIXED_NOW
 
 
 async def test_move_clone_unparseable_date_falls_back_to_utcnow(
@@ -492,7 +492,7 @@ async def test_move_clone_unparseable_date_falls_back_to_utcnow(
     ):
         await websocket_move_clone(hass, mock_connection, msg)
     call_kwargs = mock_coordinator.services.plants.promote_clone.call_args[1]
-    assert call_kwargs["transition_date"] == _FIXED_NOW.date()
+    assert call_kwargs["transition_date"] == _FIXED_NOW
 
 
 @pytest.mark.parametrize("error", [GrowspaceError("bad"), ValueError("bad")])
@@ -538,7 +538,7 @@ async def test_take_clone_success(
         mother_plant_id="mother1",
         num_clones=1,
         target_growspace_id=None,
-        transition_date=_FIXED_NOW.date(),
+        transition_date=_FIXED_NOW,
     )
     mock_connection.send_result.assert_called_once_with(50)
 
@@ -819,7 +819,7 @@ async def test_move_plant_with_valid_transition_date(
     ):
         await websocket_move_plant(hass, mock_connection, msg)
     call_kwargs = mock_coordinator.services.plants.transition_plant.call_args[1]
-    assert call_kwargs["transition_date"] == "2026-01-10"
+    assert call_kwargs["transition_date"] == _FIXED_DT.isoformat()
     mock_connection.send_result.assert_called_once_with(82)
 
 

--- a/tests/logic/test_plant_lifecycle_manager.py
+++ b/tests/logic/test_plant_lifecycle_manager.py
@@ -232,6 +232,39 @@ async def test_handle_transition_logic_fallthrough(manager, repository_mock) -> 
 
 
 @pytest.mark.asyncio
+async def test_update_plant_preserves_lifecycle_datetime_time(
+    manager, repository_mock
+) -> None:
+    """update_plant stores a lifecycle datetime with its time intact (ADR-0013).
+
+    Previously DATE_FIELDS were run through format_date, truncating to date-only;
+    the time the user picked was silently discarded on the way to storage.
+    """
+    plant = Plant(plant_id="p1", growspace_id="gs1")
+    repository_mock.get_plant.return_value = plant
+
+    await manager.update_plant("p1", flower_start="2026-03-01T14:30:00+00:00")
+
+    # Stored as a full datetime string, not truncated to "2026-03-01".
+    assert "T14:30" in plant.flower_start
+
+
+@pytest.mark.asyncio
+async def test_transition_plant_stage_preserves_supplied_datetime(
+    manager, repository_mock
+) -> None:
+    """A stage transition stamps the start field with the supplied datetime's time."""
+    plant = Plant(plant_id="p1", growspace_id="gs1")
+    repository_mock.get_plant.return_value = plant
+
+    await manager.transition_plant_stage(
+        "p1", PlantStage.FLOWER, "2026-03-01T14:30:00+00:00"
+    )
+
+    assert "T14:30" in plant.flower_start
+
+
+@pytest.mark.asyncio
 async def test_remove_plant_not_found(manager, repository_mock) -> None:
     """Test remove_plant returns False when plant does not exist."""
     repository_mock.get_plant.return_value = None

--- a/tests/services/test_plant_services.py
+++ b/tests/services/test_plant_services.py
@@ -383,10 +383,9 @@ async def test_take_clone_with_transition_date(
     await handle_take_clone(hass, mock_coordinator, mock_strain_library, call)
 
     call_kwargs = mock_coordinator.services.plants.take_clones.call_args.kwargs
-    # test_date is already a datetime object from the service call, but handle_take_clone converts it.
-    # We should update test to pass date if needed or rely on converter.
-    # handle_take_clone converts it to date.
-    assert call_kwargs["transition_date"] == test_date
+    # Lifecycle Timestamp (ADR-0013): the supplied date is promoted to a
+    # midnight-local datetime, no longer truncated to a date object.
+    assert call_kwargs["transition_date"] == as_local(datetime(2024, 1, 15, 0, 0))
 
 
 @pytest.mark.asyncio
@@ -612,7 +611,8 @@ async def test_move_clone_invalid_date(
     mock_coordinator.services.plants.promote_clone.assert_called_once()
     # Logic in service: transitions invalid date string to today
     kwargs = mock_coordinator.services.plants.promote_clone.call_args_list[0].kwargs
-    assert kwargs["transition_date"] == datetime.now().date()
+    # Unparseable date falls back to now as a full datetime (ADR-0013).
+    assert kwargs["transition_date"].date() == datetime.now(UTC).date()
 
 
 @pytest.mark.asyncio
@@ -1955,8 +1955,8 @@ async def test_move_clone_default_transition_date(
     # Moving a clone calls async_promote_clone.
     mock_coordinator.services.plants.promote_clone.assert_called_once()
     kwargs = mock_coordinator.services.plants.promote_clone.call_args.kwargs
-    # Should default to today's date as date object
-    assert kwargs["transition_date"] == date.today()
+    # Defaults to now as a full datetime (ADR-0013), not a date object.
+    assert kwargs["transition_date"].date() == date.today()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Plant lifecycle dates (`seedling_start … cure_start`) are now stored as **timezone-aware ISO datetime strings** end-to-end, with the representation decided in one place: `to_lifecycle_timestamp()` in `domain/date_logic.py`.

Previously the format was decided independently at ~9 sites that disagreed: `add_plant`/`update_plant` ran every `DATE_FIELD` through `format_date` (date-only), stage transitions truncated with `.date().isoformat()`, config-flow create used a date-only `DateSelector`, while `mother_start` auto-set and the WebSocket update path stored full datetimes. The card edits these with a `datetime-local` picker, so the time the grower picked was silently discarded on the way to storage — and on re-edit the dialog raised a false "Set both date and time" toast against untouched date-only fields.

## Changes

- **New seam** `to_lifecycle_timestamp(supplied)` — preserves a supplied time, defaults to `dt_util.now()`, always returns a full ISO datetime string.
- `add_plant` / `update_plant` `DATE_FIELDS` normalisation routes through it (None preserved, so clearing a field still clears it).
- `transition_plant_stage`: `transition_date` widened to `DateInput`, stamped via the seam. `start_flowering/drying/curing` + `harvest` drop their pre-truncated `now().date()` arg and let the seam default to now.
- WebSocket `transition_date` strings keep the full datetime (no `.date()`); `plant_cloning` keeps the parsed datetime.
- Config-flow `veg_start`/`flower_start`: `DateSelector` → `DateTimeSelector`.
- Model fields stay `str | None` and store the ISO string (closes the prior gap where a field annotated `str` held a `datetime` after an update).

## Existing data

No migration. `parse_date_field` already promotes a legacy date-only value to midnight-local on read, and every consumer (day counts, calendar, sensors) reads through it. Old plants keep their date-only `*_start` until next edited; new writes are full datetime.

## Tests

New seam + transition/update behavioural tests (`test_date_logic`, `test_plant_lifecycle_manager`). Date-only contract assertions across the plant suites (coordinator, services, websocket) updated to the datetime contract. Full suite green except one **pre-existing** clock-dependent assembler test (`test_stage_days_max_across_plants`) — a local-vs-UTC date skew in `calculate_days_since` unrelated to this change (the date rolled over mid-session); it touches none of the code here.

Scope note: `WeightEntry`/`MoistureEntry` `date` fields (drying observations) stay date-only by design.

## Pairs with

- Frontend seam: Venosta-web/lovelace-growspace-manager-card#290 (ADR-0018) — stops truncating and removes the now-impossible validation. Ships together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)