### PR TITLE
View-model liters_today becomes additive via shared helper

### DIFF
--- a/custom_components/growspace_manager/view_model_builder.py
+++ b/custom_components/growspace_manager/view_model_builder.py
@@ -13,6 +13,7 @@ from homeassistant.util import dt as dt_util
 
 from .crop_steering import get_crop_steering_state
 from .domain.stage import StageDays
+from .domain.water_aggregation import compute_growspace_water
 from .models import Plant
 from .presentation import GrowspaceViewModelBuilder
 from .utils import calculate_days_since
@@ -161,18 +162,13 @@ class ViewModelBuilder:
             cycles_today = irr_coord.cycles_today
             volume_dispensed_today = irr_coord.volume_dispensed_today
 
-        # Compute liters_today for Tank-Derived Water Mode
-        liters_today: float | None = None
-        env = growspace.environment_config
-        if env and not env.irrigation_flow_sensors and not env.drain_volume_sensors:
-            trackers = (
-                self.coordinator.services.growspaces.get_all_trackers_for_growspace(
-                    growspace_id
-                )
-            )
-            liters_today = round(
-                sum(t.get_total_liters_today() for t in trackers.values()), 2
-            )
+        # Canonical [[Aggregate Water Use]] for today (ADR-0017): manual +
+        # (tank-derived in tank mode, else pump-estimate). The shared helper owns
+        # all source selection, so this path no longer branches on sensor config.
+        trackers = self.coordinator.services.growspaces.get_all_trackers_for_growspace(
+            growspace_id
+        )
+        liters_today = compute_growspace_water(growspace, trackers.values()).today
 
         # Use presentation layer to build rich growspace payload
         serialized = self._growspace_builder.build(

--- a/tests/integration/test_growspace_view_model_coverage.py
+++ b/tests/integration/test_growspace_view_model_coverage.py
@@ -20,6 +20,7 @@ from custom_components.growspace_manager.presentation.growspace_view_model impor
 )
 from custom_components.growspace_manager.view_model_builder import ViewModelBuilder
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 
 @pytest.fixture
@@ -616,10 +617,36 @@ def test_view_model_builder_passes_liters_today_from_trackers(
     assert water_usage["liters_today"] == pytest.approx(7.5)
 
 
-def test_view_model_builder_liters_today_absent_with_flow_sensors(
+def test_view_model_builder_liters_today_additive_tank_plus_manual(
     hass: HomeAssistant,
 ) -> None:
-    """ViewModelBuilder omits liters_today when irrigation flow sensors are configured."""
+    """In tank mode liters_today is tank-derived + manual, via the shared helper."""
+    today = dt_util.now().date().isoformat()
+    env = EnvironmentConfig(
+        irrigation_tanks=[
+            IrrigationTank(
+                sensor_entity="sensor.tank1", name="Tank 1", volume_liters=100.0
+            )
+        ],
+    )
+    usage = WaterUsageData()
+    usage.daily_readings = [{"date": today, "liters": 2.0, "source": "manual"}]
+    gs = Growspace(id="gs1", name="GS1", environment_config=env, water_usage=usage)
+
+    mock_tracker = MagicMock()
+    mock_tracker.get_total_liters_today.return_value = 7.5
+    coordinator = _make_mock_coordinator(hass, gs, {"sensor.tank1": mock_tracker})
+
+    result = ViewModelBuilder(coordinator).build_serialized_growspace("gs1")
+
+    water_usage = result["irrigation"]["water_usage"]
+    assert water_usage["liters_today"] == pytest.approx(9.5)
+
+
+def test_view_model_builder_liters_today_measured_with_flow_sensors(
+    hass: HomeAssistant,
+) -> None:
+    """Flow sensors no longer gate liters_today; it reports the measured figure (ADR-0017)."""
     env = EnvironmentConfig(
         irrigation_flow_sensors=["sensor.flow1"],
         irrigation_tanks=[
@@ -636,13 +663,14 @@ def test_view_model_builder_liters_today_absent_with_flow_sensors(
     result = ViewModelBuilder(coordinator).build_serialized_growspace("gs1")
 
     water_usage = result["irrigation"]["water_usage"]
-    assert "liters_today" not in water_usage
+    assert water_usage["liters_today"] == pytest.approx(0.0)
 
 
-def test_view_model_builder_liters_today_absent_with_drain_volume_sensors(
+def test_view_model_builder_liters_today_measured_with_drain_volume_sensors(
     hass: HomeAssistant,
 ) -> None:
-    """ViewModelBuilder omits liters_today when drain volume sensors are configured."""
+    """Drain volume sensors no longer gate liters_today; it reports the measured figure (ADR-0017)."""
+    today = dt_util.now().date().isoformat()
     env = EnvironmentConfig(
         drain_volume_sensors=["sensor.drain1"],
         irrigation_tanks=[
@@ -651,15 +679,18 @@ def test_view_model_builder_liters_today_absent_with_drain_volume_sensors(
             )
         ],
     )
-    gs = Growspace(
-        id="gs1", name="GS1", environment_config=env, water_usage=WaterUsageData()
-    )
+    usage = WaterUsageData()
+    usage.daily_readings = [
+        {"date": today, "liters": 3.0, "source": "manual"},
+        {"date": today, "liters": 1.5, "source": "pump_estimate"},
+    ]
+    gs = Growspace(id="gs1", name="GS1", environment_config=env, water_usage=usage)
     coordinator = _make_mock_coordinator(hass, gs, {})
 
     result = ViewModelBuilder(coordinator).build_serialized_growspace("gs1")
 
     water_usage = result["irrigation"]["water_usage"]
-    assert "liters_today" not in water_usage
+    assert water_usage["liters_today"] == pytest.approx(4.5)
 
 
 def test_vpd_optimal_overrides_round_trips_in_environment_attributes(


### PR DESCRIPTION
## Summary

Closes #471.

The growspace view-model payload's `water_usage.liters_today` now reports the canonical [[Aggregate Water Use]] for today via `compute_growspace_water(growspace, trackers).today`, replacing the previous tank-only sum that was gated on sensor configuration.

The shared helper (ADR-0017) owns all source selection, so `liters_today` is now **additive**:
- **tank mode** → tank-derived + manual
- **otherwise** → manual + pump-estimate

This makes the payload consistent with the `WaterUsageSensor` and briefing KPI, and unblocks the card's Tank-Derived Water Chip displaying the additive figure.

### Behavior change
`liters_today` is now always present (`>= 0.0`) on the view-model path. Flow/drain sensors no longer gate it — they only gate Tank-Derived Water Mode, never water use as a source.

## Acceptance criteria
- [x] `view_model_builder` computes `liters_today` via `compute_growspace_water(growspace, trackers).today`
- [x] Correct for all three modes: tank-mode (tank + manual), pump-only (manual + pump-estimate), manual-only
- [x] Existing view-model tests updated to additive values (no snapshot captured `liters_today`)
- [x] Full suite green (4463 passed); production file ruff-clean

## Tests
- Added `test_view_model_builder_liters_today_additive_tank_plus_manual` (tracer: tank 7.5 + manual 2.0 = 9.5)
- Flipped the two `..._absent_with_flow/drain_sensors` tests to assert the measured figure is now present (`measured_with_flow_sensors`, `measured_with_drain_volume_sensors` covering manual + pump-estimate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)