### PR TITLE
feat(notifications): persist + round-trip notification settings & timed notifications

### DIFF
--- a/custom_components/growspace_manager/view_model_builder.py
+++ b/custom_components/growspace_manager/view_model_builder.py
@@ -230,6 +230,16 @@ class ViewModelBuilder:
             else None
         )
 
+        # Global notification settings ride every growspace payload so the card's
+        # Config Dialog (which seeds from the device payload) can round-trip saved
+        # values. They are global, not per-growspace, but mirror notifications_enabled
+        # in being duplicated across payloads.
+        options = self.coordinator.config_entry.options
+        serialized["notification_settings"] = options.get("notification_settings", {})
+        serialized["ai_auto_alerts"] = options.get("ai_settings", {}).get(
+            "ai_auto_alerts", True
+        )
+
         # Top-level timestamp for efficient frontend equality checks (change detection)
         serialized["_ts"] = int(current_time * 1000)
 

--- a/custom_components/growspace_manager/view_model_builder.py
+++ b/custom_components/growspace_manager/view_model_builder.py
@@ -239,6 +239,7 @@ class ViewModelBuilder:
         serialized["ai_auto_alerts"] = options.get("ai_settings", {}).get(
             "ai_auto_alerts", True
         )
+        serialized["timed_notifications"] = options.get("timed_notifications", [])
 
         # Top-level timestamp for efficient frontend equality checks (change detection)
         serialized["_ts"] = int(current_time * 1000)

--- a/custom_components/growspace_manager/websocket/notifications.py
+++ b/custom_components/growspace_manager/websocket/notifications.py
@@ -32,6 +32,7 @@ SCHEMA_WS_SAVE_NOTIFICATION_SETTINGS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA
         vol.Required("type"): WS_TYPE_SAVE_NOTIFICATION_SETTINGS,
         vol.Required("notification_settings"): dict,
         vol.Required("ai_auto_alerts"): bool,
+        vol.Optional("timed_notifications"): list,
     }
 )
 
