### PR TITLE
ExhaustFanController: combined-demand regulation + speed dispatch (#475)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -240,6 +240,20 @@ A sparse dict stored on `CirculationFanConfig` as `stage_vpd_overrides`. Keyed b
 **Fan Speed Composition**
 `final_speed = clamp(regulation_speed + wind_offset, min_speed, max_speed)` where `regulation_speed` is the output of the active regulation mode (or the safety override when active), and `wind_offset` is the sine term (zero when `wind_enabled=False`).
 
+## Exhaust Fan Controller
+
+**ExhaustFanController**
+An optional per-growspace subsystem that evacuates air by driving all `exhaust_fan_entities` on the same fixed 10 s tick as the [[Circulation Fan Controller]], registered in the `SubsystemManager` as an `EnvironmentController` with a `get_exhaust_fan_controller` accessor. Unlike the circulation fan there is **no single regulation mode and no dynamic wind layer**: exhaust output is always the combined **Exhaust Demand**. The controller is a no-op when `enabled=False` or no `exhaust_fan_entities` are configured, and it restarts cleanly when `configure_exhaust_fan` rewrites the config. See [ADR-0018](./docs/adr/0018-exhaust-fan-combined-demand.md).
+
+**Exhaust Demand**
+Each tick computes three demand terms from the shared `domain/fan_control.py` helpers and drives the fan to the highest: a **temperature term** (`compute_fan_speed` — hotter tent → more exhaust), a **humidity term** (`compute_fan_speed` — more humid → more exhaust), and an **inverted VPD term** (`compute_inverted_fan_speed` — more exhaust when VPD is *below* target, i.e. the air is too saturated). The result is `final = clamp(max(temperature, humidity, vpd_inverted), min_speed, max_speed)`. A sensor that is missing or unavailable drops its term from the maximum; if none of the three read, the tick is a no-op. When `stage_vpd_enabled` is set, the VPD target is resolved per stage and day/night via the shared `resolve_stage_vpd_target` (and `stage_vpd_overrides`), exactly like the circulation fan. The source-air gate and the critical-temperature override are separate slices and do not participate in this demand calculation.
+
+**Exhaust Speed Dispatch**
+The final demand is dispatched per entity domain: a `fan` entity receives it as a percentage (`fan.set_percentage`); a `switch` or `input_boolean` exhaust device is turned **on** when the demand exceeds `min_speed` and **off** otherwise.
+
+**ExhaustFanConfig**
+The dataclass stored on `EnvironmentConfig` that holds the exhaust controller settings: `enabled`, `min_speed`, `max_speed`, per-term `temperature_target`/`temperature_tolerance`, `humidity_target`/`humidity_tolerance`, `vpd_target`/`vpd_tolerance`, `stage_vpd_enabled`, `stage_vpd_overrides`, and (consumed by separate slices) `critical_temp_low`, `critical_temp_high`, `critical_temp_hysteresis`. There is no `regulation_mode` and no wind field. Absent or `enabled=False` means no exhaust control. Source-air gating reuses the existing `minimum_source_air_temperature` and lung-room sensors on `EnvironmentConfig` rather than adding fields here.
+
 **VPD Optimal Overrides**
 A per-growspace sparse dict stored on `EnvironmentConfig` as `vpd_optimal_overrides`. Keyed by user-facing stage name (`"seedling"`, `"clone"`, `"mother"`, `"veg"`, `"flower_early"`, `"flower_mid"`, `"flower_late"`, `"dry"`, `"cure"`); each entry is `{"day": {"low": float, "high": float}, "night": {"low": float, "high": float}}`. Only stages the user has explicitly edited are present — absent stages fall back to `VPD_OPTIMAL_THRESHOLDS`. Applies to the **standard sub-stage only**: the acclimation phases for `seedling` and `clone` (`BayesianStage.SEEDLING`, `BayesianStage.CLONE`) always use hardcoded defaults regardless of any override. Drives the "not optimal" chip and the optimal conditions binary sensor. Distinct from `stage_vpd_overrides` on `CirculationFanConfig`, which controls the fan regulation target, not Bayesian evaluation. Validation rules: `0.1 ≤ low < high ≤ 3.0` kPa; unknown stage keys are rejected; each entry must contain both `"day"` and `"night"` with both `"low"` and `"high"` — a partial entry is invalid. Configurable per-growspace via the **VPD Targets** tab in the config dialog.
 

--- a/custom_components/growspace_manager/circulation_fan_coordinator.py
+++ b/custom_components/growspace_manager/circulation_fan_coordinator.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from datetime import timedelta
 import logging
-import math
 import time
 from typing import TYPE_CHECKING
 
@@ -15,9 +14,15 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import FanRegulationMode, PlantStage
+from .const import FanRegulationMode
 from .domain.day_night import DayNightTracker
-from .domain.stage_calculator import determine_coordinator_stage
+from .domain.fan_control import (
+    FAN_VPD_STAGE_DEFAULTS,
+    compute_fan_speed,
+    compute_wind_offset,
+    evaluate_temp_override,
+    resolve_stage_vpd_target,
+)
 
 if TYPE_CHECKING:
     from .coordinator import GrowspaceCoordinator
@@ -27,88 +32,14 @@ _LOGGER = logging.getLogger(__name__)
 
 _TICK_INTERVAL = timedelta(seconds=10)
 
-# Per-stage VPD targets (day / night) for dynamic VPD mode.
-# Values are midpoints of the tightest Bayesian optimal range for each stage.
-FAN_VPD_STAGE_DEFAULTS: dict[PlantStage, dict[str, float]] = {
-    PlantStage.SEEDLING:      {"day": 0.60, "night": 0.60},
-    PlantStage.CLONE:         {"day": 0.50, "night": 0.50},
-    PlantStage.MOTHER:        {"day": 0.70, "night": 0.60},
-    PlantStage.VEG:           {"day": 0.70, "night": 0.60},
-    PlantStage.FLOWER_EARLY:  {"day": 1.15, "night": 1.00},
-    PlantStage.FLOWER_MID:    {"day": 1.20, "night": 1.00},
-    PlantStage.FLOWER_LATE:   {"day": 1.25, "night": 1.05},
-    PlantStage.DRY:           {"day": 0.95, "night": 0.95},
-    PlantStage.CURE:          {"day": 0.75, "night": 0.75},
-}
-
-
-def evaluate_temp_override(
-    current_temp: float,
-    critical_temp_low: float | None,
-    critical_temp_high: float | None,
-    hysteresis: float,
-    override_active: bool,
-    override_direction: str | None,
-    vpd_speed: int,
-    min_speed: int,
-    max_speed: int,
-) -> tuple[int, bool, str | None]:
-    """Apply temperature safety override logic for VPD mode.
-
-    Returns (final_speed, new_override_active, new_override_direction).
-    Override direction is "high" or "low" when active, None otherwise.
-    """
-    if critical_temp_low is None and critical_temp_high is None:
-        return vpd_speed, False, None
-
-    if not override_active:
-        if critical_temp_high is not None and current_temp > critical_temp_high:
-            return max_speed, True, "high"
-        if critical_temp_low is not None and current_temp < critical_temp_low:
-            return min_speed, True, "low"
-        return vpd_speed, False, None
-
-    if override_direction == "high":
-        if critical_temp_high is not None and current_temp <= critical_temp_high - hysteresis:
-            return vpd_speed, False, None
-        return max_speed, True, "high"
-
-    # override_direction == "low"
-    if critical_temp_low is not None and current_temp >= critical_temp_low + hysteresis:
-        return vpd_speed, False, None
-    return min_speed, True, "low"
-
-
-def compute_wind_offset(
-    amplitude_pct: int,
-    elapsed_seconds: float,
-    period_seconds: int,
-) -> float:
-    """Compute wind offset as amplitude × sin(2π × elapsed / period)."""
-    return amplitude_pct * math.sin(2 * math.pi * elapsed_seconds / period_seconds)
-
-
-def compute_fan_speed(
-    value: float,
-    target: float,
-    tolerance: float,
-    min_speed: int,
-    max_speed: int,
-) -> int:
-    """Compute fan speed via linear mapping of value relative to target band.
-
-    Below (target - tolerance): min_speed
-    Above (target + tolerance): max_speed
-    Inside the band: linearly interpolated
-    """
-    lower = target - tolerance
-    upper = target + tolerance
-    if value <= lower:
-        return min_speed
-    if value >= upper:
-        return max_speed
-    t = (value - lower) / (upper - lower)
-    return round(min_speed + t * (max_speed - min_speed))
+# Re-exported from .domain.fan_control so existing importers keep working.
+__all__ = [
+    "FAN_VPD_STAGE_DEFAULTS",
+    "CirculationFanCoordinator",
+    "compute_fan_speed",
+    "compute_wind_offset",
+    "evaluate_temp_override",
+]
 
 
 class CirculationFanCoordinator:
@@ -260,18 +191,9 @@ class CirculationFanCoordinator:
         plants = self.main_coordinator.services.growspaces.get_growspace_plants(
             self.growspace_id
         )
-        if not plants:
-            return cfg.vpd_target
-
-        stage = determine_coordinator_stage(plants)
-        day_key = "day" if is_day else "night"
-        override = cfg.stage_vpd_overrides.get(stage.value)
-        if override:
-            return override[day_key]
-        stage_entry = FAN_VPD_STAGE_DEFAULTS.get(stage)
-        if stage_entry:
-            return stage_entry[day_key]
-        return cfg.vpd_target
+        return resolve_stage_vpd_target(
+            plants, cfg.stage_vpd_overrides, cfg.vpd_target, is_day
+        )
 
     def _read_sensor(self, mode: FanRegulationMode) -> float | None:
         """Read the first available sensor value for the given regulation mode."""

--- a/custom_components/growspace_manager/domain/fan_control.py
+++ b/custom_components/growspace_manager/domain/fan_control.py
@@ -21,15 +21,15 @@ if TYPE_CHECKING:
 # Per-stage VPD targets (day / night) for dynamic VPD mode.
 # Values are midpoints of the tightest Bayesian optimal range for each stage.
 FAN_VPD_STAGE_DEFAULTS: dict[PlantStage, dict[str, float]] = {
-    PlantStage.SEEDLING:      {"day": 0.60, "night": 0.60},
-    PlantStage.CLONE:         {"day": 0.50, "night": 0.50},
-    PlantStage.MOTHER:        {"day": 0.70, "night": 0.60},
-    PlantStage.VEG:           {"day": 0.70, "night": 0.60},
-    PlantStage.FLOWER_EARLY:  {"day": 1.15, "night": 1.00},
-    PlantStage.FLOWER_MID:    {"day": 1.20, "night": 1.00},
-    PlantStage.FLOWER_LATE:   {"day": 1.25, "night": 1.05},
-    PlantStage.DRY:           {"day": 0.95, "night": 0.95},
-    PlantStage.CURE:          {"day": 0.75, "night": 0.75},
+    PlantStage.SEEDLING: {"day": 0.60, "night": 0.60},
+    PlantStage.CLONE: {"day": 0.50, "night": 0.50},
+    PlantStage.MOTHER: {"day": 0.70, "night": 0.60},
+    PlantStage.VEG: {"day": 0.70, "night": 0.60},
+    PlantStage.FLOWER_EARLY: {"day": 1.15, "night": 1.00},
+    PlantStage.FLOWER_MID: {"day": 1.20, "night": 1.00},
+    PlantStage.FLOWER_LATE: {"day": 1.25, "night": 1.05},
+    PlantStage.DRY: {"day": 0.95, "night": 0.95},
+    PlantStage.CURE: {"day": 0.75, "night": 0.75},
 }
 
 
@@ -60,7 +60,10 @@ def evaluate_temp_override(
         return vpd_speed, False, None
 
     if override_direction == "high":
-        if critical_temp_high is not None and current_temp <= critical_temp_high - hysteresis:
+        if (
+            critical_temp_high is not None
+            and current_temp <= critical_temp_high - hysteresis
+        ):
             return vpd_speed, False, None
         return max_speed, True, "high"
 
@@ -100,6 +103,81 @@ def compute_fan_speed(
         return max_speed
     t = (value - lower) / (upper - lower)
     return round(min_speed + t * (max_speed - min_speed))
+
+
+def compute_inverted_fan_speed(
+    value: float,
+    target: float,
+    tolerance: float,
+    min_speed: int,
+    max_speed: int,
+) -> int:
+    """Compute an inverted fan speed: a lower value maps to a higher speed.
+
+    Used for the VPD exhaust term, where a VPD *below* target means the tent is
+    too humid and exhaust should ramp up:
+
+    Below (target - tolerance): max_speed
+    Above (target + tolerance): min_speed
+    Inside the band: linearly interpolated from max_speed down to min_speed
+    """
+    return compute_fan_speed(value, target, tolerance, max_speed, min_speed)
+
+
+def compute_exhaust_demand(
+    temperature: float | None,
+    humidity: float | None,
+    vpd: float | None,
+    *,
+    temperature_target: float,
+    temperature_tolerance: float,
+    humidity_target: float,
+    humidity_tolerance: float,
+    vpd_target: float,
+    vpd_tolerance: float,
+    min_speed: int,
+    max_speed: int,
+) -> int | None:
+    """Combine the temperature, humidity and inverted-VPD terms into one speed.
+
+    Each available reading is mapped to a demand term and the controller drives
+    the fan to the highest of them:
+
+    - temperature: hotter tent → more exhaust (direct mapping)
+    - humidity: more humid tent → more exhaust (direct mapping)
+    - VPD: inverted — more exhaust when VPD is *below* target (too humid)
+
+    A ``None`` reading drops that term from the maximum. Returns ``None`` when no
+    reading is available. The result is clamped to ``[min_speed, max_speed]``.
+    """
+    terms: list[int] = []
+    if temperature is not None:
+        terms.append(
+            compute_fan_speed(
+                temperature,
+                temperature_target,
+                temperature_tolerance,
+                min_speed,
+                max_speed,
+            )
+        )
+    if humidity is not None:
+        terms.append(
+            compute_fan_speed(
+                humidity, humidity_target, humidity_tolerance, min_speed, max_speed
+            )
+        )
+    if vpd is not None:
+        terms.append(
+            compute_inverted_fan_speed(
+                vpd, vpd_target, vpd_tolerance, min_speed, max_speed
+            )
+        )
+
+    if not terms:
+        return None
+
+    return max(min_speed, min(max_speed, max(terms)))
 
 
 def resolve_stage_vpd_target(

--- a/custom_components/growspace_manager/domain/fan_control.py
+++ b/custom_components/growspace_manager/domain/fan_control.py
@@ -1,0 +1,127 @@
+"""Shared pure helpers for fan-speed control.
+
+These functions hold the math used by both the circulation fan coordinator and
+the exhaust fan coordinator. They are deliberately free of Home Assistant and
+coordinator dependencies so they can be unit-tested in isolation and reused by
+any controller that maps an environmental reading onto a fan speed.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from custom_components.growspace_manager.const import PlantStage
+
+from .stage_calculator import determine_coordinator_stage
+
+if TYPE_CHECKING:
+    from custom_components.growspace_manager.models import Plant
+
+# Per-stage VPD targets (day / night) for dynamic VPD mode.
+# Values are midpoints of the tightest Bayesian optimal range for each stage.
+FAN_VPD_STAGE_DEFAULTS: dict[PlantStage, dict[str, float]] = {
+    PlantStage.SEEDLING:      {"day": 0.60, "night": 0.60},
+    PlantStage.CLONE:         {"day": 0.50, "night": 0.50},
+    PlantStage.MOTHER:        {"day": 0.70, "night": 0.60},
+    PlantStage.VEG:           {"day": 0.70, "night": 0.60},
+    PlantStage.FLOWER_EARLY:  {"day": 1.15, "night": 1.00},
+    PlantStage.FLOWER_MID:    {"day": 1.20, "night": 1.00},
+    PlantStage.FLOWER_LATE:   {"day": 1.25, "night": 1.05},
+    PlantStage.DRY:           {"day": 0.95, "night": 0.95},
+    PlantStage.CURE:          {"day": 0.75, "night": 0.75},
+}
+
+
+def evaluate_temp_override(
+    current_temp: float,
+    critical_temp_low: float | None,
+    critical_temp_high: float | None,
+    hysteresis: float,
+    override_active: bool,
+    override_direction: str | None,
+    vpd_speed: int,
+    min_speed: int,
+    max_speed: int,
+) -> tuple[int, bool, str | None]:
+    """Apply temperature safety override logic for VPD mode.
+
+    Returns (final_speed, new_override_active, new_override_direction).
+    Override direction is "high" or "low" when active, None otherwise.
+    """
+    if critical_temp_low is None and critical_temp_high is None:
+        return vpd_speed, False, None
+
+    if not override_active:
+        if critical_temp_high is not None and current_temp > critical_temp_high:
+            return max_speed, True, "high"
+        if critical_temp_low is not None and current_temp < critical_temp_low:
+            return min_speed, True, "low"
+        return vpd_speed, False, None
+
+    if override_direction == "high":
+        if critical_temp_high is not None and current_temp <= critical_temp_high - hysteresis:
+            return vpd_speed, False, None
+        return max_speed, True, "high"
+
+    # override_direction == "low"
+    if critical_temp_low is not None and current_temp >= critical_temp_low + hysteresis:
+        return vpd_speed, False, None
+    return min_speed, True, "low"
+
+
+def compute_wind_offset(
+    amplitude_pct: int,
+    elapsed_seconds: float,
+    period_seconds: int,
+) -> float:
+    """Compute wind offset as amplitude × sin(2π × elapsed / period)."""
+    return amplitude_pct * math.sin(2 * math.pi * elapsed_seconds / period_seconds)
+
+
+def compute_fan_speed(
+    value: float,
+    target: float,
+    tolerance: float,
+    min_speed: int,
+    max_speed: int,
+) -> int:
+    """Compute fan speed via linear mapping of value relative to target band.
+
+    Below (target - tolerance): min_speed
+    Above (target + tolerance): max_speed
+    Inside the band: linearly interpolated
+    """
+    lower = target - tolerance
+    upper = target + tolerance
+    if value <= lower:
+        return min_speed
+    if value >= upper:
+        return max_speed
+    t = (value - lower) / (upper - lower)
+    return round(min_speed + t * (max_speed - min_speed))
+
+
+def resolve_stage_vpd_target(
+    plants: list[Plant],
+    stage_vpd_overrides: dict[str, dict[str, float]],
+    fallback_vpd_target: float,
+    is_day: bool,
+) -> float:
+    """Resolve the effective VPD target from the active plant stage.
+
+    Falls back to ``fallback_vpd_target`` when the growspace has no plants or
+    the active stage is not present in the override map or the defaults.
+    """
+    if not plants:
+        return fallback_vpd_target
+
+    stage = determine_coordinator_stage(plants)
+    day_key = "day" if is_day else "night"
+    override = stage_vpd_overrides.get(stage.value)
+    if override:
+        return override[day_key]
+    stage_entry = FAN_VPD_STAGE_DEFAULTS.get(stage)
+    if stage_entry:
+        return stage_entry[day_key]
+    return fallback_vpd_target

--- a/custom_components/growspace_manager/exhaust_fan_coordinator.py
+++ b/custom_components/growspace_manager/exhaust_fan_coordinator.py
@@ -1,0 +1,207 @@
+"""Exhaust Fan Coordinator for Growspace Manager.
+
+Drives the configured exhaust devices on a fixed tick using a combined demand
+signal: the maximum of a temperature term, a humidity term and an inverted-VPD
+term (see ADR 0018 and CONTEXT.md "Exhaust Demand"). Unlike the circulation
+fan, exhaust has no single regulation mode and no dynamic wind layer.
+
+This slice excludes the source-air gate and the critical-temperature override —
+those are handled by separate slices.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import timedelta
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.event import async_track_time_interval
+
+from .const import FanRegulationMode
+from .domain.day_night import DayNightTracker
+from .domain.fan_control import compute_exhaust_demand, resolve_stage_vpd_target
+
+if TYPE_CHECKING:
+    from .coordinator import GrowspaceCoordinator
+    from .models import EnvironmentConfig, ExhaustFanConfig
+
+_LOGGER = logging.getLogger(__name__)
+
+_TICK_INTERVAL = timedelta(seconds=10)
+
+# Entity domains driven on/off rather than by percentage.
+_SWITCH_DOMAINS = ("switch", "input_boolean")
+
+
+class ExhaustFanCoordinator:
+    """Controls exhaust devices via combined temperature/humidity/VPD demand."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        growspace_id: str,
+        main_coordinator: GrowspaceCoordinator,
+    ) -> None:
+        """Initialize the ExhaustFanCoordinator."""
+        self.hass = hass
+        self.config_entry = config_entry
+        self.growspace_id = growspace_id
+        self.main_coordinator = main_coordinator
+        self._remove_tick: Callable[[], None] | None = None
+        self._day_night = DayNightTracker(growspace_id)
+
+    @property
+    def _env_config(self) -> EnvironmentConfig | None:
+        gs = self.main_coordinator.growspaces.get(self.growspace_id)
+        return gs.environment_config if gs else None
+
+    async def async_setup(self) -> None:
+        """Start the polling tick when enabled and exhaust entities are configured."""
+        if self._env_config is None:
+            return
+
+        cfg = self._env_config.exhaust_fan_config
+        if not cfg.enabled:
+            _LOGGER.debug("ExhaustFanCoordinator disabled for %s", self.growspace_id)
+            return
+
+        if not self._env_config.exhaust_fan_entities:
+            _LOGGER.debug(
+                "ExhaustFanCoordinator: no exhaust entities for %s", self.growspace_id
+            )
+            return
+
+        self._remove_tick = async_track_time_interval(
+            self.hass, self._on_tick, _TICK_INTERVAL
+        )
+        _LOGGER.info("ExhaustFanCoordinator started for %s", self.growspace_id)
+
+    @callback
+    def _on_tick(self, _now: object) -> None:
+        """Handle polling tick — schedule async regulation."""
+        self.config_entry.async_create_background_task(
+            self.hass, self._async_regulate(), "exhaust_fan_regulate"
+        )
+
+    async def _async_regulate(self) -> None:
+        """Read sensors, compute combined demand, and dispatch to each device."""
+        if self._env_config is None:
+            return
+
+        cfg = self._env_config.exhaust_fan_config
+        if not cfg.enabled or not self._env_config.exhaust_fan_entities:
+            return
+
+        vpd_target = self._effective_vpd_target(cfg)
+        speed = compute_exhaust_demand(
+            self._read_sensor(FanRegulationMode.TEMPERATURE),
+            self._read_sensor(FanRegulationMode.HUMIDITY),
+            self._read_sensor(FanRegulationMode.VPD),
+            temperature_target=cfg.temperature_target,
+            temperature_tolerance=cfg.temperature_tolerance,
+            humidity_target=cfg.humidity_target,
+            humidity_tolerance=cfg.humidity_tolerance,
+            vpd_target=vpd_target,
+            vpd_tolerance=cfg.vpd_tolerance,
+            min_speed=cfg.min_speed,
+            max_speed=cfg.max_speed,
+        )
+        if speed is None:
+            return
+
+        for entity_id in self._env_config.exhaust_fan_entities:
+            await self._dispatch(entity_id, speed, cfg.min_speed)
+
+    def _effective_vpd_target(self, cfg: ExhaustFanConfig) -> float:
+        """Resolve the VPD target, honoring stage-aware overrides when enabled."""
+        if not cfg.stage_vpd_enabled:
+            return cfg.vpd_target
+
+        light_sensors = self._env_config.light_sensors if self._env_config else []
+        is_day = self._day_night.determine(self.hass, light_sensors)
+        plants = self.main_coordinator.services.growspaces.get_growspace_plants(
+            self.growspace_id
+        )
+        return resolve_stage_vpd_target(
+            plants, cfg.stage_vpd_overrides, cfg.vpd_target, is_day
+        )
+
+    async def _dispatch(self, entity_id: str, speed: int, min_speed: int) -> None:
+        """Drive a single exhaust device by domain.
+
+        ``fan`` entities receive the speed as a percentage; ``switch`` and
+        ``input_boolean`` devices are turned on when the demand exceeds
+        ``min_speed`` and off otherwise.
+        """
+        domain = entity_id.split(".", 1)[0]
+        if domain == "fan":
+            await self._call_service(
+                "fan",
+                "set_percentage",
+                {ATTR_ENTITY_ID: entity_id, "percentage": speed},
+            )
+        elif domain in _SWITCH_DOMAINS:
+            service = SERVICE_TURN_ON if speed > min_speed else SERVICE_TURN_OFF
+            await self._call_service(domain, service, {ATTR_ENTITY_ID: entity_id})
+
+    async def _call_service(
+        self, domain: str, service: str, data: dict[str, object]
+    ) -> None:
+        """Call a Home Assistant service, logging device failures without raising."""
+        try:
+            await self.hass.services.async_call(domain, service, data, blocking=False)
+        except HomeAssistantError, TimeoutError:
+            _LOGGER.warning(
+                "Failed to call %s.%s on %s",
+                domain,
+                service,
+                data.get(ATTR_ENTITY_ID),
+                exc_info=True,
+            )
+
+    def _read_sensor(self, mode: FanRegulationMode) -> float | None:
+        """Read the first available sensor value for the given measurement."""
+        if self._env_config is None:
+            return None
+        if mode == FanRegulationMode.HUMIDITY:
+            sensors = self._env_config.humidity_sensors
+        elif mode == FanRegulationMode.TEMPERATURE:
+            sensors = self._env_config.temperature_sensors
+        elif mode == FanRegulationMode.VPD:
+            sensors = self._env_config.vpd_sensors
+        else:
+            return None
+
+        if not sensors:
+            return None
+
+        state = self.hass.states.get(sensors[0])
+        if not state or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            return None
+        try:
+            return float(state.state)
+        except ValueError:
+            return None
+
+    async def async_restart(self) -> None:
+        """Restart the polling tick after a config change."""
+        self.unload()
+        await self.async_setup()
+
+    def unload(self) -> None:
+        """Stop the polling tick."""
+        if self._remove_tick is not None:
+            self._remove_tick()
+            self._remove_tick = None

--- a/custom_components/growspace_manager/managers/subsystem.py
+++ b/custom_components/growspace_manager/managers/subsystem.py
@@ -16,6 +16,9 @@ from custom_components.growspace_manager.circulation_fan_coordinator import (
 from custom_components.growspace_manager.dehumidifier_coordinator import (
     DehumidifierCoordinator,
 )
+from custom_components.growspace_manager.exhaust_fan_coordinator import (
+    ExhaustFanCoordinator,
+)
 from custom_components.growspace_manager.humidifier_coordinator import (
     HumidifierCoordinator,
 )
@@ -72,7 +75,7 @@ class SubsystemManager:
         ] = {}
         self.light_cycle_trackers: dict[str, LightCycleTracker] = {}
         # All VPD/temperature/humidity controllers keyed by growspace_id.
-        # Each list is ordered: [DehumidifierCoordinator, HumidifierCoordinator, CirculationFanCoordinator, ...]
+        # Each list is ordered: [DehumidifierCoordinator, HumidifierCoordinator, CirculationFanCoordinator, ExhaustFanCoordinator, ...]
         self.environment_controllers: dict[str, list[EnvironmentController]] = {}
 
     async def async_initialize_sub_coordinators(
@@ -125,6 +128,7 @@ class SubsystemManager:
             DehumidifierCoordinator(self.hass, self.entry, growspace_id, self.coordinator),
             HumidifierCoordinator(self.hass, self.entry, growspace_id, self.coordinator),
             CirculationFanCoordinator(self.hass, self.entry, growspace_id, self.coordinator),
+            ExhaustFanCoordinator(self.hass, self.entry, growspace_id, self.coordinator),
         ]
         for controller in controllers:
             await controller.async_setup()
@@ -150,6 +154,15 @@ class SubsystemManager:
         """Return the circulation fan coordinator for a growspace, or None."""
         for c in self.environment_controllers.get(growspace_id, []):
             if isinstance(c, CirculationFanCoordinator):
+                return c
+        return None
+
+    def get_exhaust_fan_controller(
+        self, growspace_id: str
+    ) -> ExhaustFanCoordinator | None:
+        """Return the exhaust fan coordinator for a growspace, or None."""
+        for c in self.environment_controllers.get(growspace_id, []):
+            if isinstance(c, ExhaustFanCoordinator):
                 return c
         return None
 

--- a/custom_components/growspace_manager/services/environment.py
+++ b/custom_components/growspace_manager/services/environment.py
@@ -468,9 +468,10 @@ async def handle_configure_exhaust_fan(
 ) -> None:
     """Handle the configure_exhaust_fan service call.
 
-    Persists the exhaust fan configuration onto the target growspace. Exhaust
+    Persists the exhaust fan configuration onto the target growspace and
+    restarts the exhaust controller so the new settings take effect. Exhaust
     demand is always combined (temperature/humidity/VPD), so there is no
-    regulation mode or wind layer. No controller is started here.
+    regulation mode or wind layer.
     """
     growspace_id = call.data.get("growspace_id")
 
@@ -504,6 +505,12 @@ async def handle_configure_exhaust_fan(
 
     await coordinator.services.save()
     await coordinator.services.request_refresh()
+
+    fan_coord = coordinator._subsystem_manager.get_exhaust_fan_controller(
+        growspace_id
+    )
+    if fan_coord:
+        await fan_coord.async_restart()
 
     _LOGGER.info("Exhaust fan controller configured for '%s'", growspace.name)
 

--- a/docs/adr/0018-exhaust-fan-combined-demand.md
+++ b/docs/adr/0018-exhaust-fan-combined-demand.md
@@ -1,0 +1,110 @@
+# ADR 0018 — Exhaust Fan Controller: Combined-Demand Regulation
+
+**Status:** Accepted
+
+## Context
+
+The integration already drives in-tent air movement through the
+**CirculationFanController** ([[Circulation Fan Controller]]), which picks
+*exactly one* regulation mode (`humidity`, `temperature`, or `vpd`) and layers a
+dynamic wind oscillation on top. That single-mode model fits a fan whose job is
+to keep air stirring inside the canopy.
+
+Exhaust is a different job. An exhaust fan (or damper) evacuates hot, humid air
+*out* of the tent, and the grower wants it to respond to **whichever stress is
+worst right now** — not to a single pre-chosen variable:
+
+- the tent is **too hot** → pull more air,
+- the tent is **too humid** → pull more air,
+- the **VPD is too low** (air is saturated relative to the leaf) → pull more air.
+
+A mode selector would force the grower to guess which of these dominates, and the
+answer changes across the day and the grow stage. So exhaust needs a *combined*
+signal, and the VPD term has to be **inverted** relative to circulation: for
+circulation VPD mode, a high VPD reading raises fan speed; for exhaust, a **low**
+VPD (humid) is the condition that demands evacuation.
+
+The three terms reuse the same linear band math the circulation controller
+already uses. Before this work that math (`compute_fan_speed`,
+`evaluate_temp_override`, the stage-aware VPD target resolution, and
+`FAN_VPD_STAGE_DEFAULTS`) lived *inside* `circulation_fan_coordinator.py`, so an
+exhaust controller could only get at it by importing from a sibling coordinator
+or by duplicating it.
+
+## Decision
+
+1. **Extract the fan-control math into a shared `domain/fan_control.py` module**
+   (the enabling refactor, [#473]). `compute_fan_speed`,
+   `evaluate_temp_override`, `compute_wind_offset`, `resolve_stage_vpd_target`,
+   and `FAN_VPD_STAGE_DEFAULTS` become coordinator-free pure functions. The
+   circulation coordinator re-exports them, so its behavior and tests are
+   unchanged.
+
+2. **Add an `ExhaustFanController`** as a per-growspace `EnvironmentController`,
+   registered in the `SubsystemManager` alongside the dehumidifier, humidifier,
+   and circulation controllers, with a `get_exhaust_fan_controller` accessor. It
+   runs on the same fixed 10 s tick.
+
+3. **Demand is the maximum of three terms**, clamped to the configured band:
+
+   ```
+   temp_demand     = compute_fan_speed(temp,     temp_target, temp_tol, min, max)
+   humidity_demand = compute_fan_speed(humidity, hum_target,  hum_tol,  min, max)
+   vpd_demand      = compute_inverted_fan_speed(vpd, vpd_target, vpd_tol, min, max)
+
+   final = clamp(max(temp_demand, humidity_demand, vpd_demand), min_speed, max_speed)
+   ```
+
+   `compute_inverted_fan_speed` is the only *new* term: it delegates to
+   `compute_fan_speed` with the speed bounds swapped, so a VPD at/below
+   `target − tolerance` yields `max_speed` and a VPD at/above `target + tolerance`
+   yields `min_speed`. A sensor that is missing or unavailable drops its term from
+   the maximum; if none of the three sensors read, the tick is a no-op.
+
+4. **Stage-aware VPD targets are honored** via the shared
+   `resolve_stage_vpd_target` when `stage_vpd_enabled` is set, exactly like
+   circulation — including day/night resolution and per-stage overrides.
+
+5. **Speed dispatch is per entity domain.** A `fan` entity receives the final
+   speed as a percentage (`fan.set_percentage`). A `switch` or `input_boolean`
+   exhaust device is turned **on** when the final speed exceeds `min_speed` and
+   **off** otherwise. The controller is a no-op when `enabled=False` or no
+   exhaust entities are configured, and it restarts cleanly when the
+   `configure_exhaust_fan` service rewrites the config.
+
+## Scope
+
+This slice deliberately implements **only** the combined-demand regulation and
+the per-domain dispatch. Two adjacent concerns are handled by separate slices and
+are **out of scope here**, even though `ExhaustFanConfig` already carries fields
+for them:
+
+- the **source-air gate** (skip/limit exhaust when the lung-room / source air is
+  colder than `minimum_source_air_temperature`), and
+- the **critical-temperature override** (`critical_temp_low` /
+  `critical_temp_high` / `critical_temp_hysteresis`).
+
+## Consequences
+
+- One implementation of the fan band math, shared by circulation and exhaust;
+  fixing or extending it happens in one place.
+- Exhaust responds to the worst of heat, humidity, and saturation without the
+  grower choosing a mode, which matches how an evacuation fan is actually used.
+- The inverted VPD term is a thin, separately unit-tested helper, so the
+  "more exhaust when it's humid" rule is pinned by its own tests rather than
+  buried in the controller.
+
+## Why Not
+
+- **Reuse the circulation single-mode model** — forces the grower to pick one
+  stress variable for a fan whose purpose is to react to all of them.
+- **Sum the three terms instead of taking the max** — would push the fan past the
+  level any single condition justifies and make the band bounds meaningless.
+- **A second copy of `compute_fan_speed` for inversion** — duplicates the band
+  math; swapping the speed bounds on the existing helper expresses the inversion
+  with no new arithmetic.
+- **Implement the source-air gate and critical-temp override here too** — larger,
+  separately testable safety behaviors; bundling them would blur this slice's
+  combined-demand contract.
+
+[#473]: https://github.com/Venosta-web/growspace_manager/issues/473

--- a/tests/core/test_exhaust_fan_demand.py
+++ b/tests/core/test_exhaust_fan_demand.py
@@ -1,0 +1,77 @@
+"""Unit tests for the exhaust fan demand pure functions."""
+
+import pytest
+
+from custom_components.growspace_manager.domain.fan_control import (
+    compute_exhaust_demand,
+    compute_inverted_fan_speed,
+)
+
+_BANDS = {
+    "temperature_target": 25.0,
+    "temperature_tolerance": 2.0,
+    "humidity_target": 60.0,
+    "humidity_tolerance": 5.0,
+    "vpd_target": 1.0,
+    "vpd_tolerance": 0.2,
+    "min_speed": 10,
+    "max_speed": 90,
+}
+
+
+@pytest.mark.parametrize(
+    ("value", "target", "tolerance", "min_speed", "max_speed", "expected"),
+    [
+        # VPD below (target - tolerance) → too humid → exhaust hard → max_speed
+        (0.5, 1.0, 0.2, 10, 90, 90),
+        # VPD at exactly lower bound → max_speed
+        (0.8, 1.0, 0.2, 10, 90, 90),
+        # VPD above (target + tolerance) → dry enough → exhaust min → min_speed
+        (1.5, 1.0, 0.2, 10, 90, 10),
+        # VPD at exactly upper bound → min_speed
+        (1.2, 1.0, 0.2, 10, 90, 10),
+        # VPD at target midpoint → midpoint speed
+        (1.0, 1.0, 0.2, 10, 90, 50),
+        # ¼ of the way up the band → ¾ exhaust (inverted)
+        (0.9, 1.0, 0.2, 0, 100, 75),
+    ],
+)
+def test_compute_inverted_fan_speed(
+    value: float,
+    target: float,
+    tolerance: float,
+    min_speed: int,
+    max_speed: int,
+    expected: int,
+) -> None:
+    """Inverted mapping: lower VPD → higher exhaust speed."""
+    assert (
+        compute_inverted_fan_speed(value, target, tolerance, min_speed, max_speed)
+        == expected
+    )
+
+
+def test_combined_demand_takes_the_highest_term() -> None:
+    """Demand is the max of the temperature, humidity and inverted-VPD terms.
+
+    Hot tent (temp above band → 90), comfortable humidity (at target → 50),
+    dry VPD (above band → inverted min → 10): the temperature term wins.
+    """
+    assert compute_exhaust_demand(30.0, 60.0, 1.5, **_BANDS) == 90
+
+
+def test_combined_demand_vpd_inversion_can_dominate() -> None:
+    """A too-humid VPD (below target) drives demand even when temp/humidity are calm."""
+    # temp at target → 50, humidity at target → 50, vpd well below band → 90
+    assert compute_exhaust_demand(25.0, 60.0, 0.5, **_BANDS) == 90
+
+
+def test_combined_demand_skips_missing_terms() -> None:
+    """A None reading drops that term from the max; remaining terms still count."""
+    # No temperature reading; humidity above band → 90 should still win
+    assert compute_exhaust_demand(None, 70.0, 1.5, **_BANDS) == 90
+
+
+def test_combined_demand_all_missing_returns_none() -> None:
+    """No readings at all → no demand to compute."""
+    assert compute_exhaust_demand(None, None, None, **_BANDS) is None

--- a/tests/core/test_services_environment.py
+++ b/tests/core/test_services_environment.py
@@ -1,6 +1,6 @@
 """Tests for the environment service handlers."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -384,6 +384,7 @@ async def test_handle_configure_exhaust_fan_success(
     mock_gs.name = "Test GS"
     mock_gs.environment_config = EnvironmentConfig()
     mock_coordinator.growspaces = {growspace_id: mock_gs}
+    mock_coordinator._subsystem_manager.get_exhaust_fan_controller.return_value = None
 
     mock_call.data = {
         "growspace_id": growspace_id,
@@ -418,6 +419,46 @@ async def test_handle_configure_exhaust_fan_success(
     assert fan_cfg.critical_temp_low is None
     mock_coordinator.async_commit.assert_awaited_once()
     mock_coordinator.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_configure_exhaust_fan_restarts_controller(
+    mock_hass: MagicMock, mock_coordinator: MagicMock, mock_call: MagicMock
+) -> None:
+    """Configuring the exhaust fan restarts a running controller."""
+    growspace_id = "gs1"
+    mock_gs = MagicMock()
+    mock_gs.name = "Test GS"
+    mock_gs.environment_config = EnvironmentConfig()
+    mock_coordinator.growspaces = {growspace_id: mock_gs}
+    fan_coord = MagicMock()
+    fan_coord.async_restart = AsyncMock()
+    mock_coordinator._subsystem_manager.get_exhaust_fan_controller.return_value = (
+        fan_coord
+    )
+
+    mock_call.data = {"growspace_id": growspace_id, "enabled": True}
+
+    await handle_configure_exhaust_fan(mock_hass, mock_coordinator, mock_call)
+    fan_coord.async_restart.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_configure_exhaust_fan_no_fan_controller(
+    mock_hass: MagicMock, mock_coordinator: MagicMock, mock_call: MagicMock
+) -> None:
+    """Configuring the exhaust fan is a no-op for restart when no controller exists."""
+    growspace_id = "gs1"
+    mock_gs = MagicMock()
+    mock_gs.name = "Test GS"
+    mock_gs.environment_config = EnvironmentConfig()
+    mock_coordinator.growspaces = {growspace_id: mock_gs}
+    mock_coordinator._subsystem_manager.get_exhaust_fan_controller.return_value = None
+
+    mock_call.data = {"growspace_id": growspace_id, "enabled": True}
+
+    await handle_configure_exhaust_fan(mock_hass, mock_coordinator, mock_call)
+    assert mock_gs.environment_config.exhaust_fan_config.enabled is True
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_subsystem_manager.py
+++ b/tests/core/test_subsystem_manager.py
@@ -7,6 +7,9 @@ import pytest
 from custom_components.growspace_manager.circulation_fan_coordinator import (
     CirculationFanCoordinator,
 )
+from custom_components.growspace_manager.exhaust_fan_coordinator import (
+    ExhaustFanCoordinator,
+)
 from custom_components.growspace_manager.dehumidifier_coordinator import (
     DehumidifierCoordinator,
 )
@@ -225,6 +228,7 @@ async def test_circulation_fan_coordinators_setup_and_cancel(
         ("get_dehumidifier_controller", DehumidifierCoordinator),
         ("get_humidifier_controller", HumidifierCoordinator),
         ("get_circulation_fan_controller", CirculationFanCoordinator),
+        ("get_exhaust_fan_controller", ExhaustFanCoordinator),
     ],
 )
 def test_get_controller_returns_matching_instance(
@@ -247,6 +251,7 @@ def test_get_controller_returns_matching_instance(
         "get_dehumidifier_controller",
         "get_humidifier_controller",
         "get_circulation_fan_controller",
+        "get_exhaust_fan_controller",
     ],
 )
 def test_get_controller_returns_none_when_absent(

--- a/tests/integration/test_circulation_fan_coordinator.py
+++ b/tests/integration/test_circulation_fan_coordinator.py
@@ -1092,7 +1092,7 @@ def test_get_stage_vpd_target_returns_correct_value(
     )
     plant = MagicMock()
     with patch(
-        "custom_components.growspace_manager.circulation_fan_coordinator.determine_coordinator_stage",
+        "custom_components.growspace_manager.domain.fan_control.determine_coordinator_stage",
         return_value=stage,
     ):
         main_coord = _make_coordinator("gs1", env, plants=[plant])
@@ -1125,7 +1125,7 @@ async def test_stage_vpd_enabled_regulate_uses_stage_target(
 
     mock_hass.states.get.side_effect = _get_state
     with patch(
-        "custom_components.growspace_manager.circulation_fan_coordinator.determine_coordinator_stage",
+        "custom_components.growspace_manager.domain.fan_control.determine_coordinator_stage",
         return_value=PlantStage.FLOWER_MID,
     ):
         main_coord = _make_coordinator("gs1", env, plants=[MagicMock()])
@@ -1212,7 +1212,7 @@ def test_get_stage_vpd_target_override_present_uses_override(
     )
     plant = MagicMock()
     with patch(
-        "custom_components.growspace_manager.circulation_fan_coordinator.determine_coordinator_stage",
+        "custom_components.growspace_manager.domain.fan_control.determine_coordinator_stage",
         return_value=PlantStage.VEG,
     ):
         main_coord = _make_coordinator("gs1", env, plants=[plant])
@@ -1233,7 +1233,7 @@ def test_get_stage_vpd_target_override_absent_uses_default(
     )
     plant = MagicMock()
     with patch(
-        "custom_components.growspace_manager.circulation_fan_coordinator.determine_coordinator_stage",
+        "custom_components.growspace_manager.domain.fan_control.determine_coordinator_stage",
         return_value=PlantStage.VEG,
     ):
         main_coord = _make_coordinator("gs1", env, plants=[plant])
@@ -1270,7 +1270,7 @@ def test_get_stage_vpd_target_unknown_stage_falls_back_to_vpd_target(
     mock_stage = MagicMock()
     mock_stage.value = "non_existent_stage"
     with patch(
-        "custom_components.growspace_manager.circulation_fan_coordinator.determine_coordinator_stage",
+        "custom_components.growspace_manager.domain.fan_control.determine_coordinator_stage",
         return_value=mock_stage,
     ):
         main_coord = _make_coordinator("gs1", env, plants=[plant])

--- a/tests/integration/test_exhaust_fan_coordinator.py
+++ b/tests/integration/test_exhaust_fan_coordinator.py
@@ -1,0 +1,368 @@
+"""Integration tests for ExhaustFanCoordinator."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.growspace_manager.exhaust_fan_coordinator import (
+    ExhaustFanCoordinator,
+)
+from custom_components.growspace_manager.models import EnvironmentConfig
+from custom_components.growspace_manager.models.growspace import ExhaustFanConfig
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture
+def mock_hass() -> MagicMock:
+    """Return mock HomeAssistant."""
+    hass = MagicMock(spec=HomeAssistant)
+    hass.states = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    return hass
+
+
+@pytest.fixture
+def mock_track_time_interval():
+    """Patch async_track_time_interval and capture the registered callback."""
+    with patch(
+        "custom_components.growspace_manager.exhaust_fan_coordinator.async_track_time_interval"
+    ) as mock:
+        mock.return_value = MagicMock()
+        yield mock
+
+
+def _make_env_config(
+    *,
+    enabled: bool = True,
+    temperature_sensors: list[str] | None = None,
+    humidity_sensors: list[str] | None = None,
+    vpd_sensors: list[str] | None = None,
+    light_sensors: list[str] | None = None,
+    exhaust_fan_entities: list[str] | None = None,
+    temperature_target: float = 25.0,
+    temperature_tolerance: float = 2.0,
+    humidity_target: float = 60.0,
+    humidity_tolerance: float = 5.0,
+    vpd_target: float = 1.0,
+    vpd_tolerance: float = 0.2,
+    min_speed: int = 10,
+    max_speed: int = 90,
+    stage_vpd_enabled: bool = False,
+    stage_vpd_overrides: dict[str, dict[str, float]] | None = None,
+) -> EnvironmentConfig:
+    fan_cfg = ExhaustFanConfig(
+        enabled=enabled,
+        min_speed=min_speed,
+        max_speed=max_speed,
+        temperature_target=temperature_target,
+        temperature_tolerance=temperature_tolerance,
+        humidity_target=humidity_target,
+        humidity_tolerance=humidity_tolerance,
+        vpd_target=vpd_target,
+        vpd_tolerance=vpd_tolerance,
+        stage_vpd_enabled=stage_vpd_enabled,
+        stage_vpd_overrides=stage_vpd_overrides or {},
+    )
+    return EnvironmentConfig(
+        temperature_sensors=temperature_sensors
+        if temperature_sensors is not None
+        else ["sensor.temperature"],
+        humidity_sensors=humidity_sensors
+        if humidity_sensors is not None
+        else ["sensor.humidity"],
+        vpd_sensors=vpd_sensors if vpd_sensors is not None else ["sensor.vpd"],
+        light_sensors=light_sensors if light_sensors is not None else [],
+        exhaust_fan_entities=exhaust_fan_entities
+        if exhaust_fan_entities is not None
+        else ["fan.exhaust"],
+        exhaust_fan_config=fan_cfg,
+    )
+
+
+def _make_coordinator(
+    growspace_id: str,
+    env_config: EnvironmentConfig,
+    plants: list | None = None,
+) -> MagicMock:
+    coord = MagicMock()
+    gs = MagicMock()
+    gs.environment_config = env_config
+    coord.growspaces = {growspace_id: gs}
+    coord.services.growspaces.get_growspace_plants.return_value = plants or []
+    return coord
+
+
+def _state(value: str) -> MagicMock:
+    state = MagicMock()
+    state.state = value
+    return state
+
+
+def _states_from(mapping: dict[str, str]):
+    def _get(entity_id: str):
+        if entity_id in mapping:
+            return _state(mapping[entity_id])
+        return None
+
+    return _get
+
+
+# ---------------------------------------------------------------------------
+# async_setup / lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_async_setup_starts_tick_when_enabled(
+    mock_hass: MagicMock, mock_track_time_interval: MagicMock
+) -> None:
+    """Enabled config with exhaust entities starts the polling tick."""
+    env = _make_env_config(enabled=True)
+    coord = ExhaustFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord.async_setup()
+    mock_track_time_interval.assert_called_once()
+
+
+async def test_async_setup_skips_when_disabled(
+    mock_hass: MagicMock, mock_track_time_interval: MagicMock
+) -> None:
+    """Disabled config does not start the tick."""
+    env = _make_env_config(enabled=False)
+    coord = ExhaustFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord.async_setup()
+    mock_track_time_interval.assert_not_called()
+
+
+async def test_async_setup_skips_when_no_exhaust_entities(
+    mock_hass: MagicMock, mock_track_time_interval: MagicMock
+) -> None:
+    """No exhaust entities configured → tick is not started."""
+    env = _make_env_config(enabled=True, exhaust_fan_entities=[])
+    coord = ExhaustFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord.async_setup()
+    mock_track_time_interval.assert_not_called()
+
+
+async def test_unload_cancels_tick(
+    mock_hass: MagicMock, mock_track_time_interval: MagicMock
+) -> None:
+    """Unload cancels the registered tick."""
+    cancel_mock = MagicMock()
+    mock_track_time_interval.return_value = cancel_mock
+    env = _make_env_config(enabled=True)
+    coord = ExhaustFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord.async_setup()
+    coord.unload()
+    cancel_mock.assert_called_once()
+    assert coord._remove_tick is None
+
+
+async def test_async_restart_restarts_tick(
+    mock_hass: MagicMock, mock_track_time_interval: MagicMock
+) -> None:
+    """Restart stops then starts the tick again under the new config."""
+    cancel_mock = MagicMock()
+    mock_track_time_interval.return_value = cancel_mock
+    env = _make_env_config(enabled=True)
+    coord = ExhaustFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord.async_setup()
+    await coord.async_restart()
+    cancel_mock.assert_called_once()
+    assert mock_track_time_interval.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Combined demand + dispatch
+# ---------------------------------------------------------------------------
+
+
+async def test_fan_entity_driven_by_percentage(mock_hass: MagicMock) -> None:
+    """A fan entity receives the combined demand as a percentage."""
+    env = _make_env_config(exhaust_fan_entities=["fan.exhaust"])
+    mock_hass.states.get.side_effect = _states_from(
+        {
+            "sensor.temperature": "30.0",  # hot → temp term = max_speed (90)
+            "sensor.humidity": "60.0",
+            "sensor.vpd": "1.0",
+        }
+    )
+    coord = ExhaustFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord._async_regulate()
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "fan",
+        "set_percentage",
+        {ATTR_ENTITY_ID: "fan.exhaust", "percentage": 90},
+        blocking=False,
+    )
+
+
+async def test_switch_entity_turned_on_above_min_speed(mock_hass: MagicMock) -> None:
+    """A switch device is turned on when demand exceeds min_speed."""
+    env = _make_env_config(exhaust_fan_entities=["switch.exhaust"])
+    mock_hass.states.get.side_effect = _states_from(
+        {
+            "sensor.temperature": "30.0",  # demand = 90 > min_speed (10)
+            "sensor.humidity": "60.0",
+            "sensor.vpd": "1.0",
+        }
+    )
+    coord = ExhaustFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord._async_regulate()
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "switch",
+        "turn_on",
+        {ATTR_ENTITY_ID: "switch.exhaust"},
+        blocking=False,
+    )
+
+
+async def test_switch_entity_turned_off_at_min_speed(mock_hass: MagicMock) -> None:
+    """A switch device is turned off when demand is at the min_speed floor."""
+    env = _make_env_config(exhaust_fan_entities=["switch.exhaust"])
+    mock_hass.states.get.side_effect = _states_from(
+        {
+            "sensor.temperature": "20.0",  # cool → temp term = min_speed
+            "sensor.humidity": "50.0",  # dry → humidity term = min_speed
+            "sensor.vpd": "1.5",  # high vpd → inverted = min_speed
+        }
+    )
+    coord = ExhaustFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord._async_regulate()
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "switch",
+        "turn_off",
+        {ATTR_ENTITY_ID: "switch.exhaust"},
+        blocking=False,
+    )
+
+
+async def test_input_boolean_entity_turned_on_above_min_speed(
+    mock_hass: MagicMock,
+) -> None:
+    """An input_boolean device is driven on/off like a switch."""
+    env = _make_env_config(exhaust_fan_entities=["input_boolean.exhaust"])
+    mock_hass.states.get.side_effect = _states_from(
+        {
+            "sensor.temperature": "30.0",
+            "sensor.humidity": "60.0",
+            "sensor.vpd": "1.0",
+        }
+    )
+    coord = ExhaustFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord._async_regulate()
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "input_boolean",
+        "turn_on",
+        {ATTR_ENTITY_ID: "input_boolean.exhaust"},
+        blocking=False,
+    )
+
+
+async def test_no_sensor_readings_skips_dispatch(mock_hass: MagicMock) -> None:
+    """All sensors unavailable → no service call, no exception."""
+    env = _make_env_config()
+    mock_hass.states.get.side_effect = _states_from(
+        {
+            "sensor.temperature": STATE_UNAVAILABLE,
+            "sensor.humidity": STATE_UNAVAILABLE,
+            "sensor.vpd": STATE_UNAVAILABLE,
+        }
+    )
+    coord = ExhaustFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord._async_regulate()
+    mock_hass.services.async_call.assert_not_called()
+
+
+async def test_disabled_config_skips_dispatch(mock_hass: MagicMock) -> None:
+    """A disabled controller does nothing even if regulate is invoked."""
+    env = _make_env_config(enabled=False)
+    mock_hass.states.get.side_effect = _states_from(
+        {"sensor.temperature": "30.0", "sensor.humidity": "60.0", "sensor.vpd": "1.0"}
+    )
+    coord = ExhaustFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord._async_regulate()
+    mock_hass.services.async_call.assert_not_called()
+
+
+async def test_all_exhaust_entities_receive_dispatch(mock_hass: MagicMock) -> None:
+    """Every configured exhaust entity is driven, dispatched by its domain."""
+    env = _make_env_config(exhaust_fan_entities=["fan.exhaust", "switch.damper"])
+    mock_hass.states.get.side_effect = _states_from(
+        {"sensor.temperature": "30.0", "sensor.humidity": "60.0", "sensor.vpd": "1.0"}
+    )
+    coord = ExhaustFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord._async_regulate()
+    assert mock_hass.services.async_call.await_count == 2
+    domains = {call[0][0] for call in mock_hass.services.async_call.await_args_list}
+    assert domains == {"fan", "switch"}
+
+
+# ---------------------------------------------------------------------------
+# Stage-aware VPD
+# ---------------------------------------------------------------------------
+
+
+async def test_stage_vpd_enabled_uses_stage_target(mock_hass: MagicMock) -> None:
+    """With stage_vpd_enabled, the VPD term uses the resolved stage target.
+
+    flower_late day target is 1.25; a VPD reading of 1.25 sits exactly at the
+    inverted-VPD midpoint → demand of 50 (between min 10 and max 90).
+    """
+    env = _make_env_config(
+        stage_vpd_enabled=True,
+        exhaust_fan_entities=["fan.exhaust"],
+        # Keep temp/humidity terms at the floor so VPD dominates.
+        temperature_target=25.0,
+        humidity_target=60.0,
+    )
+    mock_hass.states.get.side_effect = _states_from(
+        {
+            "sensor.temperature": "20.0",  # min term
+            "sensor.humidity": "50.0",  # min term
+            "sensor.vpd": "1.25",  # at flower_late day target → inverted midpoint
+        }
+    )
+    coord = ExhaustFanCoordinator(
+        mock_hass,
+        MagicMock(),
+        "gs1",
+        _make_coordinator("gs1", env, plants=[MagicMock()]),
+    )
+    with patch(
+        "custom_components.growspace_manager.exhaust_fan_coordinator.resolve_stage_vpd_target",
+        return_value=1.25,
+    ) as mock_resolve:
+        await coord._async_regulate()
+
+    mock_resolve.assert_called_once()
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "fan",
+        "set_percentage",
+        {ATTR_ENTITY_ID: "fan.exhaust", "percentage": 50},
+        blocking=False,
+    )


### PR DESCRIPTION
Implements the `ExhaustFanController` (#475) on top of its prerequisite refactor (#473), branched off and targeting **`prerelease`**.

## #473 — shared fan-control helpers (enabling refactor)
Extracts `compute_fan_speed`, `evaluate_temp_override`, `compute_wind_offset`, `FAN_VPD_STAGE_DEFAULTS`, and the stage-aware VPD target resolution out of `circulation_fan_coordinator.py` into a coordinator-free `domain/fan_control.py`. The circulation coordinator re-exports them, so existing importers and unit tests pass unchanged (only the `determine_coordinator_stage` patch target moved with the code). No behavioral change to circulation fan control.

## #475 — combined-demand exhaust controller
- `ExhaustFanController` registered in `SubsystemManager` as an `EnvironmentController` with a `get_exhaust_fan_controller` accessor, on the same fixed 10 s tick.
- Demand = `clamp(max(temperature, humidity, vpd_inverted), min_speed, max_speed)`, reusing the shared helpers. The VPD term is inverted via the new `compute_inverted_fan_speed` (more exhaust when VPD is *below* target / too humid). A missing/unavailable sensor drops its term; all-missing is a no-op.
- Stage-aware VPD target resolution honored when `stage_vpd_enabled`.
- Speed dispatch by entity domain: `fan` → `set_percentage`; `switch`/`input_boolean` → `turn_on` above `min_speed`, `turn_off` otherwise.
- No-op when disabled or no exhaust entities; `configure_exhaust_fan` now restarts the controller.
- Unit tests for the combined-demand math (incl. VPD inversion) and per-domain dispatch.

**Out of scope (separate slices, per ADR 0018):** the source-air gate and the critical-temperature override, even though `ExhaustFanConfig` already carries fields for them.

## Docs
Adds `docs/adr/0018-exhaust-fan-combined-demand.md` and the CONTEXT.md *Exhaust Fan Controller* / *Exhaust Demand* sections referenced by the issue.

## Testing
`pytest tests/ -q` → **4496 passed, 1 failed**. The single failure (`test_stage_days_max_across_plants`) is a pre-existing `date.today()` day-boundary flake in the environment-state assembler, untouched by this PR (no files here touch `calculate_days_since`/the assembler). Targeted fan/exhaust/subsystem/service/core-init suites: all green. `ruff check`/`ruff format` clean on changed source.

> Note: merging into `prerelease` (not the `dev` default) won't auto-close #473/#475 via the keywords — they'll close when `prerelease` merges down or manually.

Closes #473
Closes #475