### PR TITLE
Fix set_irrigation_strategy rejecting Pore EC band fields

### DIFF
--- a/custom_components/growspace_manager/schemas.py
+++ b/custom_components/growspace_manager/schemas.py
@@ -644,6 +644,15 @@ SET_IRRIGATION_STRATEGY_SCHEMA = vol.Schema(
         vol.Optional("dynamic_interval_ceiling"): vol.All(
             vol.Coerce(float), vol.Range(min=1.0, max=5.0)
         ),
+        # Pore EC Target Band + EC Modulation. min/max are nullable to allow
+        # clearing the band; both edges share the non-negative float coercion.
+        vol.Optional("pore_ec_target_min"): vol.Any(
+            None, vol.All(vol.Coerce(float), vol.Range(min=0.0))
+        ),
+        vol.Optional("pore_ec_target_max"): vol.Any(
+            None, vol.All(vol.Coerce(float), vol.Range(min=0.0))
+        ),
+        vol.Optional("ec_modulation_enabled"): bool,
     }
 )
 

--- a/custom_components/growspace_manager/services.yaml
+++ b/custom_components/growspace_manager/services.yaml
@@ -1097,6 +1097,25 @@ set_irrigation_strategy:
           min: 1.0
           max: 5.0
           step: 0.1
+    pore_ec_target_min:
+      description: Lower edge of the Pore EC Target Band (mS/cm) that EC Modulation steers toward. Distinct from the per-stage feed EC range.
+      required: false
+      selector:
+        number:
+          min: 0.0
+          step: 0.1
+    pore_ec_target_max:
+      description: Upper edge of the Pore EC Target Band (mS/cm) that EC Modulation steers toward. Must be above the lower edge.
+      required: false
+      selector:
+        number:
+          min: 0.0
+          step: 0.1
+    ec_modulation_enabled:
+      description: Opt-in toggle for EC Modulation. When off (or the band/sensors are absent), the modulation factor is exactly 1.0.
+      required: false
+      selector:
+        boolean:
 
 set_irrigation_settings:
   description: Set irrigation and drain pump settings for a growspace.

--- a/tests/test_schemas_validation.py
+++ b/tests/test_schemas_validation.py
@@ -143,6 +143,26 @@ def test_set_irrigation_strategy_schema_accepts_volume_mode_fields(
 @pytest.mark.parametrize(
     ("field_name", "value"),
     [
+        ("pore_ec_target_min", 2.5),
+        ("pore_ec_target_max", 4.0),
+        ("pore_ec_target_min", None),
+        ("pore_ec_target_max", None),
+        ("ec_modulation_enabled", True),
+        ("ec_modulation_enabled", False),
+    ],
+)
+def test_set_irrigation_strategy_schema_accepts_pore_ec_band_fields(
+    field_name: str, value
+) -> None:
+    """Pore EC Target Band fields the card sends on save are accepted."""
+    data = {"growspace_id": "gs1", field_name: value}
+    result = SET_IRRIGATION_STRATEGY_SCHEMA(data)
+    assert result[field_name] == value
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
         ("shot_sizing_mode", "bogus"),
         ("substrate_media_type", "gravel"),
         ("p1_shot_volume_percent", 150.0),


### PR DESCRIPTION
## Problem

Saving the irrigation dialog on **any** tab failed with:

```
Failed to perform the action growspace_manager/set_irrigation_strategy.
extra keys not allowed @ data['pore_ec_target_min']
```

The dialog serializes the **full** strategy on every save, including the Pore EC Target Band fields (`pore_ec_target_min`, `pore_ec_target_max`, `ec_modulation_enabled`). The model (`models/irrigation.py`), the facade (`growspace_facade.py` — which even validates `min < max`) and the card all support these fields, but `SET_IRRIGATION_STRATEGY_SCHEMA` never whitelisted them. voluptuous rejects unknown keys, so the first unlisted key aborted the whole call — which is why it failed regardless of the active tab.

## Fix

- `schemas.py` — add `pore_ec_target_min`, `pore_ec_target_max` (nullable, non-negative float, to allow clearing the band) and `ec_modulation_enabled` (bool) to `SET_IRRIGATION_STRATEGY_SCHEMA`.
- `services.yaml` — document the three fields for parity with the HA service editor.
- `tests/test_schemas_validation.py` — parametrized regression test covering all three fields (incl. `None`), confirmed to fail before / pass after.

## Verification

- New regression test reproduces the exact error pre-fix, passes after.
- Full suite: **4385 passed**.
- ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)