@@ -55,6 +56,11 @@ async def websocket_save_notification_settings(
     ai_settings: dict[str, Any] = dict(new_options.get("ai_settings", {}))
     ai_settings["ai_auto_alerts"] = msg["ai_auto_alerts"]
     new_options["ai_settings"] = ai_settings
+
+    # Timed notifications are optional: persist them only when the card sends the
+    # list, otherwise leave the stored list untouched.
+    if "timed_notifications" in msg:
+        new_options["timed_notifications"] = msg["timed_notifications"]
 
     if hasattr(coordinator, "options"):
         coordinator.options = new_options

--- a/tests/core/test_domain_stage_calculator.py
+++ b/tests/core/test_domain_stage_calculator.py
@@ -13,6 +13,33 @@ from custom_components.growspace_manager.domain.stage_calculator import (
 from custom_components.growspace_manager.models import Plant
 
 
+@freeze_time("2024-01-11T12:00:00")
+def test_calculate_days_in_stage_card_trigger_vocabulary() -> None:
+    """The card's timed-notification trigger must be a bare stage to ever fire.
+
+    Regression guard for the cross-repo vocabulary bug: the card used to send
+    '*_start' values (e.g. 'veg_start'), which resolve to no plant start field
+    and so always return 0 days — the notification never reached its threshold.
+    The bare stage 'veg' resolves to the veg_start field and counts correctly.
+    """
+    from custom_components.growspace_manager.domain import (  # noqa: PLC0415
+        calculate_days_in_stage as domain_calc,
+    )
+
+    plant = MagicMock(spec=Plant)
+    plant.seedling_start = None
+    plant.clone_start = None
+    plant.veg_start = "2024-01-01T12:00:00"  # 10 days before frozen now
+    plant.flower_start = None
+    plant.dry_start = None
+    plant.cure_start = None
+
+    # Bare stage (what the card now sends) resolves and counts.
+    assert domain_calc(plant, "veg") == 10
+    # Legacy '*_start' value (the bug) resolves to nothing → never fires.
+    assert domain_calc(plant, "veg_start") == 0
+
+
 def test_calculate_days_in_stage_no_start() -> None:
     """Test when the stage has not started yet."""
     plant = MagicMock(spec=Plant)

--- a/tests/core/test_websocket_notifications.py
+++ b/tests/core/test_websocket_notifications.py
@@ -66,6 +66,78 @@ async def test_save_notification_settings_writes_settings_and_ai_auto_alerts(
 
 
 @pytest.mark.asyncio
+async def test_save_notification_settings_persists_timed_notifications(
+    mock_connection: MagicMock,
+) -> None:
+    """A timed_notifications list in the message is persisted into options."""
+    from custom_components.growspace_manager.websocket.notifications import (
+        websocket_save_notification_settings,
+    )
+
+    coordinator = MagicMock()
+    coordinator.config_entry.options = {"timed_notifications": [{"id": "old"}]}
+    coordinator.async_commit = AsyncMock()
+
+    timed = [
+        {
+            "id": "n1",
+            "message": "Feed me",
+            "trigger_type": "veg_start",
+            "day": 3,
+            "growspace_ids": ["gs1"],
+        }
+    ]
+
+    mock_hass = MagicMock()
+    with patch(
+        "custom_components.growspace_manager.websocket.notifications._get_coordinator",
+        return_value=coordinator,
+    ):
+        msg = {
+            "id": 2,
+            "type": "growspace_manager/save_notification_settings",
+            "notification_settings": {},
+            "ai_auto_alerts": True,
+            "timed_notifications": timed,
+        }
+        await websocket_save_notification_settings(mock_hass, mock_connection, msg)
+
+    saved_options = mock_hass.config_entries.async_update_entry.call_args[1]["options"]
+    assert saved_options["timed_notifications"] == timed
+
+
+@pytest.mark.asyncio
+async def test_save_notification_settings_leaves_timed_notifications_untouched_when_absent(
+    mock_connection: MagicMock,
+) -> None:
+    """Omitting timed_notifications preserves the existing stored list."""
+    from custom_components.growspace_manager.websocket.notifications import (
+        websocket_save_notification_settings,
+    )
+
+    coordinator = MagicMock()
+    existing = [{"id": "keep"}]
+    coordinator.config_entry.options = {"timed_notifications": existing}
+    coordinator.async_commit = AsyncMock()
+
+    mock_hass = MagicMock()
+    with patch(
+        "custom_components.growspace_manager.websocket.notifications._get_coordinator",
+        return_value=coordinator,
+    ):
+        msg = {
+            "id": 3,
+            "type": "growspace_manager/save_notification_settings",
+            "notification_settings": {},
+            "ai_auto_alerts": True,
+        }
+        await websocket_save_notification_settings(mock_hass, mock_connection, msg)
+
+    saved_options = mock_hass.config_entries.async_update_entry.call_args[1]["options"]
+    assert saved_options["timed_notifications"] == existing
+
+
+@pytest.mark.asyncio
 async def test_save_notification_settings_sends_error_when_no_coordinator(
     mock_connection: MagicMock,
 ) -> None:

--- a/tests/integration/test_growspace_view_model_coverage.py
+++ b/tests/integration/test_growspace_view_model_coverage.py
@@ -629,6 +629,41 @@ def test_view_model_builder_notification_settings_default_when_absent(
     assert result["ai_auto_alerts"] is True
 
 
+def test_view_model_builder_includes_timed_notifications(
+    hass: HomeAssistant,
+) -> None:
+    """Serialized payload carries timed notifications so the card can round-trip."""
+    gs = Growspace(id="gs1", name="GS1", water_usage=WaterUsageData())
+    coordinator = _make_mock_coordinator(hass, gs, {})
+    timed = [
+        {
+            "id": "n1",
+            "message": "Feed me",
+            "trigger_type": "veg_start",
+            "day": 3,
+            "growspace_ids": ["gs1"],
+        }
+    ]
+    coordinator.config_entry.options = {"timed_notifications": timed}
+
+    result = ViewModelBuilder(coordinator).build_serialized_growspace("gs1")
+
+    assert result["timed_notifications"] == timed
+
+
+def test_view_model_builder_timed_notifications_default_empty(
+    hass: HomeAssistant,
+) -> None:
+    """Absent timed_notifications option yields an empty list."""
+    gs = Growspace(id="gs1", name="GS1", water_usage=WaterUsageData())
+    coordinator = _make_mock_coordinator(hass, gs, {})
+    coordinator.config_entry.options = {}
+
+    result = ViewModelBuilder(coordinator).build_serialized_growspace("gs1")
+
+    assert result["timed_notifications"] == []
+
+
 def test_view_model_builder_passes_liters_today_from_trackers(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/integration/test_growspace_view_model_coverage.py
+++ b/tests/integration/test_growspace_view_model_coverage.py
@@ -594,6 +594,41 @@ def _make_mock_coordinator(
     return mock_coord
 
 
+def test_view_model_builder_includes_notification_settings(
+    hass: HomeAssistant,
+) -> None:
+    """Serialized payload carries global notification settings for the card.
+
+    The card seeds the Config Dialog's Notifications tab from the device payload,
+    so saved settings must ride the per-growspace payload to round-trip.
+    """
+    gs = Growspace(id="gs1", name="GS1", water_usage=WaterUsageData())
+    coordinator = _make_mock_coordinator(hass, gs, {})
+    coordinator.config_entry.options = {
+        "notification_settings": {"criticalCooldownMinutes": 7},
+        "ai_settings": {"ai_auto_alerts": False},
+    }
+
+    result = ViewModelBuilder(coordinator).build_serialized_growspace("gs1")
+
+    assert result["notification_settings"] == {"criticalCooldownMinutes": 7}
+    assert result["ai_auto_alerts"] is False
+
+
+def test_view_model_builder_notification_settings_default_when_absent(
+    hass: HomeAssistant,
+) -> None:
+    """Absent options yield an empty dict and ai_auto_alerts defaulting to True."""
+    gs = Growspace(id="gs1", name="GS1", water_usage=WaterUsageData())
+    coordinator = _make_mock_coordinator(hass, gs, {})
+    coordinator.config_entry.options = {}
+
+    result = ViewModelBuilder(coordinator).build_serialized_growspace("gs1")
+
+    assert result["notification_settings"] == {}
+    assert result["ai_auto_alerts"] is True
+
+
 def test_view_model_builder_passes_liters_today_from_trackers(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
## Why

The Lovelace card's Config Dialog Notifications tab could not actually persist or reload its data, and timed-notification triggers never fired. The card side is fixed in a companion PR; this PR adds the backend half (the card can't call/read what the backend doesn't expose).

## What

- **`save_notification_settings` WS command** now also persists an optional `timed_notifications` list (alongside `notification_settings` + `ai_auto_alerts`), leaving the stored list untouched when omitted.
- **`build_serialized_growspace`** now rides `notification_settings`, `ai_auto_alerts`, and `timed_notifications` on every growspace `get_data` payload (mirroring `notifications_enabled`), so the card can reseed saved values on reopen. The 30s payload cache is already invalidated by `async_commit` on save, so save→reopen is fresh.
- **Regression guard** (`test_calculate_days_in_stage_card_trigger_vocabulary`) pins the cross-repo trigger contract: a bare stage value (`veg`) resolves through the real `calculate_days_in_stage` and counts days-in-stage, while the legacy `*_start` value resolves to nothing and never fires.

Timed notifications are stored snake_case to match the existing calendar / notification_manager consumers.

## Companion PR

Card: `feat/config-dialog-notifications-save-roundtrip` (Venosta-web/lovelace-growspace-manager-card). The component side here lands first.

## Testing

- New tests for the WS persistence (present + absent), the payload injection (present + default), and the trigger-vocabulary guard.
- Affected suites green (view-model coverage, websocket notifications, coordinator, domain stage calculator, notification manager); no snapshot regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)