### PR TITLE
ci: ruff/mypy lint workflow + ruff baseline cleanup (ADR 0020)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,47 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  ruff:
+    name: Ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
+        name: Setup Python
+        with:
+          python-version: "3.14"
+      - name: Install ruff
+        run: python -m pip install --upgrade "ruff==0.15.12"
+      - name: ruff check
+        run: ruff check custom_components/ tests/
+      # Non-blocking until the existing repo-wide format drift is normalised in a
+      # dedicated PR (would otherwise conflict with in-flight feature branches).
+      - name: ruff format --check (non-blocking)
+        run: ruff format --check custom_components/ tests/
+        continue-on-error: true
+
+  mypy:
+    name: mypy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
+        name: Setup Python
+        with:
+          python-version: "3.14"
+          cache: "pip"
+      - name: install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade -r requirements.txt
+          pip install "mypy==1.20.2"
+      # Non-blocking until the inherited HA-core-strict baseline (~460 errors) is
+      # burned down in a dedicated effort; see ADR 0020.
+      - name: mypy (non-blocking)
+        run: mypy custom_components/growspace_manager/
+        continue-on-error: true

--- a/custom_components/growspace_manager/config_flow.py
+++ b/custom_components/growspace_manager/config_flow.py
@@ -20,6 +20,7 @@ from homeassistant.helpers import selector
 import homeassistant.helpers.config_validation as cv
 
 from .config_handlers import (
+    AbortFlow,
     AIConfigHandler,
     BayesianAdvancedHandler,
     DehumidifierHandler,
@@ -490,7 +491,6 @@ class OptionsFlowHandler(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Retrieve growspace from flow state and persist env config."""
-        from .config_handlers import AbortFlow
         try:
             coordinator = self.env_sensors_handler.get_coordinator()
         except AbortFlow as e:
@@ -501,7 +501,11 @@ class OptionsFlowHandler(OptionsFlow):
         if not growspace:
             return self.async_abort(reason="growspace_not_found")
         env_config = dict(self.env_config_step1 or {})
-        return await self.env_sensors_handler._async_save_and_finish(growspace, env_config)
+        # The flow orchestrates its own sensors handler; calling its save helper is
+        # the intended seam, not external private access.
+        return await self.env_sensors_handler._async_save_and_finish(  # noqa: SLF001
+            growspace, env_config
+        )
 
     async def async_step_manage_plants(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/growspace_manager/config_handlers/bayesian_advanced_handler.py
+++ b/custom_components/growspace_manager/config_handlers/bayesian_advanced_handler.py
@@ -9,12 +9,14 @@ from typing import Any
 import voluptuous as vol
 
 from custom_components.growspace_manager.const import (
+    CONF_BULK_EC_SENSORS,
     CONF_CAMERA_ENTITIES,
     CONF_DRAIN_VOLUME_SENSORS,
     CONF_ENERGY_SENSORS,
     CONF_FEED_EC_SENSORS,
     CONF_IRRIGATION_FLOW_SENSORS,
     CONF_PH_SENSORS,
+    CONF_PORE_EC_SENSORS,
     CONF_POWER_SENSORS,
     CONF_PROB_HUMIDITY_HIGH_FLOWER,
     CONF_PROB_HUMIDITY_HIGH_VEG_EARLY,
@@ -42,8 +44,6 @@ from custom_components.growspace_manager.const import (
     CONF_PROB_VPD_STRESS_FLOWER_LATE,
     CONF_PROB_VPD_STRESS_VEG_EARLY,
     CONF_PROB_VPD_STRESS_VEG_LATE,
-    CONF_BULK_EC_SENSORS,
-    CONF_PORE_EC_SENSORS,
     CONF_RUNOFF_EC_SENSORS,
 )
 from homeassistant.config_entries import ConfigFlowResult

--- a/custom_components/growspace_manager/config_handlers/dehumidifier_handler.py
+++ b/custom_components/growspace_manager/config_handlers/dehumidifier_handler.py
@@ -8,7 +8,6 @@ from typing import Any
 import voluptuous as vol
 
 from custom_components.growspace_manager.const import (
-    CONF_CONFIGURE_ADVANCED,
     CONF_CONFIGURE_DEHUMIDIFIER,
     CONF_CONFIGURE_FAN_CONTROLLER,
     CONF_CONFIGURE_HUMIDIFIER,

--- a/custom_components/growspace_manager/config_handlers/environment_sensors_handler.py
+++ b/custom_components/growspace_manager/config_handlers/environment_sensors_handler.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 from custom_components.growspace_manager.const import (
     CANONICAL_ID_CURE,
     CANONICAL_ID_DRY,
+    CONF_BULK_EC_SENSORS,
     CONF_CAMERA_ENTITIES,
     CONF_CIRCULATION_FAN_ENTITIES,
     CONF_CIRCULATION_FAN_ENTITY,
@@ -39,19 +40,16 @@ from custom_components.growspace_manager.const import (
     CONF_LIGHT_SENSORS,
     CONF_LST_OFFSET,
     CONF_PH_SENSORS,
+    CONF_PORE_EC_SENSORS,
     CONF_POWER_SENSORS,
     CONF_RUNOFF_EC_SENSORS,
     CONF_SOIL_MOISTURE_SENSOR,
-    CONF_BULK_EC_SENSORS,
-    CONF_PORE_EC_SENSORS,
     CONF_TEMP_SENSOR,
     CONF_TEMP_SENSORS,
     CONF_VPD_SENSOR,
     CONF_VPD_SENSORS,
 )
-from custom_components.growspace_manager.models import (
-    EnvironmentConfig,
-)
+from custom_components.growspace_manager.models import EnvironmentConfig
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.helpers import selector
 
@@ -691,7 +689,7 @@ class EnvironmentSensorsHandler(BaseConfigHandler[dict[str, Any]]):
         self, schema_dict: dict[Any, Any], growspace_options: dict[str, Any]
     ) -> None:
         """Add environmental thresholds, trend analysis, and photoperiod to the schema."""
-        from custom_components.growspace_manager.const import (
+        from custom_components.growspace_manager.const import (  # noqa: PLC0415
             CONF_FLOWER_EARLY_DAY_HOURS,
             CONF_FLOWER_LATE_DAY_HOURS,
             CONF_FLOWER_MID_DAY_HOURS,

--- a/custom_components/growspace_manager/config_handlers/fan_controller_handler.py
+++ b/custom_components/growspace_manager/config_handlers/fan_controller_handler.py
@@ -9,9 +9,7 @@ from typing import Any
 import voluptuous as vol
 
 from custom_components.growspace_manager.const import FanRegulationMode
-from custom_components.growspace_manager.models import (
-    CirculationFanConfig,
-)
+from custom_components.growspace_manager.models import CirculationFanConfig
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.helpers import selector
 

--- a/custom_components/growspace_manager/coordinator.py
+++ b/custom_components/growspace_manager/coordinator.py
@@ -20,45 +20,33 @@ from .conversation_store import ConversationStore
 from .data_access.growspace_repository import GrowspaceRepository
 from .data_access.notification_state import NotificationState
 from .date_time_helper import DateTimeHelper
-from .dehumidifier_coordinator import DehumidifierCoordinator
 from .environment_analyzer import EnvironmentAnalyzer
 from .event_bus_pkg import GrowspaceEventBus
 from .growspace_validator import GrowspaceValidator
-from .humidifier_coordinator import HumidifierCoordinator
 from .import_export_manager import ImportExportManager
 from .integration_types import DateInput
-from .irrigation_coordinator import IrrigationCoordinator
 from .managers.genetics import GeneticsManager
 from .managers.growspace import GrowspaceManager
 from .managers.nutrient import NutrientManager
 from .managers.plant import PlantManager
 from .managers.subsystem import SubsystemManager
-from .models import (
-    Growspace,
-    GrowspaceEvent,
-    IPMPreset,
-    NutrientInventory,
-    NutrientPreset,
-    Plant,
-)
+from .models import Growspace, GrowspaceEvent, NutrientInventory, Plant
 from .notification_manager import NotificationManager
 from .notifications import NotificationSettingsManager
-from .tank_monitor import TankLevelMonitor
 from .photoperiod_flip_checker import PhotoperiodFlipChecker
 from .presentation import PlantViewModelBuilder
 from .service_coordinator_locator import ServiceCoordinatorLocator
 from .services.environment_reporter import EnvironmentReporter
 from .services.facade import ServiceFacade
 from .services.ipm_service import IPMService
-from .services.nutrient_inventory import NutrientInventoryService
 from .services.seedfinder_scraper import SeedfinderScraper
 from .services.training_service import TrainingService
 from .services.watering_service import WateringService
 from .storage_manager import StorageManager
 from .strain_library import StrainLibrary
+from .tank_monitor import TankLevelMonitor
 from .view_model_builder import ViewModelBuilder
 from .vision_checkup_scheduler import VisionCheckupScheduler
-from .vwc_irrigation_coordinator import VWCIrrigationCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/growspace_manager/coordinator_builder.py
+++ b/custom_components/growspace_manager/coordinator_builder.py
@@ -28,7 +28,6 @@ from .managers.plant import PlantManager
 from .managers.subsystem import SubsystemManager
 from .notification_manager import NotificationManager
 from .notification_rewriter import AINotificationRewriter
-from .tank_monitor import TankLevelMonitor
 from .notifications import NotificationSettingsManager
 from .photoperiod_flip_checker import PhotoperiodFlipChecker
 from .presentation import PlantViewModelBuilder
@@ -41,6 +40,7 @@ from .services.training_service import TrainingService
 from .services.watering_service import WateringService
 from .storage_manager import StorageManager
 from .strain_library import StrainLibrary
+from .tank_monitor import TankLevelMonitor
 from .view_model_builder import ViewModelBuilder
 from .vision_checkup_scheduler import VisionCheckupScheduler
 

--- a/custom_components/growspace_manager/domain/day_night.py
+++ b/custom_components/growspace_manager/domain/day_night.py
@@ -21,6 +21,7 @@ class DayNightTracker:
     """
 
     def __init__(self, growspace_id: str) -> None:
+        """Initialize the day/night resolver for a single growspace."""
         self._growspace_id = growspace_id
         self._last_known_is_day: bool | None = None
         self._sensors_unavailable_since: float | None = None

--- a/custom_components/growspace_manager/domain/stage.py
+++ b/custom_components/growspace_manager/domain/stage.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import StrEnum
 from typing import Final
 

--- a/custom_components/growspace_manager/humidifier_coordinator.py
+++ b/custom_components/growspace_manager/humidifier_coordinator.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from .const import (
     CATEGORY_HUMIDIFIER,
     DEFAULT_HUMIDIFIER_MIN_OFFTIME,
@@ -11,9 +9,6 @@ from .const import (
     PlantStage,
 )
 from .vpd_on_off_controller import VpdOnOffController
-
-if TYPE_CHECKING:
-    from .coordinator import GrowspaceCoordinator
 
 # Default thresholds — humidifier turns ON when VPD exceeds `on`, OFF when it drops below `off`.
 # High VPD = low humidity = needs humidification.

--- a/custom_components/growspace_manager/managers/lineage.py
+++ b/custom_components/growspace_manager/managers/lineage.py
@@ -1,8 +1,10 @@
+"""Lineage tree construction and ancestry queries for the strain library."""
+
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 import json
 import logging
-from collections.abc import Awaitable, Callable
 from typing import Any
 
 import aiosqlite
@@ -40,12 +42,14 @@ class StrainLineageManager:
         db: aiosqlite.Connection | None,
         load_callback: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
+        """Initialize with the strains catalogue, DB handle and optional loader."""
         self._strains = strains
         self._db = db
         self._load_callback = load_callback
         self._lineage_cache: dict[str, LineageNode] = {}
 
     def invalidate_cache(self) -> None:
+        """Clear the cached lineage trees."""
         self._lineage_cache.clear()
 
     def get_strain_lineage_tree(

--- a/custom_components/growspace_manager/managers/strain_analytics.py
+++ b/custom_components/growspace_manager/managers/strain_analytics.py
@@ -1,17 +1,24 @@
+"""Per-strain and per-phenotype harvest analytics for the strain library."""
+
 from __future__ import annotations
 
 from typing import Any
 
 
 class StrainAnalyticsManager:
+    """Computes and caches harvest analytics derived from the strain catalogue."""
+
     def __init__(self, strains: dict[str, Any]) -> None:
+        """Initialize the manager with a reference to the strains catalogue."""
         self._strains = strains
         self._cache: dict[str, Any] | None = None
 
     def invalidate(self) -> None:
+        """Drop the cached analytics so the next compute() recalculates."""
         self._cache = None
 
     def compute(self) -> dict[str, Any]:
+        """Return per-strain/per-phenotype harvest analytics, caching the result."""
         if self._cache is not None:
             return self._cache
 

--- a/custom_components/growspace_manager/notification_rewriter.py
+++ b/custom_components/growspace_manager/notification_rewriter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from homeassistant.components import conversation
 from homeassistant.core import Context, HomeAssistant
@@ -12,10 +12,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import intent
 from homeassistant.util.dt import utcnow
 
-from .const import (
-    CONF_ASSISTANT_ID,
-    CONF_NOTIFICATION_PERSONALITY,
-)
+from .const import CONF_ASSISTANT_ID, CONF_NOTIFICATION_PERSONALITY
 from .exceptions import GrowspaceError
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/growspace_manager/strain_library.py
+++ b/custom_components/growspace_manager/strain_library.py
@@ -15,11 +15,9 @@ from typing import Any
 import aiosqlite
 
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util import dt as dt_util, slugify
 
 from .const import DB_FILE_STRAIN_LIBRARY
-from .exceptions import GrowspaceError
 from .image_manager import ImageManager
 from .import_export_manager import ImportExportManager
 from .managers.lineage import StrainLineageManager
@@ -140,14 +138,18 @@ class StrainLibrary:
 
     @property
     def strains(self) -> dict[str, dict[str, Any]]:
+        """Return the strain catalogue keyed by strain name."""
         return self._strains
 
+    # The setters below intentionally push state into the composed analytics and
+    # lineage sub-managers so all three stay in sync; SLF001 on those collaborators
+    # is the sanctioned coordination path, not a smell.
     @strains.setter
     def strains(self, value: dict[str, dict[str, Any]]) -> None:
         self._strains = value
-        self._analytics._strains = value
+        self._analytics._strains = value  # noqa: SLF001
         self._analytics.invalidate()
-        self._lineage_manager._strains = value
+        self._lineage_manager._strains = value  # noqa: SLF001
         self._lineage_manager.invalidate_cache()
 
     @property
@@ -157,15 +159,15 @@ class StrainLibrary:
     @_db.setter
     def _db(self, value: aiosqlite.Connection | None) -> None:
         self.__db = value
-        self._lineage_manager._db = value
+        self._lineage_manager._db = value  # noqa: SLF001
 
     @property
     def _lineage_cache(self) -> dict[str, dict[str, Any]]:
-        return self._lineage_manager._lineage_cache
+        return self._lineage_manager._lineage_cache  # noqa: SLF001
 
     @_lineage_cache.setter
     def _lineage_cache(self, value: dict[str, dict[str, Any]]) -> None:
-        self._lineage_manager._lineage_cache = value
+        self._lineage_manager._lineage_cache = value  # noqa: SLF001
 
     async def async_setup(self) -> bool:
         """Set up the database connection and schema.
@@ -997,11 +999,12 @@ class StrainLibrary:
         )
 
     async def _rebuild_strain_ancestry(self, strain_name: str) -> None:
-        await self._lineage_manager._rebuild_strain_ancestry(strain_name)
+        await self._lineage_manager._rebuild_strain_ancestry(strain_name)  # noqa: SLF001
 
     async def update_strain_lineage_tree(
         self, strain_name: str, parents: StoredParents
     ) -> str:
+        """Replace a strain's recorded parents and rebuild its lineage tree."""
         return await self._lineage_manager.update_strain_lineage_tree(strain_name, parents)
 
     async def async_import_seedfinder_lineage_tree(
@@ -1010,6 +1013,7 @@ class StrainLibrary:
         tree: dict[str, Any],
         scraper: Any | None = None,
     ) -> None:
+        """Import a SeedFinder-sourced lineage tree rooted at the given strain."""
         await self._lineage_manager.async_import_seedfinder_lineage_tree(
             root_strain_name, tree, scraper
         )
@@ -1017,6 +1021,7 @@ class StrainLibrary:
     async def async_update_strain_generation(
         self, strain_name: str, generation: str
     ) -> None:
+        """Update the recorded generation label for a strain."""
         await self._lineage_manager.async_update_strain_generation(strain_name, generation)
 
     def get_strain_lineage_tree(
@@ -1025,16 +1030,19 @@ class StrainLibrary:
         _seen: frozenset[str] | None = None,
         _depth: int = 0,
     ) -> LineageNode:
+        """Return the lineage tree for a strain (recursion guarded by _seen/_depth)."""
         return self._lineage_manager.get_strain_lineage_tree(strain_name, _seen, _depth)
 
     async def async_get_strains_by_ancestor(
         self, ancestor_name: str
     ) -> list[dict[str, Any]]:
+        """Return strains descended from the named ancestor."""
         return await self._lineage_manager.async_get_strains_by_ancestor(ancestor_name)
 
     async def async_get_shared_ancestors(
         self, strain_ids: list[int]
     ) -> list[dict[str, Any]]:
+        """Return ancestors common to all of the given strains."""
         return await self._lineage_manager.async_get_shared_ancestors(strain_ids)
 
     def get_strain_names(self) -> list[str]:

--- a/custom_components/growspace_manager/strategies/mold.py
+++ b/custom_components/growspace_manager/strategies/mold.py
@@ -14,8 +14,8 @@ from custom_components.growspace_manager.bayesian_evaluator import (
 )
 from custom_components.growspace_manager.domain.stage import (
     BayesianStage,
-    StageDays,
     StageClassification,
+    StageDays,
     classify_stages,
 )
 from custom_components.growspace_manager.utils import interpolate_value

--- a/custom_components/growspace_manager/utils.py
+++ b/custom_components/growspace_manager/utils.py
@@ -17,12 +17,7 @@ from .domain.date_logic import (
     parse_date_field,
     to_lifecycle_timestamp as to_lifecycle_timestamp_logic,
 )
-from .domain.stage import (
-    SPECIAL_GROWSPACE_STAGES,
-    STAGES_ORDERED,
-    BayesianStage,
-    PlantStage,
-)
+from .domain.stage import SPECIAL_GROWSPACE_STAGES, STAGES_ORDERED, PlantStage
 from .integration_types import DateInput
 
 if TYPE_CHECKING:

--- a/custom_components/growspace_manager/vpd_on_off_controller.py
+++ b/custom_components/growspace_manager/vpd_on_off_controller.py
@@ -62,6 +62,7 @@ class VpdOnOffController:
         growspace_id: str,
         main_coordinator: GrowspaceCoordinator,
     ) -> None:
+        """Initialize the VPD on/off controller for a growspace."""
         self.hass = hass
         self.config_entry = config_entry
         self.growspace_id = growspace_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -910,14 +910,42 @@ split-on-trailing-comma = false
 "homeassistant/scripts/*" = ["T201"]
 "script/*" = ["T20"]
 
-# Allow relative imports within auth and within components
+# Allow relative imports within auth and within components. This integration is
+# itself a component, so relative imports within it are the sanctioned pattern
+# (the same allowance HA core grants `homeassistant/components/*/*/*`).
 "homeassistant/auth/*/*" = ["TID252"]
 "homeassistant/components/*/*/*" = ["TID252"]
 "tests/components/*/*/*" = ["TID252"]
+"custom_components/growspace_manager/*" = ["TID252"]
 
 # Temporary
 "homeassistant/**" = ["PTH"]
-"tests/**" = ["PTH"]
+
+# This integration's tests are written more loosely than HA core's own suite:
+# they reach into internals, omit per-function docstrings and package markers,
+# and use local imports. Relax those convention rules for tests rather than
+# retrofit the whole suite. Production code under custom_components/ stays strict.
+# Correctness rules (F-codes, etc.) are deliberately NOT ignored here.
+"tests/**" = [
+  "PTH",      # pathlib not required in tests
+  "D",        # docstrings not required on test functions/modules
+  "SLF001",   # tests legitimately access private members
+  "PLC0415",  # local imports are fine in tests
+  "INP001",   # test dirs need no __init__.py
+  "TID251",   # banned-api (e.g. datetime.now) acceptable in tests
+  "S108",     # hardcoded /tmp paths are fine in tests
+  "RUF059",   # unused unpacked variables in tests
+  "E402",     # module-level import position relaxed in tests
+  "SIM117",   # nested with-statements are fine in test setup
+  "SIM118",   # key in dict.keys() acceptable in tests
+  "RET503",   # implicit return in tests
+  "RET504",   # assign-before-return is readable in tests
+  "PT006",    # parametrize name style not enforced in tests
+  "C416",     # comprehension style not enforced in tests
+  "TRY002",   # raising vanilla Exception is fine in tests
+  "B017",     # blind pytest.raises(Exception) tolerated in tests
+  "PGH003",   # blanket type: ignore tolerated in tests
+]
 
 # The service facade layer is the sanctioned reader of coordinator internals
 # (see custom_components/growspace_manager/CONTEXT.md "Seam Enforcement"), so

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Kept in lockstep with pytest-homeassistant-custom-component (which pins an exact
 # homeassistant version) and home-assistant-intents below; a fresh CI install
 # otherwise floated intents to a version missing FuzzyConfig and broke collection.
-homeassistant==2026.5.1
+homeassistant==2026.5.4
 aiosqlite
 Pillow
 python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 # Home Assistant Core (Minimal)
-homeassistant==2026.4.0
+# Kept in lockstep with pytest-homeassistant-custom-component (which pins an exact
+# homeassistant version) and home-assistant-intents below; a fresh CI install
+# otherwise floated intents to a version missing FuzzyConfig and broke collection.
+homeassistant==2026.5.1
 aiosqlite
 Pillow
 python-dateutil
@@ -20,7 +23,7 @@ pydantic
 pylint
 pipdeptree
 pytest-asyncio
-pytest-homeassistant-custom-component>=0.13.80
+pytest-homeassistant-custom-component==0.13.333
 pytest-cov
 pytest
 PyTurboJPEG
@@ -30,5 +33,5 @@ pytest-xdist
 freezegun
 requests-mock
 hassil
-home-assistant-intents
+home-assistant-intents==2026.5.5
 syrupy>=5.0.0

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -1,5 +1,5 @@
 import sys
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest

--- a/tests/components/test_sensor.py
+++ b/tests/components/test_sensor.py
@@ -14,7 +14,12 @@ import pytest
 
 from custom_components.growspace_manager import sensor as sensor_module
 from custom_components.growspace_manager.const import DOMAIN
-from custom_components.growspace_manager.models import DryingData, EnvironmentConfig, HarvestMetrics, IrrigationTank
+from custom_components.growspace_manager.models import (
+    DryingData,
+    EnvironmentConfig,
+    HarvestMetrics,
+    IrrigationTank,
+)
 from custom_components.growspace_manager.sensor import (
     AirExchangeSensor,
     CalculatedVpdSensor,

--- a/tests/components/test_sensor_coverage.py
+++ b/tests/components/test_sensor_coverage.py
@@ -337,14 +337,14 @@ def test_ec_target_sensor_week_out_of_range(
     mock_curve.stage = "flower"
     mock_curve.name = "Standard"
 
-    sensor._get_active_curve = MagicMock(return_value=mock_curve)  # noqa: SLF001
+    sensor._get_active_curve = MagicMock(return_value=mock_curve)
 
     # Test week less than last point's week, should return None (Line 1836)
-    sensor._get_current_week = MagicMock(return_value=1)  # noqa: SLF001
+    sensor._get_current_week = MagicMock(return_value=1)
     assert sensor.native_value is None
 
     # Verify the week >= last.week check returns midpoint
-    sensor._get_current_week = MagicMock(return_value=4)  # noqa: SLF001
+    sensor._get_current_week = MagicMock(return_value=4)
     assert sensor.native_value == 1.5
 
 

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -5,8 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from custom_components.growspace_manager.date_time_helper import DateTimeHelper
-
 # pytest_plugins = "pytest_homeassistant_custom_component"
 
 

--- a/tests/config/test_config_flow.py
+++ b/tests/config/test_config_flow.py
@@ -42,7 +42,7 @@ from homeassistant.config_entries import HANDLERS
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import selector
-from tests.common import MockConfigEntry  # noqa: TID251
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -561,7 +561,7 @@ async def test_options_flow_manage_growspaces_back(
     flow = OptionsFlowHandler(config_entry)
     flow.hass = hass
 
-    flow._get_main_menu_schema = lambda: vol.Schema({vol.Required("action"): str})  # noqa: SLF001
+    flow._get_main_menu_schema = lambda: vol.Schema({vol.Required("action"): str})
     # Provide a **real schema**, not a Mock
 
     # Now call the step
@@ -2994,7 +2994,7 @@ async def test_options_flow_irrigation_save_clears_pumps(
     flow = OptionsFlowHandler(config_entry)
     flow.hass = hass
     flow.selected_growspace_id = "gs1"
-    flow._current_options = {}  # noqa: SLF001
+    flow._current_options = {}
 
     # User input with NO pump entities (simulating clearing them)
     user_input = {
@@ -3059,7 +3059,7 @@ async def test_options_flow_manage_plants_back(
 
     flow = OptionsFlowHandler(config_entry)
     flow.hass = hass
-    flow._get_main_menu_schema = Mock(return_value=vol.Schema({}))  # noqa: SLF001
+    flow._get_main_menu_schema = Mock(return_value=vol.Schema({}))
 
     result = await flow.async_step_manage_plants(user_input={"action": "back"})
     assert result["type"] == FlowResultType.FORM
@@ -3386,7 +3386,7 @@ async def test_options_flow_manage_strain_library_back(
 
     flow = OptionsFlowHandler(config_entry)
     flow.hass = hass
-    flow._get_main_menu_schema = Mock(return_value=vol.Schema({}))  # noqa: SLF001
+    flow._get_main_menu_schema = Mock(return_value=vol.Schema({}))
 
     result = await flow.async_step_manage_strain_library(user_input={"action": "back"})
     assert result["type"] == FlowResultType.FORM
@@ -3485,7 +3485,7 @@ async def test_options_flow_strain_library_delete_success(
     mock_coordinator.services.config.strain_library.remove_strain = AsyncMock(
         return_value=None
     )
-    flow._get_strain_library_menu_schema = Mock(return_value=vol.Schema({}))  # noqa: SLF001
+    flow._get_strain_library_menu_schema = Mock(return_value=vol.Schema({}))
 
     result = await flow.async_step_manage_strain_library(
         user_input={"action": "delete_strain", "strain_id": "s1"}
@@ -3586,7 +3586,7 @@ async def test_delegated_fan_steps(
     mock_fan_handler = MagicMock()
     mock_delegated = AsyncMock(return_value={"type": FlowResultType.FORM})
     setattr(mock_fan_handler, delegated_method_name, mock_delegated)
-    flow._fan_controller_handler = mock_fan_handler  # noqa: SLF001
+    flow._fan_controller_handler = mock_fan_handler
 
     user_input = {"some_key": "some_value"}
     method = getattr(flow, method_name)
@@ -3611,7 +3611,7 @@ async def test_async_step_manage_breeder_blacklist(
     mock_strain_handler = MagicMock()
     mock_delegated = AsyncMock(return_value={"type": FlowResultType.FORM})
     mock_strain_handler.async_step_manage_breeder_blacklist = mock_delegated
-    flow._strain_handler = mock_strain_handler  # noqa: SLF001
+    flow._strain_handler = mock_strain_handler
 
     user_input = {"blacklist": ["Breeder A"]}
     result = await flow.async_step_manage_breeder_blacklist(user_input)
@@ -3636,7 +3636,7 @@ async def test_async_step_save_and_finish_abort_flow(
     mock_sensors_handler.get_coordinator = MagicMock(
         side_effect=AbortFlow(reason="test_abort_reason")
     )
-    flow._env_sensors_handler = mock_sensors_handler  # noqa: SLF001
+    flow._env_sensors_handler = mock_sensors_handler
 
     result = await flow.async_step_save_and_finish()
 
@@ -3686,8 +3686,8 @@ async def test_async_step_save_and_finish_success(
     mock_sensors_handler = MagicMock()
     mock_sensors_handler.get_coordinator = MagicMock(return_value=mock_coordinator)
     mock_save_and_finish = AsyncMock(return_value={"type": FlowResultType.CREATE_ENTRY})
-    mock_sensors_handler._async_save_and_finish = mock_save_and_finish  # noqa: SLF001
-    flow._env_sensors_handler = mock_sensors_handler  # noqa: SLF001
+    mock_sensors_handler._async_save_and_finish = mock_save_and_finish
+    flow._env_sensors_handler = mock_sensors_handler
 
     result = await flow.async_step_save_and_finish()
 

--- a/tests/config/test_config_flow_import_export.py
+++ b/tests/config/test_config_flow_import_export.py
@@ -4,12 +4,12 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from tests.common import MockConfigEntry
 
 from custom_components.growspace_manager.config_flow import OptionsFlowHandler
 from custom_components.growspace_manager.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -17,7 +17,7 @@ def mock_coordinator(hass: HomeAssistant, tmp_path: Path):
     """Create a mock coordinator with import/export manager and ServiceFacade support."""
     coordinator = MagicMock()
     coordinator.hass = hass
-    
+
     coordinator.import_export_manager = AsyncMock()
 
     # Strain library in config sub-facade
@@ -38,7 +38,7 @@ def mock_coordinator(hass: HomeAssistant, tmp_path: Path):
     facade.plants = MagicMock()
     facade.notifications = MagicMock()
     coordinator.services = facade
-    
+
     return coordinator
 
 

--- a/tests/config/test_dehumidifier_config_flow.py
+++ b/tests/config/test_dehumidifier_config_flow.py
@@ -38,7 +38,7 @@ async def test_configure_dehumidifier_thresholds(
     # Mock Coordinator
     mock_coordinator = MagicMock()
     mock_coordinator.services = MagicMock()
-    
+
     mock_growspace = Growspace(
         id="gs1",
         name="Test GS",

--- a/tests/config/test_fan_controller_config_flow.py
+++ b/tests/config/test_fan_controller_config_flow.py
@@ -4,9 +4,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.growspace_manager.config_handlers.environment_config_handler import (
-    EnvironmentConfigHandler,
-)
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.models import EnvironmentConfig, Growspace
 from homeassistant.core import HomeAssistant

--- a/tests/config/test_options_flow.py
+++ b/tests/config/test_options_flow.py
@@ -3,13 +3,13 @@
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
-from tests.common import MockConfigEntry
 import voluptuous as vol
 
 from custom_components.growspace_manager.config_flow import OptionsFlowHandler
 from custom_components.growspace_manager.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from tests.common import MockConfigEntry
 
 
 async def setup_test_environment(hass: HomeAssistant, coordinator):

--- a/tests/config_handlers/test_environment_sensors_handler.py
+++ b/tests/config_handlers/test_environment_sensors_handler.py
@@ -1,11 +1,9 @@
 """Tests for EnvironmentSensorsHandler — schema fields and routing."""
 
-from dataclasses import asdict
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.growspace_manager.config_handlers import AbortFlow
 from custom_components.growspace_manager.config_handlers.environment_sensors_handler import (
     EnvironmentSensorsHandler,
 )
@@ -15,7 +13,6 @@ from custom_components.growspace_manager.const import (
     CONF_BULK_EC_SENSORS,
     CONF_FEED_EC_SENSORS,
     CONF_HUMIDITY_SENSOR,
-    CONF_HUMIDITY_SENSORS,
     CONF_IRRIGATION_TANK_SENSORS,
     CONF_IRRIGATION_TANK_WARNING_LEVEL,
     CONF_PORE_EC_SENSORS,
@@ -543,7 +540,6 @@ def test_clean_input_plural_to_singular_maps_none_for_empty_list() -> None:
 @pytest.mark.asyncio
 async def test_configure_environment_loads_volume_liters_from_existing_tank() -> None:
     """volume_liters from existing tank is propagated to growspace_options."""
-    from custom_components.growspace_manager.const import CONF_IRRIGATION_TANK_VOLUME
 
     flow = _make_flow()
     tank = IrrigationTank(

--- a/tests/config_handlers/test_fan_controller_handler.py
+++ b/tests/config_handlers/test_fan_controller_handler.py
@@ -139,7 +139,7 @@ async def test_save_fan_config_persists_to_env_config_and_advances() -> None:
     growspace = Growspace(id="gs1", name="Tent", environment_config=EnvironmentConfig())
     handler = FanControllerHandler(flow)
 
-    result = await handler._async_save_fan_config_and_continue(growspace)  # noqa: SLF001
+    result = await handler._async_save_fan_config_and_continue(growspace)
 
     assert "circulation_fan_config" in flow.env_config_step1
     flow.async_step_configure_sensor_placement.assert_awaited_once()
@@ -328,7 +328,7 @@ async def test_save_fan_config_uses_defaults() -> None:
     growspace = Growspace(id="gs1", name="Tent", environment_config=EnvironmentConfig())
     handler = FanControllerHandler(flow)
 
-    await handler._async_save_fan_config_and_continue(growspace)  # noqa: SLF001
+    await handler._async_save_fan_config_and_continue(growspace)
 
     saved_cfg = flow.env_config_step1["circulation_fan_config"]
     assert saved_cfg["enabled"] is False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,12 @@
 """Shared test fixtures and utilities for growspace_manager tests."""
 
 from __future__ import annotations
-import sys
-from unittest.mock import MagicMock
 
 # Inject Session into builtins to resolve Python 3.14 NameError when evaluating type annotations at runtime
 import builtins
+import sys
+from unittest.mock import MagicMock
+
 try:
     from sqlalchemy.orm import Session
     builtins.Session = Session
@@ -37,8 +38,6 @@ if _is_ha_core:
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
-from syrupy.assertion import SnapshotAssertion
-
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.util import dt as dt_util
@@ -68,7 +67,7 @@ def patched_set_default_time_zone(time_zone):
 
 dt_util.set_default_time_zone = patched_set_default_time_zone
 
-import pytest  # noqa: E402
+import pytest
 
 
 @pytest.fixture(autouse=True)
@@ -88,12 +87,12 @@ def snapshot(snapshot: Any) -> Any:
     if isinstance(snapshot, MagicMock) or snapshot == Any:
         return snapshot
     try:
-        from pytest_homeassistant_custom_component.syrupy import (  # noqa: PLC0415
+        from pytest_homeassistant_custom_component.syrupy import (
             HomeAssistantSnapshotExtension,
         )
     except ImportError:
         try:
-            from tests.syrupy import HomeAssistantSnapshotExtension  # noqa: PLC0415
+            from tests.syrupy import HomeAssistantSnapshotExtension
         except ImportError:
             return snapshot
     return snapshot.use_extension(HomeAssistantSnapshotExtension)
@@ -112,8 +111,8 @@ def mock_recorder_before_hass(async_test_recorder) -> None:
 @pytest.fixture
 def mock_config_entry():
     """Return a standard MockConfigEntry for the integration."""
-    from custom_components.growspace_manager.const import DOMAIN  # noqa: PLC0415
-    from tests.common import MockConfigEntry  # noqa: PLC0415
+    from custom_components.growspace_manager.const import DOMAIN
+    from tests.common import MockConfigEntry
 
     return MockConfigEntry(
         domain=DOMAIN,
@@ -167,7 +166,7 @@ def create_test_sensor(
     env_config: Any | None = None,
 ) -> Any:
     """Helper to create a BayesianEnvironmentSensor for testing with all dependencies."""
-    from custom_components.growspace_manager.binary_sensor import (  # noqa: PLC0415
+    from custom_components.growspace_manager.binary_sensor import (
         SENSOR_TYPES,
         BayesianEnvironmentSensor,
     )
@@ -209,7 +208,7 @@ def _cancel_debouncer(obj: Any) -> None:
     """Helper to safely cancel a debouncer."""
     import contextlib
     from unittest.mock import Mock
-    if hasattr(obj, "_debounced_refresh") and (debouncer := getattr(obj, "_debounced_refresh")):
+    if hasattr(obj, "_debounced_refresh") and (debouncer := obj._debounced_refresh):
         if isinstance(debouncer, Mock):
             return
         if isinstance(getattr(debouncer, "async_cancel", None), Mock):
@@ -239,6 +238,7 @@ def cleanup_coordinators(request):
     """Track and automatically clean up all GrowspaceCoordinator instances and their unawaited mock coroutines."""
     import asyncio
     import contextlib
+
     from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 
     coordinators = []
@@ -307,7 +307,7 @@ def cleanup_coordinators(request):
 
     loop = asyncio.get_event_loop()
     if loop.is_running():
-        loop.create_task(shutdown_all())
+        loop.create_task(shutdown_all())  # noqa: RUF006  # fire-and-forget at teardown
     else:
         with contextlib.suppress(Exception):
             loop.run_until_complete(shutdown_all())

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest

--- a/tests/core/test_cache_invalidation.py
+++ b/tests/core/test_cache_invalidation.py
@@ -1,11 +1,11 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from tests.common import MockConfigEntry
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from homeassistant.core import HomeAssistant
+from tests.common import MockConfigEntry
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_calendar_coverage.py
+++ b/tests/core/test_calendar_coverage.py
@@ -1,12 +1,10 @@
 """Coverage tests for calendar.py."""
 
-from datetime import timedelta
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from custom_components.growspace_manager.calendar import GrowspaceCalendar
-from homeassistant.util import dt as dt_util
 
 
 @pytest.fixture

--- a/tests/core/test_circulation_fan_speed.py
+++ b/tests/core/test_circulation_fan_speed.py
@@ -1,6 +1,5 @@
 """Unit tests for the compute_fan_speed and compute_wind_offset pure functions."""
 
-import math
 
 import pytest
 

--- a/tests/core/test_coordinator.py
+++ b/tests/core/test_coordinator.py
@@ -34,7 +34,6 @@ from custom_components.growspace_manager.utils import calculate_plant_stage
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.dt import now
-
 from tests.common import MockConfigEntry, async_capture_events
 
 from .common import create_plant
@@ -2410,9 +2409,7 @@ async def test_notifications_logic_full(coordinator: GrowspaceCoordinator) -> No
     assert coordinator.notification_state.enabled[gs.id] is True
 
     # Non-existent GS
-    with patch(
-        "custom_components.growspace_manager.coordinator._LOGGER"
-    ) as mock_logger:
+    with patch("custom_components.growspace_manager.coordinator._LOGGER"):
         await coordinator.services.notifications.set_notifications_enabled(
             "missing", False
         )
@@ -2843,9 +2840,6 @@ async def test_async_refresh_growspace_data(coordinator: GrowspaceCoordinator) -
     # Pre-populate the cache with old data
     old_cached_data = {"cached": "old_data", "version": 1}
     coordinator.cache.set(gs.id, old_cached_data)
-
-    # Track if update_data_property was called
-    update_called = False
 
     with patch.object(
         coordinator.view_model_builder, "build_data_property"

--- a/tests/core/test_coordinator_coverage2.py
+++ b/tests/core/test_coordinator_coverage2.py
@@ -8,7 +8,6 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from tests.common import MockConfigEntry
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
@@ -17,7 +16,6 @@ from custom_components.growspace_manager.models import (
     Growspace,
     GrowspaceType,
     NutrientInventory,
-    NutrientPreset,
     Plant,
     PlantGenetics,
 )
@@ -30,6 +28,7 @@ from custom_components.growspace_manager.utils import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
+from tests.common import MockConfigEntry
 
 
 def create_test_coordinator(
@@ -746,7 +745,7 @@ async def test_async_save_ec_ramp_curve(hass: HomeAssistant) -> None:
 
     coordinator.services.config.save_ec_ramp_curve = AsyncMock(return_value=mock_preset)
 
-    result = await coordinator.services.config.save_ec_ramp_curve(
+    await coordinator.services.config.save_ec_ramp_curve(
         name="Bloom Ramp", points=[{"day": 1, "ec": 1.8}]
     )
 

--- a/tests/core/test_coordinator_extra_coverage.py
+++ b/tests/core/test_coordinator_extra_coverage.py
@@ -1,12 +1,13 @@
 """Additional tests for GrowspaceCoordinator to reach 100% coverage."""
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
-from .test_coordinator import create_test_coordinator
 
 from homeassistant.core import HomeAssistant
+
+from .test_coordinator import create_test_coordinator
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_data_repository.py
+++ b/tests/core/test_data_repository.py
@@ -1,12 +1,13 @@
 """Tests for the Growspace Manager DataRepository."""
 
-from .common import create_plant
 import pytest
 
 from custom_components.growspace_manager.data_access.growspace_repository import (
     GrowspaceRepository as DataRepository,
 )
 from custom_components.growspace_manager.models import Growspace
+
+from .common import create_plant
 
 
 @pytest.fixture

--- a/tests/core/test_domain_stage_calculator.py
+++ b/tests/core/test_domain_stage_calculator.py
@@ -22,7 +22,7 @@ def test_calculate_days_in_stage_card_trigger_vocabulary() -> None:
     and so always return 0 days — the notification never reached its threshold.
     The bare stage 'veg' resolves to the veg_start field and counts correctly.
     """
-    from custom_components.growspace_manager.domain import (  # noqa: PLC0415
+    from custom_components.growspace_manager.domain import (
         calculate_days_in_stage as domain_calc,
     )
 

--- a/tests/core/test_environment_config_migration.py
+++ b/tests/core/test_environment_config_migration.py
@@ -1,6 +1,5 @@
 """Tests for EnvironmentConfig field rename: substrate_ec_sensors → bulk_ec_sensors."""
 
-import pytest
 
 from custom_components.growspace_manager.models import EnvironmentConfig
 

--- a/tests/core/test_growspace_manager_drain_water.py
+++ b/tests/core/test_growspace_manager_drain_water.py
@@ -12,12 +12,12 @@ from custom_components.growspace_manager.data_access.growspace_repository import
 from custom_components.growspace_manager.exceptions import GrowspaceNotFoundError
 from custom_components.growspace_manager.growspace_validator import GrowspaceValidator
 from custom_components.growspace_manager.managers.growspace import GrowspaceManager
-from custom_components.growspace_manager.services.context import ServiceContext
 from custom_components.growspace_manager.models import (
     EnvironmentConfig,
     Growspace,
     IrrigationTank,
 )
+from custom_components.growspace_manager.services.context import ServiceContext
 from custom_components.growspace_manager.view_model_builder import ViewModelBuilder
 
 

--- a/tests/core/test_models_coverage_gap.py
+++ b/tests/core/test_models_coverage_gap.py
@@ -6,7 +6,6 @@ from custom_components.growspace_manager.models import (
     Plant,
     PlantGenetics,
     SeedBatch,
-    _sanitize_numeric_fields,
 )
 
 

--- a/tests/core/test_notification_manager_options.py
+++ b/tests/core/test_notification_manager_options.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
-
-from datetime import datetime
 
 from custom_components.growspace_manager.const import (
     CRITICAL_COOLDOWN_MINUTES,
@@ -112,34 +110,32 @@ def test_get_tier_cooldown_falls_back_to_const_when_absent(
 
 def test_is_on_cooldown_respects_option_override() -> None:
     """_is_on_cooldown uses the option-driven cooldown, not the class-level constant."""
-    from datetime import timezone
 
     manager = _make_manager({"critical_cooldown_minutes": 1})
     growspace_id = "gs1"
     tier = NotificationTier.CRITICAL
 
     # Record cooldown 30 seconds ago
-    thirty_seconds_ago = datetime.now(tz=timezone.utc) - timedelta(seconds=30)
+    thirty_seconds_ago = datetime.now(tz=UTC) - timedelta(seconds=30)
     manager._cooldowns[growspace_id] = {tier: thirty_seconds_ago}
 
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     # 30s < 1 min — should be on cooldown
     assert manager._is_on_cooldown(growspace_id, tier, now) is True
 
 
 def test_is_on_cooldown_expired_with_option_override() -> None:
     """_is_on_cooldown returns False when the option-driven cooldown has passed."""
-    from datetime import timezone
 
     manager = _make_manager({"critical_cooldown_minutes": 1})
     growspace_id = "gs1"
     tier = NotificationTier.CRITICAL
 
     # Record cooldown 90 seconds ago
-    ninety_seconds_ago = datetime.now(tz=timezone.utc) - timedelta(seconds=90)
+    ninety_seconds_ago = datetime.now(tz=UTC) - timedelta(seconds=90)
     manager._cooldowns[growspace_id] = {tier: ninety_seconds_ago}
 
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     # 90s > 1 min — should NOT be on cooldown
     assert manager._is_on_cooldown(growspace_id, tier, now) is False
 

--- a/tests/core/test_notification_settings_payload.py
+++ b/tests/core/test_notification_settings_payload.py
@@ -10,7 +10,7 @@ import pytest
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from homeassistant.core import HomeAssistant
-from tests.common import MockConfigEntry  # noqa: TID251
+from tests.common import MockConfigEntry
 
 
 def create_coordinator(hass: HomeAssistant, options: dict[str, Any]) -> GrowspaceCoordinator:

--- a/tests/core/test_nutrient_preset_migration.py
+++ b/tests/core/test_nutrient_preset_migration.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from custom_components.growspace_manager.models import NutrientInventory, NutrientPreset, NutrientStock
+from custom_components.growspace_manager.models import (
+    NutrientInventory,
+    NutrientPreset,
+    NutrientStock,
+)
 from custom_components.growspace_manager.storage_manager import _migrate_preset_items
 
 

--- a/tests/core/test_shutdown.py
+++ b/tests/core/test_shutdown.py
@@ -1,11 +1,11 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from tests.common import MockConfigEntry
 
 from custom_components.growspace_manager import DOMAIN, async_unload_entry
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from homeassistant.core import HomeAssistant
+from tests.common import MockConfigEntry
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_subarea_manager.py
+++ b/tests/core/test_subarea_manager.py
@@ -12,8 +12,8 @@ from custom_components.growspace_manager.data_access.growspace_repository import
 from custom_components.growspace_manager.exceptions import GrowspaceNotFoundError
 from custom_components.growspace_manager.growspace_validator import GrowspaceValidator
 from custom_components.growspace_manager.managers.growspace import GrowspaceManager
-from custom_components.growspace_manager.services.context import ServiceContext
 from custom_components.growspace_manager.models import Growspace
+from custom_components.growspace_manager.services.context import ServiceContext
 from custom_components.growspace_manager.view_model_builder import ViewModelBuilder
 from homeassistant.exceptions import ServiceValidationError
 

--- a/tests/core/test_subsystem_manager.py
+++ b/tests/core/test_subsystem_manager.py
@@ -7,11 +7,11 @@ import pytest
 from custom_components.growspace_manager.circulation_fan_coordinator import (
     CirculationFanCoordinator,
 )
-from custom_components.growspace_manager.exhaust_fan_coordinator import (
-    ExhaustFanCoordinator,
-)
 from custom_components.growspace_manager.dehumidifier_coordinator import (
     DehumidifierCoordinator,
+)
+from custom_components.growspace_manager.exhaust_fan_coordinator import (
+    ExhaustFanCoordinator,
 )
 from custom_components.growspace_manager.humidifier_coordinator import (
     HumidifierCoordinator,

--- a/tests/core/test_tank_water_tracker.py
+++ b/tests/core/test_tank_water_tracker.py
@@ -494,8 +494,8 @@ def test_get_total_liters_today_timezone() -> None:
     In US/Eastern (UTC-4/5), an event at 03:30:00 UTC on 2026-03-22 is 23:30:00 on 2026-03-21 local.
     An event at 04:30:00 UTC on 2026-03-22 is 00:30:00 on 2026-03-22 local.
     """
-    from homeassistant.util import dt as dt_util  # noqa: PLC0415
-    from tests.conftest import _orig_set_default_time_zone  # noqa: PLC0415, TID251
+    from homeassistant.util import dt as dt_util
+    from tests.conftest import _orig_set_default_time_zone
 
     tz = dt_util.get_time_zone("US/Eastern")
     assert tz is not None
@@ -525,8 +525,8 @@ def test_get_total_liters_today_timezone() -> None:
 
 def test_get_total_liters_7d_timezone() -> None:
     """Test get_total_liters_7d handles local timezone boundaries correctly."""
-    from homeassistant.util import dt as dt_util  # noqa: PLC0415
-    from tests.conftest import _orig_set_default_time_zone  # noqa: PLC0415, TID251
+    from homeassistant.util import dt as dt_util
+    from tests.conftest import _orig_set_default_time_zone
 
     tz = dt_util.get_time_zone("US/Eastern")
     assert tz is not None

--- a/tests/core/test_vpd_optimal_overrides_model.py
+++ b/tests/core/test_vpd_optimal_overrides_model.py
@@ -1,6 +1,5 @@
 """Tests for vpd_optimal_overrides field on EnvironmentConfig."""
 
-import pytest
 
 from custom_components.growspace_manager.models import EnvironmentConfig
 

--- a/tests/core/test_websocket_ai_assistant.py
+++ b/tests/core/test_websocket_ai_assistant.py
@@ -1173,10 +1173,10 @@ async def test_send_message_injects_context_when_coordinator_available(
 
 def test_build_context_message_skips_empty_entity_ids() -> None:
     """_build_context_message ignores None or empty string entity IDs in specs."""
+    from custom_components.growspace_manager.models import EnvironmentConfig
     from custom_components.growspace_manager.websocket.ai_assistant import (
         _build_context_message,
     )
-    from custom_components.growspace_manager.models import EnvironmentConfig
 
     coordinator = _make_coordinator_with_growspace(
         vpd_sensor=None,

--- a/tests/core/test_websocket_get_briefing.py
+++ b/tests/core/test_websocket_get_briefing.py
@@ -10,7 +10,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.websocket.ai_assistant import (
     SCHEMA_WS_GET_BRIEFING,
     WS_TYPE_GET_BRIEFING,

--- a/tests/core/test_websocket_notifications.py
+++ b/tests/core/test_websocket_notifications.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from homeassistant.exceptions import ServiceValidationError
 
 

--- a/tests/domain/test_day_night.py
+++ b/tests/domain/test_day_night.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.growspace_manager.domain.day_night import DayNightTracker
-from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.const import STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 
 
 @pytest.fixture

--- a/tests/domain/test_drying_models.py
+++ b/tests/domain/test_drying_models.py
@@ -1,6 +1,5 @@
 """Tests for DryingData model defaults and serialization."""
 
-import pytest
 
 from custom_components.growspace_manager.models import (
     DryingData,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,16 +7,15 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 sys.modules["homeassistant.components.ai_task"] = MagicMock()
 
 # Inject Recorder dummy to satisfy Python 3.14 lazy annotation evaluation in recorder.migration
-import homeassistant.components.recorder.migration as migration
+from homeassistant.components.recorder import migration
+
 if not hasattr(migration, "Recorder"):
     migration.Recorder = MagicMock()
 
-from freezegun.api import FrozenDateTimeFactory
+import freezegun
 import pytest
 
 from custom_components.growspace_manager.date_time_helper import DateTimeHelper
-
-import freezegun
 
 
 @pytest.fixture(autouse=True)
@@ -33,7 +32,8 @@ def freeze_time() -> None:
 @pytest.fixture
 def mock_coordinator():
     """Create a comprehensive mock coordinator with all services mocked."""
-    from unittest.mock import MagicMock, AsyncMock
+    from unittest.mock import AsyncMock, MagicMock
+
     from custom_components.growspace_manager.services.facade import ServiceFacade
 
     coordinator = MagicMock()

--- a/tests/integration/conftest_syspath.py
+++ b/tests/integration/conftest_syspath.py
@@ -1,4 +1,3 @@
 import sys
-import os
 
 sys.path.insert(0, "/home/maxi/core/core")

--- a/tests/integration/test_alert_monitor.py
+++ b/tests/integration/test_alert_monitor.py
@@ -2,16 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 import uuid
 
 import pytest
 
-from custom_components.growspace_manager.const import (
-    ATTR_PROBABILITY,
-    ATTR_REASONS,
-    DOMAIN,
-)
+from custom_components.growspace_manager.const import ATTR_PROBABILITY, ATTR_REASONS
 
 GROWSPACE_ID = "tent1"
 STRESS_REASONS = ["High VPD: 1.8 kPa", "Fan off"]

--- a/tests/integration/test_alert_monitor_websocket.py
+++ b/tests/integration/test_alert_monitor_websocket.py
@@ -8,7 +8,6 @@ import pytest
 
 from custom_components.growspace_manager.const import DOMAIN
 
-
 GROWSPACE_ID = "tent1"
 
 

--- a/tests/integration/test_alert_monitor_wiring.py
+++ b/tests/integration/test_alert_monitor_wiring.py
@@ -9,15 +9,15 @@ Verifies that:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from tests.common import MockConfigEntry
 
 from custom_components.growspace_manager import DOMAIN
 from custom_components.growspace_manager.alert_monitor import AlertMonitor
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from homeassistant.core import HomeAssistant
+from tests.common import MockConfigEntry
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_circulation_fan_coordinator.py
+++ b/tests/integration/test_circulation_fan_coordinator.py
@@ -1,9 +1,8 @@
 """Integration tests for CirculationFanCoordinator."""
 
-from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import time as time_module
 
 from custom_components.growspace_manager.circulation_fan_coordinator import (
     FAN_VPD_STAGE_DEFAULTS,
@@ -12,7 +11,7 @@ from custom_components.growspace_manager.circulation_fan_coordinator import (
 from custom_components.growspace_manager.const import FanRegulationMode, PlantStage
 from custom_components.growspace_manager.models import EnvironmentConfig
 from custom_components.growspace_manager.models.growspace import CirculationFanConfig
-from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 
@@ -915,7 +914,6 @@ async def test_on_tick_creates_background_task(
     coord._on_tick(object())
 
     config_entry.async_create_background_task.assert_called_once()
-    _, kwargs = config_entry.async_create_background_task.call_args_list[0][0], config_entry.async_create_background_task.call_args_list[0][1]
     call_args = config_entry.async_create_background_task.call_args
     assert call_args[0][0] is mock_hass
     assert call_args[0][2] == "circulation_fan_regulate"
@@ -1041,7 +1039,9 @@ def test_read_sensor_unknown_mode_returns_none(
 
 def test_fan_vpd_stage_defaults_covers_all_coordinator_stages() -> None:
     """FAN_VPD_STAGE_DEFAULTS has entries for every stage determine_coordinator_stage can return."""
-    from custom_components.growspace_manager.circulation_fan_coordinator import FAN_VPD_STAGE_DEFAULTS
+    from custom_components.growspace_manager.circulation_fan_coordinator import (
+        FAN_VPD_STAGE_DEFAULTS,
+    )
     from custom_components.growspace_manager.const import PlantStage
 
     coordinator_stages = {
@@ -1308,7 +1308,9 @@ def test_stage_vpd_overrides_validation(
     match: str,
 ) -> None:
     """_validate_stage_vpd_overrides rejects out-of-range values, unknown keys, and incomplete entries."""
-    from custom_components.growspace_manager.services.environment import _validate_stage_vpd_overrides
+    from custom_components.growspace_manager.services.environment import (
+        _validate_stage_vpd_overrides,
+    )
     from homeassistant.exceptions import ServiceValidationError
 
     with pytest.raises(ServiceValidationError, match=match):

--- a/tests/integration/test_config_handlers_environment_coverage.py
+++ b/tests/integration/test_config_handlers_environment_coverage.py
@@ -257,7 +257,7 @@ async def test_save_and_finish(handler) -> None:
     env_config = {"temperature_sensors": ["sensor.t1"]}
 
     # Code calls await coordinator.async_commit()
-    result = await handler._async_save_and_finish(gs, env_config)  # noqa: SLF001
+    result = await handler._async_save_and_finish(gs, env_config)
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     handler.config_entry.runtime_data.services.save.assert_awaited_once()
@@ -495,7 +495,7 @@ async def test_add_lst_offset_to_schema(handler) -> None:
 
     opts = {CONF_TEMP_SENSOR: "s1", CONF_HUMIDITY_SENSOR: "s2"}
     # Line 652 path
-    handler._add_lst_offset_to_schema(schema_dict, opts)  # noqa: SLF001
+    handler._add_lst_offset_to_schema(schema_dict, opts)
     assert any("lst_offset" in str(k) for k in schema_dict)
 
 
@@ -800,7 +800,7 @@ def test_process_irrigation_tanks_comprehensive(
         "irrigation_tank_volume": 120.0,
     }
 
-    result = handler._process_irrigation_tanks(  # noqa: SLF001
+    result = handler._process_irrigation_tanks(
         env_config, existing_tanks=existing_tanks
     )
 
@@ -850,7 +850,7 @@ def test_process_irrigation_tanks_empty(
     env_config = {
         "irrigation_tank_sensors": [],
     }
-    result = handler._process_irrigation_tanks(env_config)  # noqa: SLF001
+    result = handler._process_irrigation_tanks(env_config)
     assert result["irrigation_tanks"] == []
 
 
@@ -864,7 +864,7 @@ def test_lst_offset_default_for_dry_and_cure_stages(
         "temperature_sensors": ["sensor.temp"],
         "humidity_sensors": ["sensor.humid"],
     }
-    handler._add_lst_offset_to_schema(schema_dict, growspace_options, stage="dry")  # noqa: SLF001
+    handler._add_lst_offset_to_schema(schema_dict, growspace_options, stage="dry")
     lst_key = None
     for k in schema_dict:
         if k.schema == "lst_offset":
@@ -875,7 +875,7 @@ def test_lst_offset_default_for_dry_and_cure_stages(
 
     # Test for "cure" stage
     schema_dict = {}
-    handler._add_lst_offset_to_schema(schema_dict, growspace_options, stage="cure")  # noqa: SLF001
+    handler._add_lst_offset_to_schema(schema_dict, growspace_options, stage="cure")
     lst_key = None
     for k in schema_dict:
         if k.schema == "lst_offset":
@@ -886,7 +886,7 @@ def test_lst_offset_default_for_dry_and_cure_stages(
 
     # Test for other stage e.g. "veg" (should default to -2.0)
     schema_dict = {}
-    handler._add_lst_offset_to_schema(schema_dict, growspace_options, stage="veg")  # noqa: SLF001
+    handler._add_lst_offset_to_schema(schema_dict, growspace_options, stage="veg")
     lst_key = None
     for k in schema_dict:
         if k.schema == "lst_offset":
@@ -1013,7 +1013,7 @@ async def test_process_irrigation_tanks_edge_cases(
         "irrigation_tank_volume": 120.0,
     }
 
-    result = handler._process_irrigation_tanks(  # noqa: SLF001
+    result = handler._process_irrigation_tanks(
         env_config, existing_tanks=existing_tanks
     )
 

--- a/tests/integration/test_coordinator_cache.py
+++ b/tests/integration/test_coordinator_cache.py
@@ -1,13 +1,14 @@
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-from .common import create_plant
 import pytest
-from tests.common import MockConfigEntry
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from homeassistant.core import HomeAssistant
+from tests.common import MockConfigEntry
+
+from .common import create_plant
 
 
 def create_test_coordinator(

--- a/tests/integration/test_coordinator_coverage.py
+++ b/tests/integration/test_coordinator_coverage.py
@@ -4,8 +4,6 @@ from datetime import date
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from tests.common import async_capture_events
-from tests.core.test_coordinator import create_test_coordinator
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
@@ -16,6 +14,8 @@ from custom_components.growspace_manager.models import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from tests.common import async_capture_events
+from tests.core.test_coordinator import create_test_coordinator
 
 
 @pytest.fixture

--- a/tests/integration/test_coordinator_load_coverage.py
+++ b/tests/integration/test_coordinator_load_coverage.py
@@ -3,12 +3,12 @@
 from unittest.mock import MagicMock
 
 import pytest
-from tests.common import MockConfigEntry
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from custom_components.growspace_manager.models import Growspace, Plant, PlantGenetics
 from homeassistant.core import HomeAssistant
+from tests.common import MockConfigEntry
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_coordinator_services.py
+++ b/tests/integration/test_coordinator_services.py
@@ -4,13 +4,13 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
-from tests.common import MockConfigEntry
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture

--- a/tests/integration/test_coverage_gap_fillers.py
+++ b/tests/integration/test_coverage_gap_fillers.py
@@ -19,10 +19,10 @@ from custom_components.growspace_manager.dehumidifier_coordinator import (
     DehumidifierCoordinator,
 )
 from custom_components.growspace_manager.domain.day_night import DayNightTracker
-from custom_components.growspace_manager.vpd_on_off_controller import VpdOnOffController
 
 # Direct imports of the functions we want to test
 from custom_components.growspace_manager.services.plant_facade import PlantFacade
+from custom_components.growspace_manager.vpd_on_off_controller import VpdOnOffController
 from custom_components.growspace_manager.websocket import _merge_logbook_event
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant

--- a/tests/integration/test_coverage_top_off.py
+++ b/tests/integration/test_coverage_top_off.py
@@ -25,14 +25,13 @@ from custom_components.growspace_manager.const import (
     PlantStage,
 )
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
-from custom_components.growspace_manager.domain.environment_state_assembler import (
-    AssembledEnvironment,
-)
 from custom_components.growspace_manager.dehumidifier_coordinator import (
     DehumidifierCoordinator,
 )
+from custom_components.growspace_manager.domain.environment_state_assembler import (
+    AssembledEnvironment,
+)
 from custom_components.growspace_manager.managers.plant import PlantManager
-from custom_components.growspace_manager.services.context import ServiceContext
 from custom_components.growspace_manager.models import (
     BaseModel,
     EnvironmentConfig,
@@ -41,6 +40,7 @@ from custom_components.growspace_manager.models import (
     NutrientInventory,
     Plant,
 )
+from custom_components.growspace_manager.services.context import ServiceContext
 from custom_components.growspace_manager.services.plant_facade import PlantFacade
 from custom_components.growspace_manager.storage_manager import StorageManager
 from custom_components.growspace_manager.strategies.mold import (
@@ -169,7 +169,7 @@ async def test_mold_risk_stage_branches_coverage(hass: HomeAssistant) -> None:
     )
     mock_coordinator.growspaces = {"gs1": mock_growspace}
 
-    description = GrowspaceBinarySensorDescription(
+    _description = GrowspaceBinarySensorDescription(
         key="mold_risk",
         sensor_type="mold_risk",
         name="Mold Risk",
@@ -238,7 +238,7 @@ async def test_lifecycle_history_closing_coverage(hass: HomeAssistant) -> None:
     validator = MagicMock()
     gs_service = MagicMock()
     strain_library = MagicMock()
-    serializer = MagicMock()
+    _serializer = MagicMock()
     save_callback = AsyncMock()
     lock = MagicMock()
     lock.__aenter__ = AsyncMock(return_value=None)
@@ -822,7 +822,7 @@ async def test_lifecycle_history_stages_coverage(hass: HomeAssistant) -> None:
     validator = MagicMock()
     gs_service = MagicMock()
     strain_library = MagicMock()
-    serializer = MagicMock()
+    _serializer = MagicMock()
     save_callback = AsyncMock()
     lock = MagicMock()
     lock.__aenter__ = AsyncMock(return_value=None)

--- a/tests/integration/test_debug_services.py
+++ b/tests/integration/test_debug_services.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from .common import create_plant
 import pytest
 
 from custom_components.growspace_manager.models import Plant
@@ -18,6 +17,8 @@ from custom_components.growspace_manager.services.debug import (
 )
 from custom_components.growspace_manager.strain_library import StrainLibrary
 from homeassistant.core import HomeAssistant, ServiceCall
+
+from .common import create_plant
 
 
 @pytest.fixture

--- a/tests/integration/test_environment_reporter.py
+++ b/tests/integration/test_environment_reporter.py
@@ -4,7 +4,6 @@ import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from tests.common import async_capture_events
 
 from custom_components.growspace_manager.const import EVENT_GROWSPACE_LOG_ENTRY
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
@@ -15,6 +14,7 @@ from custom_components.growspace_manager.services.environment_reporter import (
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.util import dt as dt_util
+from tests.common import async_capture_events
 
 
 @pytest.fixture

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1,7 +1,5 @@
 """Tests for Growspace Manager events."""
 
-from .common import create_plant
-
 from custom_components.growspace_manager.events import (
     EVENT_CLONES_TAKEN,
     EVENT_GROWSPACE_UPDATED,
@@ -12,6 +10,8 @@ from custom_components.growspace_manager.events import (
 )
 from custom_components.growspace_manager.models import Growspace
 from homeassistant.core import HomeAssistant, callback
+
+from .common import create_plant
 
 
 async def test_async_fire_growspace_event(hass: HomeAssistant) -> None:

--- a/tests/integration/test_facade_comprehensive.py
+++ b/tests/integration/test_facade_comprehensive.py
@@ -1,26 +1,19 @@
 """Comprehensive tests for ServiceFacade to increase coverage."""
 
-from datetime import date
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.growspace_manager.const import DOMAIN, PlantStage
+from custom_components.growspace_manager.const import PlantStage
+from custom_components.growspace_manager.data_access.notification_state import (
+    NotificationState,
+)
 from custom_components.growspace_manager.models import (
-    DrainConfig,
-    ECRampCurve,
-    EnvironmentConfig,
     Growspace,
     HarvestMetrics,
     IrrigationConfig,
     IrrigationTank,
     PhenotypeScore,
-    Plant,
-    PlantGenetics,
-    WaterUsageData,
-)
-from custom_components.growspace_manager.data_access.notification_state import (
-    NotificationState,
 )
 from custom_components.growspace_manager.services.facade import ServiceFacade
 from homeassistant.exceptions import ServiceValidationError
@@ -252,14 +245,14 @@ def test_get_sorted_growspace_options(mock_coordinator) -> None:
 
 def test_properties(mock_coordinator) -> None:
     """ServiceFacade should expose four domain sub-facades."""
+    from custom_components.growspace_manager.services.config_facade import ConfigFacade
     from custom_components.growspace_manager.services.growspace_facade import (
         GrowspaceFacade,
     )
-    from custom_components.growspace_manager.services.plant_facade import PlantFacade
-    from custom_components.growspace_manager.services.config_facade import ConfigFacade
     from custom_components.growspace_manager.services.notifications_facade import (
         NotificationsFacade,
     )
+    from custom_components.growspace_manager.services.plant_facade import PlantFacade
 
     facade = ServiceFacade(mock_coordinator)
     assert isinstance(facade.growspaces, GrowspaceFacade)
@@ -318,7 +311,6 @@ async def test_set_lighting_schedule_alias(mock_coordinator) -> None:
 @pytest.mark.asyncio
 async def test_set_lighting_schedule_no_dli(mock_coordinator) -> None:
     """async_set_lighting_schedule without dli_veg should not set dli_target_veg."""
-    from custom_components.growspace_manager.models import EnvironmentConfig
 
     facade = ServiceFacade(mock_coordinator)
     gs = Growspace(id="gs1", name="GS1")

--- a/tests/integration/test_facade_coverage.py
+++ b/tests/integration/test_facade_coverage.py
@@ -6,7 +6,6 @@ import pytest
 from custom_components.growspace_manager.const import PlantStage
 from custom_components.growspace_manager.models import DrainConfig, Growspace
 from custom_components.growspace_manager.services.facade import ServiceFacade
-from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 
 

--- a/tests/integration/test_final_coverage_gaps.py
+++ b/tests/integration/test_final_coverage_gaps.py
@@ -14,7 +14,6 @@ from custom_components.growspace_manager.irrigation_coordinator import (
     IrrigationCoordinator,
 )
 from custom_components.growspace_manager.managers.plant import PlantManager
-from custom_components.growspace_manager.services.context import ServiceContext
 from custom_components.growspace_manager.models import (
     Growspace,
     IPMPreset,
@@ -26,6 +25,7 @@ from custom_components.growspace_manager.models import (
 from custom_components.growspace_manager.service_coordinator_locator import (
     ServiceCoordinatorLocator,
 )
+from custom_components.growspace_manager.services.context import ServiceContext
 from custom_components.growspace_manager.services.ipm_service import IPMService
 from custom_components.growspace_manager.services.watering_service import (
     WateringService,

--- a/tests/integration/test_harvests_schema_migration.py
+++ b/tests/integration/test_harvests_schema_migration.py
@@ -14,7 +14,6 @@ import pytest
 
 from custom_components.growspace_manager.strain_library import StrainLibrary
 
-
 _OLD_HARVESTS_SCHEMA = """
 CREATE TABLE IF NOT EXISTS strains (
     strain_id INTEGER PRIMARY KEY,

--- a/tests/integration/test_init_coverage.py
+++ b/tests/integration/test_init_coverage.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from aiohttp import web
 import pytest
-from tests.common import MockConfigEntry
 
 from custom_components.growspace_manager import (
     async_reload_entry,
@@ -32,6 +31,7 @@ from custom_components.growspace_manager.websocket import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
+from tests.common import MockConfigEntry
 
 # --- Websocket Tests ---
 

--- a/tests/integration/test_init_extra_coverage.py
+++ b/tests/integration/test_init_extra_coverage.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from tests.common import MockConfigEntry
-
 from custom_components.growspace_manager import (
     _async_remove_dynamic_entities,
     async_register_sidebar_panel,
@@ -12,6 +10,7 @@ from custom_components.growspace_manager import (
 )
 from custom_components.growspace_manager.const import CONF_SHOW_SIDEBAR, DOMAIN
 from homeassistant.core import HomeAssistant
+from tests.common import MockConfigEntry
 
 
 async def test_async_setup_entry_pending_growspace_success(hass: HomeAssistant) -> None:

--- a/tests/integration/test_ipm_logic.py
+++ b/tests/integration/test_ipm_logic.py
@@ -1,11 +1,6 @@
 from unittest.mock import AsyncMock, MagicMock
 
-from .common import create_plant
 import pytest
-from tests.common import (
-    MockConfigEntry,
-    async_capture_events,
-)
 
 from custom_components.growspace_manager.const import (
     CATEGORY_IPM,
@@ -15,6 +10,9 @@ from custom_components.growspace_manager.const import (
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from custom_components.growspace_manager.models import Growspace, IPMPreset
 from homeassistant.core import HomeAssistant
+from tests.common import MockConfigEntry, async_capture_events
+
+from .common import create_plant
 
 
 @pytest.fixture

--- a/tests/integration/test_irrigation_config_volume_mode_flow.py
+++ b/tests/integration/test_irrigation_config_volume_mode_flow.py
@@ -40,7 +40,7 @@ def handler(mock_coordinator: MagicMock) -> IrrigationConfigHandler:
     coordinator.async_commit = AsyncMock()
     coordinator.async_request_refresh = AsyncMock()
     # The facade's get_growspace delegates to the data repository.
-    coordinator._data_repository.get_growspace.side_effect = (  # noqa: SLF001
+    coordinator._data_repository.get_growspace.side_effect = (
         lambda gid: coordinator.growspaces.get(gid)
     )
 

--- a/tests/integration/test_light_cycle_tracker.py
+++ b/tests/integration/test_light_cycle_tracker.py
@@ -80,7 +80,7 @@ async def fire_state_change(
         "old_state": MagicMock(state=old_state),
         "new_state": MagicMock(state=new_state, domain="binary_sensor"),
     }
-    await tracker._on_sensor_change(event)  # noqa: SLF001
+    await tracker._on_sensor_change(event)
 
 
 # ---------------------------------------------------------------------------
@@ -168,7 +168,7 @@ async def test_numeric_sensor_above_zero_is_on(
         "custom_components.growspace_manager.light_cycle_tracker.dt_util.now",
         return_value=MagicMock(time=lambda: fixed_time),
     ):
-        await tracker._on_sensor_change(event)  # noqa: SLF001
+        await tracker._on_sensor_change(event)
 
     assert gs.irrigation_strategy.detected_lights_on_time == "07:00:00"
 
@@ -190,7 +190,7 @@ async def test_numeric_sensor_zero_is_off_no_write(
         "old_state": MagicMock(state="500", domain="sensor"),
         "new_state": MagicMock(state="0", domain="sensor"),
     }
-    await tracker._on_sensor_change(event)  # noqa: SLF001
+    await tracker._on_sensor_change(event)
 
     assert gs.irrigation_strategy.detected_lights_on_time is None
     mock_main_coordinator.async_commit.assert_not_awaited()
@@ -234,7 +234,7 @@ async def test_listeners_removed_on_unload(
     tracker.unload()
 
     remove_fn.assert_called_once()
-    assert tracker._remove_listeners == []  # noqa: SLF001
+    assert tracker._remove_listeners == []
 
 
 async def test_no_write_when_irrigation_disabled(
@@ -261,7 +261,7 @@ async def test_is_active_no_growspace(
     """Test _is_active returns False when the growspace is missing from coordinator."""
     mock_main_coordinator.growspaces = {}
     tracker = LightCycleTracker(mock_hass, "gs1", mock_main_coordinator)
-    assert tracker._is_active() is False  # noqa: SLF001
+    assert tracker._is_active() is False
 
 
 async def test_is_active_no_irrigation_strategy(
@@ -273,7 +273,7 @@ async def test_is_active_no_irrigation_strategy(
     growspace.irrigation_strategy = None
     mock_main_coordinator.growspaces = {"gs1": growspace}
     tracker = LightCycleTracker(mock_hass, "gs1", mock_main_coordinator)
-    assert tracker._is_active() is False  # noqa: SLF001
+    assert tracker._is_active() is False
 
 
 async def test_light_sensors_no_growspace(
@@ -283,7 +283,7 @@ async def test_light_sensors_no_growspace(
     """Test _light_sensors returns empty list when the growspace is missing."""
     mock_main_coordinator.growspaces = {}
     tracker = LightCycleTracker(mock_hass, "gs1", mock_main_coordinator)
-    assert tracker._light_sensors() == []  # noqa: SLF001
+    assert tracker._light_sensors() == []
 
 
 @pytest.mark.parametrize("state", [STATE_UNAVAILABLE, STATE_UNKNOWN])
@@ -294,7 +294,7 @@ async def test_is_sensor_on_unavailable_or_unknown(
 ) -> None:
     """Test _is_sensor_on returns None when sensor state is unavailable or unknown."""
     tracker = LightCycleTracker(mock_hass, "gs1", mock_main_coordinator)
-    assert tracker._is_sensor_on("sensor.light1", state, "sensor") is None  # noqa: SLF001
+    assert tracker._is_sensor_on("sensor.light1", state, "sensor") is None
 
 
 async def test_is_sensor_on_non_numeric_sensor_value(
@@ -303,7 +303,7 @@ async def test_is_sensor_on_non_numeric_sensor_value(
 ) -> None:
     """Test _is_sensor_on returns None when sensor value cannot be converted to float."""
     tracker = LightCycleTracker(mock_hass, "gs1", mock_main_coordinator)
-    assert tracker._is_sensor_on("sensor.light1", "not-a-number", "sensor") is None  # noqa: SLF001
+    assert tracker._is_sensor_on("sensor.light1", "not-a-number", "sensor") is None
 
 
 async def test_record_lights_on_no_growspace(
@@ -313,7 +313,7 @@ async def test_record_lights_on_no_growspace(
     """Test _record_lights_on exits early when the growspace is missing from coordinator."""
     mock_main_coordinator.growspaces = {}
     tracker = LightCycleTracker(mock_hass, "gs1", mock_main_coordinator)
-    await tracker._record_lights_on()  # noqa: SLF001
+    await tracker._record_lights_on()
     mock_main_coordinator.async_commit.assert_not_awaited()
 
 
@@ -326,5 +326,5 @@ async def test_record_lights_on_no_irrigation_strategy(
     growspace.irrigation_strategy = None
     mock_main_coordinator.growspaces = {"gs1": growspace}
     tracker = LightCycleTracker(mock_hass, "gs1", mock_main_coordinator)
-    await tracker._record_lights_on()  # noqa: SLF001
+    await tracker._record_lights_on()
     mock_main_coordinator.async_commit.assert_not_awaited()

--- a/tests/integration/test_optimistic_events.py
+++ b/tests/integration/test_optimistic_events.py
@@ -1,11 +1,12 @@
 from unittest.mock import AsyncMock, MagicMock
 
-from .common import create_plant
 import pytest
-from tests.common import MockConfigEntry
 
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from homeassistant.core import HomeAssistant
+from tests.common import MockConfigEntry
+
+from .common import create_plant
 
 
 @pytest.fixture

--- a/tests/integration/test_plant_facade_coverage.py
+++ b/tests/integration/test_plant_facade_coverage.py
@@ -5,13 +5,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.growspace_manager.const import DOMAIN, NotificationTier, PlantStage, VERSION
-from custom_components.growspace_manager.models import (
-    HarvestMetrics,
-    PhenotypeScore,
-    Plant,
-    PlantGenetics,
+from custom_components.growspace_manager.const import (
+    DOMAIN,
+    VERSION,
+    NotificationTier,
+    PlantStage,
 )
+from custom_components.growspace_manager.models import Plant, PlantGenetics
 from custom_components.growspace_manager.services.plant_facade import PlantFacade
 from homeassistant.exceptions import ServiceValidationError
 
@@ -51,13 +51,13 @@ async def test_add_plant_success(mock_coordinator: MagicMock) -> None:
     plant = Plant(plant_id="plant_1", growspace_id="gs1")
     plant.genetics = PlantGenetics(strain_name="OG Kush", phenotype_name="Pheno 1")
     mock_coordinator._plant_manager.add_plant = AsyncMock(return_value=plant)
-    
+
     mock_dr = MagicMock()
     mock_dr.async_get_or_create = MagicMock()
-    
+
     with patch("homeassistant.helpers.device_registry.async_get", return_value=mock_dr):
         result = await facade.add_plant(strain="OG Kush")
-        
+
     assert result == plant
     mock_dr.async_get_or_create.assert_called_once_with(
         config_entry_id=mock_coordinator.config_entry.entry_id,
@@ -77,13 +77,13 @@ async def test_add_plant_success_no_genetics(mock_coordinator: MagicMock) -> Non
     plant = Plant(plant_id="plant_1", growspace_id="gs1")
     plant.genetics = None
     mock_coordinator._plant_manager.add_plant = AsyncMock(return_value=plant)
-    
+
     mock_dr = MagicMock()
     mock_dr.async_get_or_create = MagicMock()
-    
+
     with patch("homeassistant.helpers.device_registry.async_get", return_value=mock_dr):
         result = await facade.add_plant()
-        
+
     assert result == plant
     mock_dr.async_get_or_create.assert_called_once_with(
         config_entry_id=mock_coordinator.config_entry.entry_id,
@@ -181,20 +181,20 @@ async def test_remove_plant_entities(mock_coordinator: MagicMock) -> None:
     """Test remove_plant_entities removes correct HA entities."""
     facade = PlantFacade(mock_coordinator)
     mock_er = MagicMock()
-    
+
     entry1 = MagicMock()
     entry1.unique_id = "plant_123_sensor"
     entry2 = MagicMock()
     entry2.unique_id = "plant_456_sensor"
-    
+
     mock_er.entities = {
         "sensor.plant_123_sensor": entry1,
         "sensor.plant_456_sensor": entry2,
     }
-    
+
     with patch("homeassistant.helpers.entity_registry.async_get", return_value=mock_er):
         await facade.remove_plant_entities("plant_123")
-        
+
     mock_er.async_remove.assert_called_once_with("sensor.plant_123_sensor")
 
 
@@ -341,12 +341,12 @@ async def test_async_harvest_plant(mock_coordinator: MagicMock) -> None:
 async def test_async_auto_harvest(mock_coordinator: MagicMock) -> None:
     """Test _async_auto_harvest auto-harvests eligible flowering plants only."""
     facade = PlantFacade(mock_coordinator)
-    
+
     plant1 = Plant(plant_id="plant1", growspace_id="gs1")
     plant1.genetics = PlantGenetics(strain_name="OG Kush")
     plant1.transition_date = "2026-01-10"  # before frozen "2026-01-12"
     plant1.stage = PlantStage.FLOWER
-    
+
     plant2 = Plant(plant_id="plant2", growspace_id="gs1")
     plant2.genetics = PlantGenetics(strain_name="LSD")
     plant2.transition_date = "2026-01-15"  # after frozen

--- a/tests/integration/test_plant_history.py
+++ b/tests/integration/test_plant_history.py
@@ -2,9 +2,9 @@
 
 from datetime import datetime, timedelta
 
-from .common import create_plant
-
 from custom_components.growspace_manager.models import Plant, StageHistoryItem
+
+from .common import create_plant
 
 
 def test_plant_from_dict_creates_history() -> None:

--- a/tests/integration/test_plant_lifecycle_coverage.py
+++ b/tests/integration/test_plant_lifecycle_coverage.py
@@ -3,7 +3,6 @@
 from datetime import date
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from .common import create_plant
 import pytest
 
 from custom_components.growspace_manager.const import PlantStage
@@ -12,8 +11,10 @@ from custom_components.growspace_manager.data_access.notification_state import (
 )
 from custom_components.growspace_manager.exceptions import ValidationChangeError
 from custom_components.growspace_manager.managers.plant import PlantManager
-from custom_components.growspace_manager.services.context import ServiceContext
 from custom_components.growspace_manager.models import Growspace
+from custom_components.growspace_manager.services.context import ServiceContext
+
+from .common import create_plant
 
 
 @pytest.fixture

--- a/tests/integration/test_plant_services_coverage.py
+++ b/tests/integration/test_plant_services_coverage.py
@@ -1,20 +1,16 @@
 """Test plant services coverage."""
 
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.growspace_manager.const import (
-    ATTR_NOTES,
-    ATTR_PLANT_ID,
-)
+from custom_components.growspace_manager.const import ATTR_NOTES, ATTR_PLANT_ID
 from custom_components.growspace_manager.exceptions import GrowspaceError
 from custom_components.growspace_manager.services.plant_facade import PlantFacade
 from custom_components.growspace_manager.services.plant_lifecycle import (
     handle_harvest_plant,
 )
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import ServiceCall
 from homeassistant.exceptions import ServiceValidationError
 
 
@@ -28,7 +24,7 @@ async def test_handle_add_timeline_note_service_call() -> None:
 
     mock_call = MagicMock(spec=ServiceCall)
     mock_call.data = {
-        ATTR_PLANT_ID: "plant1", 
+        ATTR_PLANT_ID: "plant1",
         ATTR_NOTES: "Service call note"
     }
 
@@ -41,7 +37,7 @@ async def test_handle_add_timeline_note_service_call() -> None:
         await PlantFacade(coordinator).add_timeline_note_from_call(
             hass, strain_library, mock_call
         )
-        
+
     coordinator.services.add_timeline_note.assert_awaited_once_with(
         plant_id="plant1",
         notes="Service call note",

--- a/tests/integration/test_reset_plant_last_watered.py
+++ b/tests/integration/test_reset_plant_last_watered.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
@@ -18,6 +16,8 @@ from custom_components.growspace_manager.models import Growspace
 from custom_components.growspace_manager.services.irrigation_watering import (
     handle_reset_plant_last_watered,
 )
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from tests.common import MockConfigEntry
 
 from .common import create_plant

--- a/tests/integration/test_safety_guard_enforcement.py
+++ b/tests/integration/test_safety_guard_enforcement.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from custom_components.growspace_manager.const import (
     ATTR_GROWSPACE_ID,
-    CATEGORY_ALERT,
     DOMAIN,
     EVENT_GROWSPACE_LOG_ENTRY,
 )

--- a/tests/integration/test_services_growspace_coverage.py
+++ b/tests/integration/test_services_growspace_coverage.py
@@ -8,13 +8,13 @@ from syrupy.assertion import SnapshotAssertion
 
 from custom_components.growspace_manager.exceptions import GrowspaceNotFoundError
 from custom_components.growspace_manager.managers.growspace import GrowspaceManager
-from custom_components.growspace_manager.services.context import ServiceContext
 from custom_components.growspace_manager.models import (
     EnvironmentConfig,
     Growspace,
     GrowspaceType,
     Plant,
 )
+from custom_components.growspace_manager.services.context import ServiceContext
 from homeassistant.core import HomeAssistant
 
 

--- a/tests/integration/test_services_plant_coverage.py
+++ b/tests/integration/test_services_plant_coverage.py
@@ -1,14 +1,13 @@
 """Coverage-focused tests for PlantService."""
 
-from datetime import date
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from custom_components.growspace_manager.const import PlantStage
 from custom_components.growspace_manager.managers.plant import PlantManager
-from custom_components.growspace_manager.services.context import ServiceContext
 from custom_components.growspace_manager.models import Plant, PlantGenetics
+from custom_components.growspace_manager.services.context import ServiceContext
 from homeassistant.core import HomeAssistant
 
 

--- a/tests/integration/test_services_plant_simple_coverage.py
+++ b/tests/integration/test_services_plant_simple_coverage.py
@@ -3,7 +3,6 @@
 from datetime import date
 from unittest.mock import AsyncMock, MagicMock
 
-from .common import create_plant
 import pytest
 
 from custom_components.growspace_manager.const import (
@@ -17,9 +16,11 @@ from custom_components.growspace_manager.const import (
     EVENT_GROWSPACE_LOG_ENTRY,
 )
 from custom_components.growspace_manager.managers.plant import PlantManager
-from custom_components.growspace_manager.services.context import ServiceContext
 from custom_components.growspace_manager.models import PlantStage
+from custom_components.growspace_manager.services.context import ServiceContext
 from homeassistant.core import HomeAssistant, ServiceCall
+
+from .common import create_plant
 
 
 @pytest.fixture

--- a/tests/integration/test_storage_manager_extra.py
+++ b/tests/integration/test_storage_manager_extra.py
@@ -4,10 +4,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from custom_components.growspace_manager.models import (
-    Growspace,
-    Plant,
-)
 from custom_components.growspace_manager.storage_manager import StorageManager
 from homeassistant.core import HomeAssistant
 

--- a/tests/integration/test_strain_library_coverage.py
+++ b/tests/integration/test_strain_library_coverage.py
@@ -8,7 +8,7 @@ from custom_components.growspace_manager.strain_library import StrainLibrary
 @pytest.fixture
 def mock_hass():
     hass = MagicMock()
-    hass.config.path.return_value = "/tmp/test_db.sqlite"  # noqa: S108
+    hass.config.path.return_value = "/tmp/test_db.sqlite"
     return hass
 
 

--- a/tests/integration/test_training_logic.py
+++ b/tests/integration/test_training_logic.py
@@ -3,9 +3,7 @@
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from .common import create_plant
 import pytest
-from tests.common import MockConfigEntry
 
 from custom_components.growspace_manager.const import (
     ATTR_GROWSPACE_ID,
@@ -17,6 +15,9 @@ from custom_components.growspace_manager.const import (
 )
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from homeassistant.core import HomeAssistant, ServiceCall
+from tests.common import MockConfigEntry
+
+from .common import create_plant
 
 
 @pytest.fixture

--- a/tests/integration/test_vwc_irrigation_coordinator.py
+++ b/tests/integration/test_vwc_irrigation_coordinator.py
@@ -940,7 +940,7 @@ async def test_halt_on_runoff_ec_threshold_exceeded_halts_watering(
         ),
         patch(
             "custom_components.growspace_manager.vwc_irrigation_coordinator._LOGGER"
-        ) as mock_logger,
+        ),
     ):
         mock_hass.states.get.return_value = MagicMock(state="40.0")
         await vwc_coordinator._update_loop(now_dt)

--- a/tests/integration/test_watering_feature.py
+++ b/tests/integration/test_watering_feature.py
@@ -8,12 +8,7 @@ sensor attribute integration.
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
-from .common import create_plant
 import pytest
-from tests.common import (
-    MockConfigEntry,
-    async_capture_events,
-)
 
 from custom_components.growspace_manager.const import DOMAIN, EVENT_GROWSPACE_LOG_ENTRY
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
@@ -28,6 +23,9 @@ from custom_components.growspace_manager.services.irrigation_watering import (
     handle_water_plant,
 )
 from homeassistant.core import HomeAssistant
+from tests.common import MockConfigEntry, async_capture_events
+
+from .common import create_plant
 
 
 def create_test_coordinator(hass: HomeAssistant) -> GrowspaceCoordinator:

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -1,7 +1,7 @@
 """Test the Growspace Manager WebSocket API."""
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1517,7 +1517,7 @@ async def test_dense_entity_uses_downsampler(
     with patch(
         "custom_components.growspace_manager.websocket.environment.get_instance"
     ) as mock_recorder:
-        base = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        base = datetime(2023, 1, 1, 0, 0, 0, tzinfo=UTC)
         dense_states = [
             {
                 "last_updated": (base + timedelta(minutes=i)).isoformat(),

--- a/tests/integration/test_websocket_camera_coverage.py
+++ b/tests/integration/test_websocket_camera_coverage.py
@@ -144,7 +144,7 @@ async def test_capture_snapshot_camera_service_fails(
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            raise Exception("Camera error")  # noqa: TRY002
+            raise Exception("Camera error")
 
     with (
         patch(

--- a/tests/integration/test_websocket_coverage.py
+++ b/tests/integration/test_websocket_coverage.py
@@ -1,8 +1,8 @@
 """Tests for Websocket coverage (exceptions and edge cases)."""
 
+import asyncio
 from dataclasses import dataclass
 import json
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -587,7 +587,9 @@ def test_websocket_get_genetics_data_error(
 @pytest.mark.asyncio
 async def test_websocket_get_strain_lineage_tree_success(mock_hass: MagicMock) -> None:
     """Test get_strain_lineage_tree returns resolved tree."""
-    from custom_components.growspace_manager.websocket import websocket_get_strain_lineage_tree
+    from custom_components.growspace_manager.websocket import (
+        websocket_get_strain_lineage_tree,
+    )
 
     strain_library = MagicMock()
     strain_library.get_strain_lineage_tree.return_value = {
@@ -616,7 +618,9 @@ async def test_websocket_get_strain_lineage_tree_success(mock_hass: MagicMock) -
 @pytest.mark.asyncio
 async def test_websocket_get_strain_lineage_tree_not_loaded(mock_hass: MagicMock) -> None:
     """Test get_strain_lineage_tree when strain library not loaded."""
-    from custom_components.growspace_manager.websocket import websocket_get_strain_lineage_tree
+    from custom_components.growspace_manager.websocket import (
+        websocket_get_strain_lineage_tree,
+    )
 
     mock_hass.data = {}
     connection = MagicMock()

--- a/tests/integration/test_websocket_plant.py
+++ b/tests/integration/test_websocket_plant.py
@@ -1,7 +1,7 @@
 """Tests for websocket/plant.py handlers."""
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -30,8 +30,8 @@ from homeassistant.exceptions import ServiceValidationError
 
 _PATCH = "custom_components.growspace_manager.websocket.plant"
 _GET_COORD = f"{_PATCH}.GrowspaceCoordinator.get_for_service_call"
-_FIXED_NOW = datetime(2026, 1, 12, 12, 0, 0, tzinfo=timezone.utc)
-_FIXED_DT = datetime(2026, 1, 10, 12, 0, 0, tzinfo=timezone.utc)
+_FIXED_NOW = datetime(2026, 1, 12, 12, 0, 0, tzinfo=UTC)
+_FIXED_DT = datetime(2026, 1, 10, 12, 0, 0, tzinfo=UTC)
 
 
 @pytest.fixture

--- a/tests/issue_fixes/test_ghost_plant_bug.py
+++ b/tests/issue_fixes/test_ghost_plant_bug.py
@@ -1,13 +1,11 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
-from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.growspace_manager.const import DOMAIN
+from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
+from homeassistant.core import HomeAssistant
 
 
 @pytest.mark.asyncio

--- a/tests/issue_fixes/test_issue_drain_pump.py
+++ b/tests/issue_fixes/test_issue_drain_pump.py
@@ -3,7 +3,6 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from tests.common import MockConfigEntry
 
 from custom_components.growspace_manager.config_flow import OptionsFlowHandler
 from custom_components.growspace_manager.const import DOMAIN
@@ -12,6 +11,7 @@ from custom_components.growspace_manager.models import (
     IrrigationStrategy,
 )
 from homeassistant.core import HomeAssistant
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -77,7 +77,7 @@ async def test_irrigation_config_optional_drain_pump(
 
     mock_coordinator.services.growspaces.update_irrigation_config.assert_called_once()
     call_args = mock_coordinator.services.growspaces.update_irrigation_config.call_args
-    
+
     assert len(call_args.args) >= 1, "Expected growspace_id as positional arg"
     growspace_id = call_args.args[0]
     data = call_args.args[1]
@@ -197,7 +197,7 @@ async def test_irrigation_config_empty_string_drain_pump(
 
     mock_coordinator.services.growspaces.update_irrigation_config.assert_called_once()
     call_args = mock_coordinator.services.growspaces.update_irrigation_config.call_args
-    data = call_args.args[1]
+    _data = call_args.args[1]
 
     # This assumes the coordinator normalization logic works on the input dictionary inplace
     # OR that the arguments passed to it are what we check.

--- a/tests/logic/test_bayesian_evaluator.py
+++ b/tests/logic/test_bayesian_evaluator.py
@@ -27,7 +27,7 @@ from custom_components.growspace_manager.models import EnvironmentState
 @pytest.mark.asyncio
 async def test_async_evaluate_fallback_mold_trend_analysis_rising() -> None:
     """Test fallback mold trend analysis for rising humidity."""
-    sensor_instance = MagicMock()
+    _sensor_instance = MagicMock()
     env_config: dict[str, Any] = {
         "humidity_sensor": "sensor.humidity",
         "humidity_trend_sensitivity": 0.5,

--- a/tests/logic/test_environment_analyzer.py
+++ b/tests/logic/test_environment_analyzer.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from custom_components.growspace_manager.const import DEFAULT_FLOWER_EARLY_DAYS
-from custom_components.growspace_manager.domain.stage import BayesianStage, StageDays, classify_stages
+from custom_components.growspace_manager.domain.stage import (
+    BayesianStage,
+    StageDays,
+    classify_stages,
+)
 from custom_components.growspace_manager.environment_analyzer import EnvironmentAnalyzer
 from custom_components.growspace_manager.models import EnvironmentConfig
 from homeassistant.const import STATE_ON

--- a/tests/logic/test_evaluate_optimal_vpd_overrides.py
+++ b/tests/logic/test_evaluate_optimal_vpd_overrides.py
@@ -7,9 +7,9 @@ SEEDLING_STANDARD default day: [(0.4, 0.8), (0.3, 0.9)]
 
 from unittest.mock import MagicMock
 
-import pytest
-
-from custom_components.growspace_manager.bayesian_data import PROB_VPD_STRESS_OUT_OF_RANGE
+from custom_components.growspace_manager.bayesian_data import (
+    PROB_VPD_STRESS_OUT_OF_RANGE,
+)
 from custom_components.growspace_manager.bayesian_evaluator import evaluate_optimal_vpd
 from custom_components.growspace_manager.models import EnvironmentState
 

--- a/tests/logic/test_growspace_validator.py
+++ b/tests/logic/test_growspace_validator.py
@@ -1,8 +1,6 @@
 """Tests for GrowspaceValidator."""
 
-from unittest.mock import MagicMock
 
-from .common import create_plant
 import pytest
 
 from custom_components.growspace_manager.const import PlantStage
@@ -16,6 +14,8 @@ from custom_components.growspace_manager.exceptions import (
 )
 from custom_components.growspace_manager.growspace_validator import GrowspaceValidator
 from custom_components.growspace_manager.models import Growspace
+
+from .common import create_plant
 
 
 @pytest.fixture

--- a/tests/logic/test_post_harvest_strategies.py
+++ b/tests/logic/test_post_harvest_strategies.py
@@ -1,11 +1,16 @@
 """Tests for post-harvest strategies."""
 
 from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from custom_components.growspace_manager.models import EnvironmentState, GrowspaceType
-from custom_components.growspace_manager.strategies.drying import DryingEvaluatorStrategy
-from custom_components.growspace_manager.strategies.curing import CuringEvaluatorStrategy
+from custom_components.growspace_manager.strategies.curing import (
+    CuringEvaluatorStrategy,
+)
+from custom_components.growspace_manager.strategies.drying import (
+    DryingEvaluatorStrategy,
+)
 
 
 @pytest.fixture

--- a/tests/logic/test_stress_strategies.py
+++ b/tests/logic/test_stress_strategies.py
@@ -1,10 +1,13 @@
 """Tests for stress strategies."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 from custom_components.growspace_manager.models import EnvironmentState
-from custom_components.growspace_manager.strategies.stress import StressEvaluatorStrategy
+from custom_components.growspace_manager.strategies.stress import (
+    StressEvaluatorStrategy,
+)
 
 
 @pytest.fixture
@@ -36,7 +39,7 @@ def test_stress_notification(mock_sensor: MagicMock) -> None:
     # new_state_on is True -> should return notification
     title_msg = strategy.get_notification_title_message(True, [])
     assert title_msg is not None
-    assert "Plant Stress Alert: FloweringTent" == title_msg[0]
+    assert title_msg[0] == "Plant Stress Alert: FloweringTent"
 
     # Test when growspace is None
     strategy_no_growspace = StressEvaluatorStrategy(
@@ -48,7 +51,7 @@ def test_stress_notification(mock_sensor: MagicMock) -> None:
     )
     title_msg_fallback = strategy_no_growspace.get_notification_title_message(True, [])
     assert title_msg_fallback is not None
-    assert "Plant Stress Alert: Unknown" == title_msg_fallback[0]
+    assert title_msg_fallback[0] == "Plant Stress Alert: Unknown"
 
 
 @pytest.mark.asyncio

--- a/tests/managers/test_lineage_manager.py
+++ b/tests/managers/test_lineage_manager.py
@@ -1,7 +1,5 @@
-import pytest
 
 from custom_components.growspace_manager.managers.lineage import StrainLineageManager
-
 
 STRAINS = {
     "Gelato": {

--- a/tests/managers/test_strain_analytics_manager.py
+++ b/tests/managers/test_strain_analytics_manager.py
@@ -1,9 +1,7 @@
-import pytest
 
 from custom_components.growspace_manager.managers.strain_analytics import (
     StrainAnalyticsManager,
 )
-
 
 STRAINS_WITH_HARVESTS = {
     "OG Kush": {

--- a/tests/notifications/test_notification_settings_manager.py
+++ b/tests/notifications/test_notification_settings_manager.py
@@ -1,6 +1,7 @@
 """Tests for the NotificationSettingsManager."""
 
 from unittest.mock import MagicMock
+
 import pytest
 
 from custom_components.growspace_manager.notifications.notification_settings_manager import (

--- a/tests/sensors/test_drying_sensors.py
+++ b/tests/sensors/test_drying_sensors.py
@@ -1,9 +1,10 @@
 """Tests for DryingWeightSensor, DryingMoistureSensor, DryingReadyForCureSensor."""
 
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.growspace_manager.binary_sensor import DryingReadyForCureSensor
 from custom_components.growspace_manager.models import (
     DryingData,
     HarvestMetrics,
@@ -15,7 +16,6 @@ from custom_components.growspace_manager.sensor import (
     DryingMoistureSensor,
     DryingWeightSensor,
 )
-from custom_components.growspace_manager.binary_sensor import DryingReadyForCureSensor
 
 
 def _make_plant(

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -1,6 +1,5 @@
-import asyncio
 import inspect
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 from freezegun import freeze_time as fg_freeze_time
 import pytest
@@ -36,7 +35,7 @@ def mock_coordinator(mock_plant, mock_growspace):
     coordinator._nutrient_manager = MagicMock()
     coordinator.training_manager = MagicMock()
     coordinator.harvest_manager = MagicMock()
-    
+
     # Other services
     coordinator.watering_service = MagicMock()
     coordinator.ipm_service = MagicMock()
@@ -143,15 +142,15 @@ def mock_coordinator(mock_plant, mock_growspace):
     type(coordinator).growspace_service = property(lambda self: self._growspace_manager)
     type(coordinator).plant_service = property(lambda self: self._plant_manager)
 
-    
+
     coordinator._growspace_manager.async_add_growspace = coordinator._growspace_manager.add_growspace
     coordinator._growspace_manager.async_update_growspace = coordinator._growspace_manager.update_growspace
     coordinator._growspace_manager.async_remove_growspace = coordinator._growspace_manager.remove_growspace
     coordinator._growspace_manager.async_update_environment_config = coordinator._growspace_manager.update_environment_config
-    
+
     coordinator._nutrient_manager.async_commit_preset = coordinator._nutrient_manager.async_save_nutrient_preset
     coordinator._nutrient_manager.async_remove_preset = coordinator._nutrient_manager.async_remove_nutrient_preset
-    
+
     coordinator.training_manager.async_record_training = coordinator.training_service.async_log_training_event
 
     coordinator._growspace_manager.ensure_special_growspace = MagicMock(return_value="special_gs")

--- a/tests/services/test_config_facade_extensions.py
+++ b/tests/services/test_config_facade_extensions.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import MagicMock
 
-import pytest
-
 from custom_components.growspace_manager.services.config_facade import ConfigFacade
 
 

--- a/tests/services/test_debug_coverage.py
+++ b/tests/services/test_debug_coverage.py
@@ -1,6 +1,7 @@
 """Coverage tests for debug.py."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from custom_components.growspace_manager.models import Plant

--- a/tests/services/test_ec_target_range.py
+++ b/tests/services/test_ec_target_range.py
@@ -4,10 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.growspace_manager.const import (
-    ATTR_GROWSPACE_ID,
-    ATTR_STAGE,
-)
+from custom_components.growspace_manager.const import ATTR_GROWSPACE_ID, ATTR_STAGE
 from custom_components.growspace_manager.services.irrigation import (
     handle_set_ec_target_range,
 )

--- a/tests/services/test_ec_target_range_facade.py
+++ b/tests/services/test_ec_target_range_facade.py
@@ -1,6 +1,6 @@
 """Tests for ECTargetRange upsert behavior in GrowspaceFacade and view model round-trip."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/tests/services/test_growspace_facade_extensions.py
+++ b/tests/services/test_growspace_facade_extensions.py
@@ -2,10 +2,10 @@
 
 from unittest.mock import MagicMock
 
-import pytest
-
 from custom_components.growspace_manager.domain.stage import StageDays
-from custom_components.growspace_manager.services.growspace_facade import GrowspaceFacade
+from custom_components.growspace_manager.services.growspace_facade import (
+    GrowspaceFacade,
+)
 
 
 def _make_coordinator() -> MagicMock:

--- a/tests/services/test_irrigation_coordinator.py
+++ b/tests/services/test_irrigation_coordinator.py
@@ -231,7 +231,7 @@ async def test_async_wait_for_switch_state_timeout(
     async def mock_wait_for(fut, timeout=None):
         if hasattr(fut, "close"):
             fut.close()
-        raise asyncio.TimeoutError()
+        raise TimeoutError
 
     with patch("asyncio.wait_for", new=mock_wait_for):
         result = await coordinator._async_wait_for_switch_state(

--- a/tests/services/test_nutrient_deduction_integration.py
+++ b/tests/services/test_nutrient_deduction_integration.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from .common import create_plant
 import pytest
 
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
@@ -12,6 +11,8 @@ from custom_components.growspace_manager.models import (
     NutrientStock,
 )
 from homeassistant.core import HomeAssistant
+
+from .common import create_plant
 
 
 @pytest.fixture

--- a/tests/services/test_plant_lifecycle_handlers.py
+++ b/tests/services/test_plant_lifecycle_handlers.py
@@ -7,7 +7,6 @@ import pytest
 from custom_components.growspace_manager.const import (
     ATTR_NEW_STAGE,
     ATTR_PLANT_ID,
-    ATTR_TARGET_GROWSPACE_ID,
     ATTR_WET_WEIGHT,
 )
 from custom_components.growspace_manager.services.plant_lifecycle import (

--- a/tests/services/test_plant_scoring.py
+++ b/tests/services/test_plant_scoring.py
@@ -12,7 +12,9 @@ from custom_components.growspace_manager.models import (
     PlantGenetics,
 )
 from custom_components.growspace_manager.schemas import SCORE_PLANT_SCHEMA
-from custom_components.growspace_manager.services.plant_scoring import handle_score_plant
+from custom_components.growspace_manager.services.plant_scoring import (
+    handle_score_plant,
+)
 from homeassistant.exceptions import ServiceValidationError
 
 

--- a/tests/services/test_print_label_rework.py
+++ b/tests/services/test_print_label_rework.py
@@ -4,7 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.growspace_manager.services.strain_library import handle_print_label
+from custom_components.growspace_manager.services.strain_library import (
+    handle_print_label,
+)
 from homeassistant.core import HomeAssistant, ServiceCall
 
 

--- a/tests/services/test_print_label_size_scaling.py
+++ b/tests/services/test_print_label_size_scaling.py
@@ -4,7 +4,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.growspace_manager.services.strain_library import handle_print_label
+from custom_components.growspace_manager.services.strain_library import (
+    handle_print_label,
+)
 from homeassistant.core import HomeAssistant, ServiceCall
 
 

--- a/tests/services/test_strain_library.py
+++ b/tests/services/test_strain_library.py
@@ -1,6 +1,5 @@
 """Tests for the StrainLibrary class."""
 
-import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/services/test_strain_library_refinements.py
+++ b/tests/services/test_strain_library_refinements.py
@@ -1,10 +1,12 @@
 """Tests for strain library refinements (stubs and 0% percentages)."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
 import aiosqlite
+import pytest
 
 from custom_components.growspace_manager.strain_library import StrainLibrary
+
 
 @pytest.fixture
 def mock_hass():

--- a/tests/services/test_tank_monitor.py
+++ b/tests/services/test_tank_monitor.py
@@ -1,5 +1,6 @@
 """Tests for TankLevelMonitor."""
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/test_briefing_scheduler.py
+++ b/tests/test_briefing_scheduler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import timedelta
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -16,7 +16,6 @@ from custom_components.growspace_manager.models import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
-
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -5,18 +5,16 @@ from __future__ import annotations
 import io
 
 import numpy as np
-import pytest
 from PIL import Image
+import pytest
 
 from custom_components.growspace_manager.image_processor import (
-    GrowspaceImageProcessor,
     _GREEN_LOWER,
     _GREEN_UPPER,
-    _GRID_COLS,
     _GRID_ROWS,
+    GrowspaceImageProcessor,
     _rgb_to_hsv_ocv,
 )
-
 
 # ---------------------------------------------------------------------------
 # Image helpers

--- a/tests/test_lineage_classifier.py
+++ b/tests/test_lineage_classifier.py
@@ -1,15 +1,13 @@
 """Tests for lineage_classifier — pure functions, no HA dependencies."""
 from __future__ import annotations
 
-import pytest
 from typing import Any
 
 from custom_components.growspace_manager.managers.lineage_classifier import (
-    classify_lineage,
     _is_ancestor,
     _parse_generation,
+    classify_lineage,
 )
-
 
 # ---------------------------------------------------------------------------
 # _parse_generation

--- a/tests/test_lineage_fallback.py
+++ b/tests/test_lineage_fallback.py
@@ -29,7 +29,9 @@ def save_callback() -> AsyncMock:
 @pytest.fixture
 def manager_empty(save_callback: AsyncMock) -> GeneticsManager:
     """GeneticsManager with a plant but no pollination events."""
-    from custom_components.growspace_manager.data_access.growspace_repository import GrowspaceRepository  # noqa: PLC0415
+    from custom_components.growspace_manager.data_access.growspace_repository import (
+        GrowspaceRepository,
+    )
     repo = GrowspaceRepository()
     repo.add_plant(Plant(
         plant_id="plant-1",
@@ -43,7 +45,9 @@ def manager_empty(save_callback: AsyncMock) -> GeneticsManager:
 @pytest.fixture
 def manager_with_pollination(save_callback: AsyncMock) -> GeneticsManager:
     """GeneticsManager with a plant that has a pollination event."""
-    from custom_components.growspace_manager.data_access.growspace_repository import GrowspaceRepository  # noqa: PLC0415
+    from custom_components.growspace_manager.data_access.growspace_repository import (
+        GrowspaceRepository,
+    )
     repo = GrowspaceRepository()
     repo.add_plant(Plant(
         plant_id="plant-donor",

--- a/tests/test_photoperiod_flip_checker.py
+++ b/tests/test_photoperiod_flip_checker.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -15,7 +15,7 @@ from custom_components.growspace_manager.photoperiod_flip_checker import (
 from homeassistant.core import HomeAssistant
 
 TODAY = date(2026, 5, 24)
-TODAY_DT = datetime(2026, 5, 24, 8, 0, 0, tzinfo=timezone.utc)
+TODAY_DT = datetime(2026, 5, 24, 8, 0, 0, tzinfo=UTC)
 
 
 @pytest.fixture
@@ -29,7 +29,7 @@ def mock_coordinator(mock_hass: MagicMock) -> MagicMock:
     coordinator.hass = mock_hass
     coordinator.growspaces = {}
     coordinator.services.notifications.manager.async_send_notification = AsyncMock()
-    
+
     created_coroutines = []
 
     def async_create_background_task(hass: HomeAssistant, coro: object, name: str) -> MagicMock:
@@ -40,7 +40,7 @@ def mock_coordinator(mock_hass: MagicMock) -> MagicMock:
         side_effect=async_create_background_task
     )
     coordinator.services.growspaces.get_growspace_plants = MagicMock(return_value=[])
-    
+
     yield coordinator
 
     for coro in created_coroutines:
@@ -222,7 +222,9 @@ def test_photoperiod_flip_tier_registered_with_23h_cooldown() -> None:
     """NotificationManager._TIER_COOLDOWNS has a 23-hour entry for PHOTOPERIOD_FLIP."""
     from datetime import timedelta
 
-    from custom_components.growspace_manager.notification_manager import NotificationManager
+    from custom_components.growspace_manager.notification_manager import (
+        NotificationManager,
+    )
 
     cooldown = NotificationManager._TIER_COOLDOWNS[NotificationTier.PHOTOPERIOD_FLIP]
     assert cooldown == timedelta(hours=23)

--- a/tests/test_repro_fix.py
+++ b/tests/test_repro_fix.py
@@ -6,7 +6,6 @@ from custom_components.growspace_manager.models import (
 
 
 def test_environment_config_none_fix():
-    print("Testing EnvironmentConfig None fix...")
     data = {
         "electricity_cost_per_kwh": None,
         "dli_target_veg": None,
@@ -22,7 +21,6 @@ def test_environment_config_none_fix():
 
 
 def test_growspace_none_fix():
-    print("Testing Growspace None fix...")
     data = {
         "id": "test-gs",
         "name": "Test Growspace",

--- a/tests/test_strain_lineage_tree.py
+++ b/tests/test_strain_lineage_tree.py
@@ -1,5 +1,7 @@
-import pytest
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 
 @pytest.mark.asyncio
 async def test_update_strain_lineage_tree_stores_parents_and_derives_flat_lineage():
@@ -190,8 +192,9 @@ async def test_async_update_strain_generation_noop_when_db_none():
 @pytest.mark.asyncio
 async def test_async_update_strain_generation_updates_in_memory_cache():
     """async_update_strain_generation also updates the in-memory strains cache."""
-    from custom_components.growspace_manager.strain_library import StrainLibrary
     from unittest.mock import AsyncMock, MagicMock
+
+    from custom_components.growspace_manager.strain_library import StrainLibrary
 
     hass = MagicMock()
     hass.config.path.return_value = "/tmp/test_strain_lib.db"
@@ -211,8 +214,8 @@ async def test_async_update_strain_generation_updates_in_memory_cache():
 @pytest.mark.asyncio
 async def test_async_import_seedfinder_lineage_tree_creates_stubs_and_stores_lineage():
     """Full multi-level seedfinder tree creates ancestor stubs and wires each node's parents."""
+
     from custom_components.growspace_manager.strain_library import StrainLibrary
-    import json
 
     hass = MagicMock()
     hass.config.path.return_value = "/tmp/test_strain_lib.db"

--- a/tests/test_vision_sensor.py
+++ b/tests/test_vision_sensor.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
-
 from custom_components.growspace_manager.models import VisionCheckupResult
 from custom_components.growspace_manager.sensor import VisionCheckupSensor
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -10,18 +10,19 @@ from datetime import date, datetime
 import pytest
 
 from custom_components.growspace_manager.const import DOMAIN
-from custom_components.growspace_manager.models import (
-    EnvironmentConfig,
-    Growspace,
-    GrowspaceType,
-)
 from custom_components.growspace_manager.domain.stage import (
     BayesianStage,
     StageDays,
     classify_stages,
 )
+from custom_components.growspace_manager.models import (
+    EnvironmentConfig,
+    Growspace,
+    GrowspaceType,
+)
 from custom_components.growspace_manager.utils import (
     VPDCalculator,
+    any_light_sensor_on,
     calculate_days_since,
     calculate_plant_stage,
     days_to_week,
@@ -32,12 +33,11 @@ from custom_components.growspace_manager.utils import (
     generate_subarea_vpd_sensor_unique_id,
     generate_vpd_sensor_unique_id,
     interpolate_value,
+    is_light_sensor_on,
     parse_date_field,
     parse_date_field_v2,
     read_aggregated_sensor_value,
     read_environment_vpd,
-    any_light_sensor_on,
-    is_light_sensor_on,
     read_sensor_value,
     strip_markdown_fence,
 )


### PR DESCRIPTION
First implementation step of the GSM CI safeguards from ADR 0020.

## Ruff baseline: 3889 → 0
The integration had 3889 ruff errors repo-wide, but ~3400 were a config mismatch — the `pyproject.toml` is a copy of Home Assistant core's, with `per-file-ignores` still keyed to core's paths (`homeassistant/*`). Fixed by:
- **Component relative imports** (`TID252`): allowed within `custom_components/growspace_manager/*`, exactly as HA core allows for `homeassistant/components/*`.
- **Test convention rules**: relaxed for `tests/**` (docstrings `D`, private access `SLF001`, local imports `PLC0415`, `INP001`, `S108`, …) — these tests are written more loosely than HA core's suite, and retrofitting them adds no safety. **Production code under `custom_components/` stays fully strict.** Correctness rules (F-codes) are deliberately *not* ignored.
- `ruff --fix` for unused imports / import sorting.
- Hand-fixed the genuine residual: source docstrings, justified `noqa` for intentional internal access & lazy imports, a real missing `Any` import, and test hygiene (unused vars, stray prints, dangling task).

## CI: `.github/workflows/lint.yaml`
- **`ruff check`** — blocking gate (passes clean).
- **`ruff format --check`** — non-blocking; the repo has ~237 files of format drift that need a dedicated reformat PR (would conflict with in-flight branches).
- **`mypy`** — non-blocking; the inherited HA-core-strict config yields ~460 genuine source typing errors. Burning that down is a separate effort before it can become a hard gate.

## Validation
`ruff check` clean · **full pytest suite green (4537 passed, 46 snapshots)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)