### PR TITLE
feat(ai): feed aggregate water use into growspace AI context

### DIFF
--- a/custom_components/growspace_manager/services/ai_assistant.py
+++ b/custom_components/growspace_manager/services/ai_assistant.py
@@ -16,6 +16,9 @@ from custom_components.growspace_manager.const import (
     PlantStage,
 )
 from custom_components.growspace_manager.domain import calculate_days_in_stage
+from custom_components.growspace_manager.domain.water_aggregation import (
+    compute_growspace_water,
+)
 from custom_components.growspace_manager.schemas import (
     ANALYZE_ALL_GROWSPACES_SCHEMA,
     ASK_GROW_ADVICE_SCHEMA,
@@ -118,12 +121,25 @@ class GrowAssistant:
         # Strain analytics
         strain_analytics = self._get_strain_analytics(plants)
 
+        # Canonical [[Aggregate Water Use]] — manual + tank-derived-or-pump
+        # (ADR-0017). Same helper and facade the briefing Water Use KPI uses, so
+        # the AI context and the briefing report the same number.
+        trackers = self.coordinator.services.growspaces.get_all_trackers_for_growspace(
+            growspace_id
+        ).values()
+        water = compute_growspace_water(growspace, trackers)
+
         return {
             "growspace": {
                 "id": growspace_id,
                 "name": growspace.name,
                 "size": f"{growspace.rows}x{growspace.plants_per_row}",
                 "total_plants": len(plants),
+            },
+            "water": {
+                "today_liters": water.today,
+                "cycle_liters": water.cycle,
+                "source": water.source,
             },
             "environment": {
                 "sensors": sensor_data,
@@ -348,6 +364,17 @@ class GrowAssistant:
         lines.extend(self._format_sensor_data(data["environment"]["sensors"]))
         lines.append("")
 
+        # Aggregate water use today (manual + tank-derived-or-pump, ADR-0017).
+        # Optional like the other sections: callers that assemble a partial
+        # context (e.g. the vision checkup seam) may omit it.
+        water = data.get("water")
+        if water:
+            lines.append(
+                f"WATER USE TODAY: {water['today_liters']} L "
+                f"(cycle {water['cycle_liters']} L)"
+            )
+            lines.append("")
+
         # Add Bayesian analysis
         lines.extend(self._format_analysis_data(data["analysis"]))
 
@@ -356,7 +383,9 @@ class GrowAssistant:
 
         # Add strain-specific context (breeder notes, preferences)
         if data["plants"]["count"] > 0:
-            plants = self.coordinator._data_repository.get_growspace_plants(data["growspace"]["id"])
+            plants = self.coordinator._data_repository.get_growspace_plants(
+                data["growspace"]["id"]
+            )
             strain_context = self._get_strain_specific_context(plants)
             if strain_context:
                 lines.append("STRAIN-SPECIFIC GUIDANCE:")
@@ -495,7 +524,12 @@ class GrowAssistant:
             _LOGGER.error("Error getting AI advice: %s", err)
             if any(
                 m in str(err)
-                for m in ("429", "Too Many Requests", "RESOURCE_EXHAUSTED", "resource_exhausted")
+                for m in (
+                    "429",
+                    "Too Many Requests",
+                    "RESOURCE_EXHAUSTED",
+                    "resource_exhausted",
+                )
             ):
                 raise ServiceValidationError("rate_limited") from err
             # Fallback to context if AI fails
@@ -544,7 +578,12 @@ class GrowAssistant:
             err_code = getattr(result.response, "error_code", "") or ""
             if any(
                 m in speech_text or m.lower() in err_code.lower()
-                for m in ("429", "Too Many Requests", "RESOURCE_EXHAUSTED", "resource_exhausted")
+                for m in (
+                    "429",
+                    "Too Many Requests",
+                    "RESOURCE_EXHAUSTED",
+                    "resource_exhausted",
+                )
             ):
                 raise ServiceValidationError("rate_limited")
 
@@ -552,7 +591,9 @@ class GrowAssistant:
                 response = speech_text
                 if max_length and len(response) > max_length:
                     response = response[:max_length].rsplit(" ", 1)[0] + "..."
-                _LOGGER.info("AI assistant provided advice for growspace %s", growspace_id)
+                _LOGGER.info(
+                    "AI assistant provided advice for growspace %s", growspace_id
+                )
                 return response
 
         raise ServiceValidationError("AI assistant returned an empty response")
@@ -606,12 +647,14 @@ async def handle_analyze_all_growspaces(
     all_data = []
     issues_found = []
 
-    for growspace_id in (gs.id for gs in coordinator._data_repository.get_all_growspaces()):
+    for growspace_id in (
+        gs.id for gs in coordinator._data_repository.get_all_growspaces()
+    ):
         try:
             data = assistant.gather_growspace_data(growspace_id)
             all_data.append(data)
             issues_found.extend(_analyze_growspace_issues(data))
-        except Exception as err :  # noqa: BLE001
+        except Exception as err:  # noqa: BLE001
             _LOGGER.warning("Error analyzing growspace %s: %s", growspace_id, err)
 
     # Build comprehensive summary
@@ -669,7 +712,7 @@ async def handle_analyze_all_growspaces(
                 "growspaces_analyzed": len(all_data),
             }
 
-    except Exception as err :  # noqa: BLE001
+    except Exception as err:  # noqa: BLE001
         _LOGGER.error("Error analyzing all growspaces: %s", err)
         # Fallback to summary
         return {
@@ -769,7 +812,7 @@ async def handle_strain_recommendation(
         try:
             gs_data = assistant.gather_growspace_data(growspace_id)
             growspace_context = f"\nTARGET GROWSPACE: {gs_data['growspace']['name']} ({gs_data['growspace']['size']})"
-        except Exception as e :  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001
             _LOGGER.warning(
                 "Failed to gather growspace data for strain recommendation for growspace %s: %s",
                 growspace_id,
@@ -815,7 +858,7 @@ async def handle_strain_recommendation(
                 "strains_analyzed": len(all_strains),
             }
 
-    except Exception as err :  # noqa: BLE001
+    except Exception as err:  # noqa: BLE001
         _LOGGER.error("Error getting strain recommendation: %s", err)
         return {
             "response": f"Error getting strain recommendation: {err}\n\nStrain Data:\n\n{context}",

--- a/tests/integration/test_ai_assistant.py
+++ b/tests/integration/test_ai_assistant.py
@@ -5,7 +5,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from custom_components.growspace_manager.const import CONF_AI_ENABLED, CONF_ASSISTANT_ID
-from custom_components.growspace_manager.models import EnvironmentConfig, Growspace
+from custom_components.growspace_manager.domain.water_aggregation import (
+    compute_growspace_water,
+)
+from custom_components.growspace_manager.models import (
+    EnvironmentConfig,
+    Growspace,
+    IrrigationTank,
+)
 from custom_components.growspace_manager.services.ai_assistant import (
     GrowAssistant,
     _analyze_growspace_issues,
@@ -18,6 +25,7 @@ from custom_components.growspace_manager.services.ai_assistant import (
 )
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.util import dt as dt_util
 
 GROWSPACE_ID = "test_growspace"
 GROWSPACE_NAME = "Test Growspace"
@@ -58,6 +66,10 @@ def mock_coordinator() -> MagicMock:
     # 4. Attach repositories to coordinator facade
     coordinator._data_repository = data_repo
     coordinator.plants = plant_repo
+
+    # Water aggregation reads tank trackers via the growspaces facade; default to
+    # no trackers (measured mode) so compute_growspace_water has an iterable.
+    coordinator.services.growspaces.get_all_trackers_for_growspace.return_value = {}
 
     coordinator.options = {
         "ai_settings": {
@@ -217,6 +229,120 @@ def testgather_growspace_data_missing(
         assistant.gather_growspace_data("missing_id")
 
 
+def test_gather_growspace_data_includes_aggregate_water(
+    assistant: GrowAssistant, mock_coordinator: MagicMock
+) -> None:
+    """gather_growspace_data carries today's aggregate water from the shared helper."""
+    growspace = mock_coordinator._data_repository.get_growspace(GROWSPACE_ID)
+    today = dt_util.now().date().isoformat()
+    growspace.water_usage.daily_readings = [
+        {"date": today, "liters": 3.5, "source": "manual"}
+    ]
+
+    data = assistant.gather_growspace_data(GROWSPACE_ID)
+
+    trackers = mock_coordinator.services.growspaces.get_all_trackers_for_growspace(
+        GROWSPACE_ID
+    ).values()
+    expected = compute_growspace_water(growspace, trackers).today
+    assert expected == 3.5
+    assert data["water"]["today_liters"] == expected
+
+
+def test_format_context_data_renders_water_use(
+    assistant: GrowAssistant, mock_coordinator: MagicMock
+) -> None:
+    """_format_context_data renders the aggregate water figure into the context."""
+    growspace = mock_coordinator._data_repository.get_growspace(GROWSPACE_ID)
+    today = dt_util.now().date().isoformat()
+    growspace.water_usage.daily_readings = [
+        {"date": today, "liters": 4.2, "source": "manual"}
+    ]
+
+    data = assistant.gather_growspace_data(GROWSPACE_ID)
+    context = assistant._format_context_data(data)
+
+    assert "WATER USE TODAY: 4.2" in context
+
+
+def _tank_tracker(today_liters: float) -> MagicMock:
+    """Build a TankWaterTracker stand-in returning fixed liter figures."""
+    tracker = MagicMock()
+    tracker.get_total_liters_today.return_value = today_liters
+    tracker.get_total_liters_since.return_value = today_liters
+    return tracker
+
+
+@pytest.mark.parametrize(
+    ("environment_config", "daily_readings", "trackers"),
+    [
+        # manual-only: explicit watering event, measured branch
+        (
+            EnvironmentConfig(),
+            [
+                {
+                    "date": dt_util.now().date().isoformat(),
+                    "liters": 2.0,
+                    "source": "manual",
+                }
+            ],
+            {},
+        ),
+        # pump-only: pump-cycle estimate written through, measured branch
+        (
+            EnvironmentConfig(),
+            [
+                {
+                    "date": dt_util.now().date().isoformat(),
+                    "liters": 7.5,
+                    "source": "pump_estimate",
+                }
+            ],
+            {},
+        ),
+        # tank-derived: reservoir-level inference adds onto manual
+        (
+            EnvironmentConfig(
+                irrigation_tanks=[
+                    IrrigationTank(sensor_entity="sensor.tank", volume_liters=50.0)
+                ]
+            ),
+            [
+                {
+                    "date": dt_util.now().date().isoformat(),
+                    "liters": 1.0,
+                    "source": "manual",
+                }
+            ],
+            {"sensor.tank": _tank_tracker(5.0)},
+        ),
+    ],
+    ids=["manual_only", "pump_only", "tank_derived"],
+)
+def test_aggregate_water_context_across_modes(
+    assistant: GrowAssistant,
+    mock_coordinator: MagicMock,
+    environment_config: EnvironmentConfig,
+    daily_readings: list[dict[str, object]],
+    trackers: dict[str, MagicMock],
+) -> None:
+    """The AI water context matches the helper across all three water modes."""
+    growspace = mock_coordinator._data_repository.get_growspace(GROWSPACE_ID)
+    growspace.environment_config = environment_config
+    growspace.water_usage.daily_readings = daily_readings
+    mock_coordinator.services.growspaces.get_all_trackers_for_growspace.return_value = (
+        trackers
+    )
+
+    expected = compute_growspace_water(growspace, trackers.values()).today
+
+    data = assistant.gather_growspace_data(GROWSPACE_ID)
+    context = assistant._format_context_data(data)
+
+    assert data["water"]["today_liters"] == expected
+    assert f"WATER USE TODAY: {expected}" in context
+
+
 async def testgather_growspace_data_with_plants(
     assistant: GrowAssistant,
     mock_coordinator: MagicMock,
@@ -238,12 +364,19 @@ async def testgather_growspace_data_with_plants(
 async def test_gather_growspace_data_legacy_dict(
     assistant: GrowAssistant, mock_coordinator: MagicMock, mock_hass: MagicMock
 ) -> None:
-    """Test gathering data with legacy dict environment config."""
+    """Test gathering data with legacy dict-sourced environment config.
+
+    Storage deserializes a stored options dict into an EnvironmentConfig via
+    ``EnvironmentConfig.from_dict`` (storage_manager.py:347), so the growspace
+    always carries the dataclass at runtime — mirror that here.
+    """
     gs = mock_coordinator._data_repository.get_growspace(GROWSPACE_ID)
-    gs.environment_config = {
-        "temperature_sensor": "sensor.legacy_temp",
-        "humidity_sensor": "sensor.legacy_humidity",
-    }
+    gs.environment_config = EnvironmentConfig.from_dict(
+        {
+            "temperature_sensor": "sensor.legacy_temp",
+            "humidity_sensor": "sensor.legacy_humidity",
+        }
+    )
 
     def side_effect(entity_id):
         if entity_id == "sensor.legacy_temp":

--- a/tests/services/test_growspace_services.py
+++ b/tests/services/test_growspace_services.py
@@ -7,6 +7,7 @@ import pytest
 from custom_components.growspace_manager.const import CONF_AI_ENABLED, CONF_ASSISTANT_ID
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from custom_components.growspace_manager.exceptions import GrowspaceError
+from custom_components.growspace_manager.models import EnvironmentConfig, Growspace
 from custom_components.growspace_manager.services.ai_assistant import (
     handle_ask_grow_advice,
 )
@@ -232,14 +233,17 @@ async def test_handle_ask_grow_advice_success(
         "ai_settings": {CONF_AI_ENABLED: True, CONF_ASSISTANT_ID: "test_agent"},
     }
     mock_call.data = {"growspace_id": "gs1", "user_query": "How are things?"}
-    # Mock growspace with environment config
-    mock_gs = MagicMock()
-    mock_gs.environment_config = {
-        "temperature_sensor": "sensor.temp",
-        "humidity_sensor": None,
-        "vpd_sensor": None,
-        "co2_sensor": None,
-    }
+    # Real growspace: env_config is always an EnvironmentConfig dataclass at
+    # runtime (storage deserializes it), which the water aggregation helper reads.
+    mock_gs = Growspace(
+        id="gs1",
+        name="Test Growspace",
+        environment_config=EnvironmentConfig(temperature_sensor="sensor.temp"),
+    )
+    # Frozen to 2026-01-12 by the conftest freeze_time fixture.
+    mock_gs.water_usage.daily_readings = [
+        {"date": "2026-01-12", "liters": 6.5, "source": "manual"}
+    ]
     mock_coordinator.growspaces = {"gs1": mock_gs}
 
     # Mock environment sensors
@@ -274,6 +278,8 @@ async def test_handle_ask_grow_advice_success(
     assert "25 °C" in prompt
     assert "STRESS DETECTED" in prompt
     assert "Temp high" in prompt
+    # Aggregate water use reaches the LLM prompt end-to-end (issue #472)
+    assert "WATER USE TODAY: 6.5" in prompt
 
 
 @pytest.mark.asyncio
@@ -338,14 +344,13 @@ async def test_handle_ask_grow_advice_llm_failure(
         "ai_settings": {CONF_AI_ENABLED: True, CONF_ASSISTANT_ID: "test_agent"},
     }
     mock_call.data = {"growspace_id": "gs1"}
-    # Mock growspace with environment config
-    mock_gs = MagicMock()
-    mock_gs.environment_config = {
-        "temperature_sensor": "sensor.temp",
-        "humidity_sensor": None,
-        "vpd_sensor": None,
-        "co2_sensor": None,
-    }
+    # Real growspace: env_config is always an EnvironmentConfig dataclass at
+    # runtime (storage deserializes it), which the water aggregation helper reads.
+    mock_gs = Growspace(
+        id="gs1",
+        name="Test Growspace",
+        environment_config=EnvironmentConfig(temperature_sensor="sensor.temp"),
+    )
     mock_coordinator.growspaces = {"gs1": mock_gs}
 
     # Mock LLM returns None or empty response


### PR DESCRIPTION
Closes #472

## What

Feeds the AI assistant's growspace context with the canonical **Aggregate Water Use** so Growmaster chat and briefings reason about water from all three sources (manual, tank-derived, pump-estimate) — not just whichever single source happened to be wired before.

`gather_growspace_data` now computes today's (and cycle) aggregate via the shared `compute_growspace_water(...)` helper (ADR-0017) and `_format_context_data` renders it into the LLM prompt as `WATER USE TODAY: <n> L (cycle <n> L)`.

## Why it matches the briefing KPI

It uses the **identical path** the briefing Water Use KPI uses:
`coordinator.services.growspaces.get_all_trackers_for_growspace(id).values()` → `compute_growspace_water(growspace, trackers)`. Same accessor, same helper, same `.values()` — so chat and briefings report the same number by construction.

The formatted line lands in the real prompt: `get_ai_advice` builds `full_prompt` from `_format_context_data(data)` before sending to `_execute_conversation`.

## Acceptance criteria

- [x] AI growspace context includes today's aggregate water via the shared helper
- [x] Number agrees with the briefing Water Use KPI for the same growspace
- [x] Works across all three modes (tank, pump-only, manual-only) — covered by a parametrized test
- [x] Tests cover the context carrying the aggregate figure; production files ruff-clean

## Tests

- `test_gather_growspace_data_includes_aggregate_water`
- `test_format_context_data_renders_water_use`
- `test_aggregate_water_context_across_modes` (parametrized: manual_only / pump_only / tank_derived)

Full suite: 4467 passed, 1 pre-existing date-dependent failure unrelated to water (`test_stage_days_max_across_plants`, confirmed via stash). Production files (`ai_assistant.py`, `water_aggregation.py`) pass `ruff check` and `ruff format --check`.

> Stacked on `feat-471-viewmodel-additive-water`; retarget to `dev` once #471 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)