### PR TITLE
feat(environment): accept and expose lst_offset in configure_environment

### DIFF
--- a/custom_components/growspace_manager/presentation/growspace_view_model.py
+++ b/custom_components/growspace_manager/presentation/growspace_view_model.py
@@ -573,6 +573,7 @@ class GrowspaceViewModelBuilder:
         attributes[CONF_TEMP_SENSORS] = env_config.temperature_sensors
         attributes[CONF_HUMIDITY_SENSORS] = env_config.humidity_sensors
         attributes[CONF_VPD_SENSORS] = env_config.vpd_sensors
+        attributes["lst_offset"] = env_config.lst_offset
 
         # New sensor arrays and scalars
         attributes["substrate_temperature_sensors"] = (

--- a/custom_components/growspace_manager/services/environment.py
+++ b/custom_components/growspace_manager/services/environment.py
@@ -298,6 +298,7 @@ async def handle_configure_environment(
         power_sensors=call.data.get(CONF_POWER_SENSORS, []),
         energy_sensors=call.data.get(CONF_ENERGY_SENSORS, []),
         electricity_cost_per_kwh=call.data.get(CONF_ELECTRICITY_COST),
+        lst_offset=call.data.get("lst_offset", -2.0),
         circulation_fan_config=_parse_fan_config(
             call.data.get("circulation_fan_config"),
             growspace.environment_config,

--- a/tests/core/snapshots/test_presentation_snapshots.ambr
+++ b/tests/core/snapshots/test_presentation_snapshots.ambr
@@ -80,6 +80,7 @@
       ]),
       'light_sensors': list([
       ]),
+      'lst_offset': -2.0,
       'lung_room_temp_sensors': list([
       ]),
       'ph_sensors': list([

--- a/tests/integration/test_growspace_view_model_coverage.py
+++ b/tests/integration/test_growspace_view_model_coverage.py
@@ -878,3 +878,27 @@ def test_substrate_payload_shot_composition_null_without_irrigation_coordinator(
         result = ViewModelBuilder(coordinator).build_serialized_growspace("gs1")
 
     assert result["irrigation"]["substrate"]["shot_composition"] is None
+
+
+def test_get_environment_attributes_includes_lst_offset(
+    hass: HomeAssistant, builder: GrowspaceViewModelBuilder
+) -> None:
+    """Test that _get_environment_attributes includes lst_offset from config."""
+    env_config = EnvironmentConfig(lst_offset=-3.5)
+    growspace = Growspace(id="gs1", name="Test", environment_config=env_config)
+
+    attrs = builder._get_environment_attributes(growspace)
+
+    assert attrs["lst_offset"] == -3.5
+
+
+def test_get_environment_attributes_includes_default_lst_offset(
+    hass: HomeAssistant, builder: GrowspaceViewModelBuilder
+) -> None:
+    """Test that _get_environment_attributes includes default lst_offset."""
+    env_config = EnvironmentConfig()
+    growspace = Growspace(id="gs1", name="Test", environment_config=env_config)
+
+    attrs = builder._get_environment_attributes(growspace)
+
+    assert attrs["lst_offset"] == -2.0

--- a/tests/services/test_environment_config.py
+++ b/tests/services/test_environment_config.py
@@ -110,3 +110,50 @@ async def test_handle_configure_environment_with_coordinates_and_tanks(
     assert updated_config.irrigation_tanks[0].sensor_entity == "sensor.tank_a_level"
     assert updated_config.irrigation_tanks[1].name == "Tank B"
     assert updated_config.irrigation_tanks[1].sensor_entity == "sensor.tank_b_level"
+
+
+@pytest.mark.asyncio
+async def test_handle_configure_environment_persists_lst_offset(
+    mock_hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+    mock_call: MagicMock,
+) -> None:
+    """Test that configure_environment stores the lst_offset from the service call."""
+    growspace_id = "gs1"
+
+    mock_gs = MagicMock()
+    mock_gs.name = "Test Growspace"
+    mock_gs.environment_config = EnvironmentConfig()
+    mock_coordinator.growspaces = {growspace_id: mock_gs}
+
+    mock_call.data = {
+        "growspace_id": growspace_id,
+        "lst_offset": -3.5,
+    }
+
+    await handle_configure_environment(mock_hass, mock_coordinator, mock_call)
+
+    assert mock_gs.environment_config.lst_offset == -3.5
+
+
+@pytest.mark.asyncio
+async def test_handle_configure_environment_defaults_lst_offset(
+    mock_hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+    mock_call: MagicMock,
+) -> None:
+    """Test that configure_environment defaults lst_offset to -2.0 when not provided."""
+    growspace_id = "gs1"
+
+    mock_gs = MagicMock()
+    mock_gs.name = "Test Growspace"
+    mock_gs.environment_config = EnvironmentConfig()
+    mock_coordinator.growspaces = {growspace_id: mock_gs}
+
+    mock_call.data = {
+        "growspace_id": growspace_id,
+    }
+
+    await handle_configure_environment(mock_hass, mock_coordinator, mock_call)
+
+    assert mock_gs.environment_config.lst_offset == -2.0


### PR DESCRIPTION
## Summary
- `configure_environment` service now accepts `lst_offset` in its payload and persists it on `EnvironmentConfig` (defaults to -2.0 when omitted)
- View model serialization includes `lst_offset` in WebSocket environment attributes so the card can read it back

## Context
Enables the Lovelace card to display a live VPD calculation with a user-adjustable leaf surface temperature offset slider in the config dialog.

## Test plan
- [x] `test_handle_configure_environment_persists_lst_offset` — custom offset stored
- [x] `test_handle_configure_environment_defaults_lst_offset` — default when not sent
- [x] `test_get_environment_attributes_includes_lst_offset` — WS payload includes custom value
- [x] `test_get_environment_attributes_includes_default_lst_offset` — WS payload includes default
- [x] Full test suite (4529 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)