### PR TITLE
feat(exhaust): round-trip exhaust_fan_config in get_data (#488)

### DIFF
--- a/custom_components/growspace_manager/presentation/growspace_view_model.py
+++ b/custom_components/growspace_manager/presentation/growspace_view_model.py
@@ -679,6 +679,7 @@ class GrowspaceViewModelBuilder:
         # Circulation fan controller config — must be included so the frontend
         # dialog re-opens with the persisted enabled state (not the default False).
         attributes["circulation_fan_config"] = asdict(env_config.circulation_fan_config)
+        attributes["exhaust_fan_config"] = asdict(env_config.exhaust_fan_config)
 
         # Vision checkup config — same reason: persisted enabled state must round-trip.
         attributes["vision_checkup_config"] = asdict(env_config.vision_checkup_config)

--- a/tests/core/snapshots/test_presentation_snapshots.ambr
+++ b/tests/core/snapshots/test_presentation_snapshots.ambr
@@ -42,6 +42,23 @@
       'electricity_cost_per_kwh': 0.0,
       'energy_sensors': list([
       ]),
+      'exhaust_fan_config': dict({
+        'critical_temp_high': None,
+        'critical_temp_hysteresis': 1.0,
+        'critical_temp_low': None,
+        'enabled': False,
+        'humidity_target': 60.0,
+        'humidity_tolerance': 5.0,
+        'max_speed': 100,
+        'min_speed': 0,
+        'stage_vpd_enabled': False,
+        'stage_vpd_overrides': dict({
+        }),
+        'temperature_target': 25.0,
+        'temperature_tolerance': 2.0,
+        'vpd_target': 1.0,
+        'vpd_tolerance': 0.2,
+      }),
       'exhaust_fan_entities': list([
       ]),
       'feed_ec_sensors': list([

--- a/tests/integration/test_growspace_view_model_coverage.py
+++ b/tests/integration/test_growspace_view_model_coverage.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -6,6 +7,7 @@ import pytest
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.models import (
     EnvironmentConfig,
+    ExhaustFanConfig,
     Growspace,
     IrrigationConfig,
     IrrigationTank,
@@ -710,6 +712,22 @@ def test_vpd_optimal_overrides_round_trips_in_environment_attributes(
 
     assert attrs["vpd_optimal_overrides"] == overrides
     assert attrs["vpd_optimal_overrides"]["flower_mid"]["day"]["low"] == 0.5
+
+
+def test_exhaust_fan_config_round_trips_in_environment_attributes(
+    hass: HomeAssistant, builder: GrowspaceViewModelBuilder
+) -> None:
+    """exhaust_fan_config must be returned by _get_environment_attributes so the dialog re-opens with saved values."""
+    env_config = EnvironmentConfig(
+        exhaust_fan_config=ExhaustFanConfig(enabled=True, max_speed=70)
+    )
+    gs = Growspace(id="gs1", name="GS1", environment_config=env_config)
+
+    attrs = builder._get_environment_attributes(gs)
+
+    assert attrs["exhaust_fan_config"] == asdict(env_config.exhaust_fan_config)
+    assert attrs["exhaust_fan_config"]["enabled"] is True
+    assert attrs["exhaust_fan_config"]["max_speed"] == 70
 
 
 def test_build_includes_subareas(

--- a/tests/integration/test_overview_attributes.py
+++ b/tests/integration/test_overview_attributes.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from custom_components.growspace_manager.models import CirculationFanConfig, VisionCheckupConfig
+from custom_components.growspace_manager.models import (
+    CirculationFanConfig,
+    ExhaustFanConfig,
+    VisionCheckupConfig,
+)
 from custom_components.growspace_manager.presentation.growspace_view_model import (
     GrowspaceViewModelBuilder,
 )
@@ -54,6 +58,7 @@ async def test_growspace_view_model_includes_temp_hum(hass) -> None:
     mock_env.humidifier_thresholds = {}
     mock_env.dehumidifier_thresholds = {}
     mock_env.circulation_fan_config = CirculationFanConfig()
+    mock_env.exhaust_fan_config = ExhaustFanConfig()
     mock_env.vision_checkup_config = VisionCheckupConfig()
 
     mock_growspace = MagicMock()
@@ -152,6 +157,7 @@ async def test_environment_attributes_includes_circulation_fan_config(hass) -> N
     mock_env.humidifier_thresholds = {}
     mock_env.dehumidifier_thresholds = {}
     mock_env.circulation_fan_config = fan_cfg
+    mock_env.exhaust_fan_config = ExhaustFanConfig()
     mock_env.vision_checkup_config = VisionCheckupConfig()
 
     mock_growspace = MagicMock()
@@ -208,6 +214,7 @@ def _make_mock_env() -> MagicMock:
     mock_env.humidifier_thresholds = {}
     mock_env.dehumidifier_thresholds = {}
     mock_env.circulation_fan_config = CirculationFanConfig()
+    mock_env.exhaust_fan_config = ExhaustFanConfig()
     mock_env.vision_checkup_config = VisionCheckupConfig()
     return mock_env
 


### PR DESCRIPTION
Closes #488

## Summary

Completes the `exhaust_fan_config` round-trip so the card panel (Venosta-web/lovelace-growspace-manager-card#319) re-seeds from the persisted config on reload.

**Gap 1 (fixed here):** `_get_environment_attributes` now serializes `exhaust_fan_config` alongside `circulation_fan_config`, so `get_data` emits the full dict via `asdict`.

**Gap 2 (already done in #478):** `handle_configure_environment` already preserves an existing `exhaust_fan_config` across its config rebuild (`services/environment.py:305-310`), with a passing regression test (`test_handle_configure_environment_preserves_exhaust_fan_config`). No change needed — left the existing implementation rather than refactoring it into the suggested `_parse_exhaust_fan_config` helper, since `configure_environment`'s schema accepts no exhaust payload and the current code already meets the AC.

## Changes

- `presentation/growspace_view_model.py`: emit `exhaust_fan_config` in env attributes
- `tests/integration/test_growspace_view_model_coverage.py`: new round-trip test (TDD red→green)
- `tests/integration/test_overview_attributes.py`: set real `ExhaustFanConfig()` on the `MagicMock` env fixtures (asdict can't serialize a Mock)
- `tests/core/snapshots/test_presentation_snapshots.ambr`: regenerated (adds only the `exhaust_fan_config` dict)

## Acceptance criteria

- [x] `get_data` environment payload includes `exhaust_fan_config` (full dict via `asdict`)
- [x] `configure_environment` preserves an existing `exhaust_fan_config` when the call omits it (already done + tested in #478)
- [x] A configure_exhaust_fan → reload round-trip returns the saved exhaust settings (test)
- [x] Card #319's round-trip AC can be marked green once this ships

## Testing

- Full suite: **4521 passed** (46 snapshots)
- Lint/format clean on changed code

🤖 Generated with [Claude Code](https://claude.com/claude-code)