### PR TITLE
fix(tank-water): ship full-data 24h consumption buckets to frontend

### DIFF
--- a/custom_components/growspace_manager/presentation/growspace_view_model.py
+++ b/custom_components/growspace_manager/presentation/growspace_view_model.py
@@ -28,6 +28,9 @@ from custom_components.growspace_manager.const import (
     CONF_VPD_SENSORS,
     DOMAIN,
 )
+from custom_components.growspace_manager.tank_water_tracker import (
+    consumption_buckets_24h,
+)
 from custom_components.growspace_manager.utils import days_to_week
 from homeassistant.util import dt as dt_util
 
@@ -48,9 +51,11 @@ def _compute_tank_water_summaries(
 ) -> dict[str, Any]:
     """Compute compact 7-day water summaries from the full event list.
 
-    Returns two compact structures suitable for entity attributes:
+    Returns compact structures suitable for entity attributes:
     - ``recent_refills``: up to 20 refill events within the last 7 days.
     - ``daily_7d``: per-day consumed/refilled totals for the last 7 days.
+    - ``buckets_24h``: non-zero 15-min consumption buckets for the last 24h,
+      so the 24h chart has full-data granularity without shipping raw events.
     """
     now = dt_util.now()
     window_start = now - _7_DAYS
@@ -94,6 +99,7 @@ def _compute_tank_water_summaries(
             }
             for k, v in sorted(daily.items())
         ],
+        "buckets_24h": consumption_buckets_24h(events),
     }
 
 
@@ -657,11 +663,12 @@ class GrowspaceViewModelBuilder:
                         "hours_remaining": hours_remaining,
                         "depletion_status": depletion_status,
                         "water_history": {
-                            # Raw snapshots and events are limited to stay
-                            # within HA's 16 384-byte entity-attribute limit.
-                            # Compact pre-computed summaries cover the full 7d.
-                            "snapshots": tank.water_history.snapshots[-24:],
-                            "events": tank.water_history.events[-20:],
+                            # Only compact, pre-computed summaries are shipped to
+                            # stay within HA's 16 384-byte entity-attribute limit:
+                            # daily_7d (7d totals), recent_refills, and buckets_24h
+                            # (full-data 15-min consumption). Raw snapshots/events
+                            # are intentionally NOT included — the frontend renders
+                            # exclusively from these summaries.
                             **_compute_tank_water_summaries(tank.water_history.events),
                         },
                     }

--- a/custom_components/growspace_manager/tank_water_tracker.py
+++ b/custom_components/growspace_manager/tank_water_tracker.py
@@ -86,7 +86,10 @@ def _fill_buckets(
     last_end = last_start + bucket_size
 
     for ev in events:
-        ev_dt = _parse_ts(ev["timestamp"])
+        try:
+            ev_dt = _parse_ts(ev["timestamp"])
+        except (KeyError, ValueError, TypeError):
+            continue  # skip events with missing/invalid timestamps
         if ev_dt < first_start or ev_dt >= last_end:
             continue
         # Find the bucket index
@@ -97,6 +100,25 @@ def _fill_buckets(
             buckets[idx]["liters_consumed"] += ev["liters"]
         else:
             buckets[idx]["liters_refilled"] += ev["liters"]
+
+
+def consumption_buckets_24h(
+    events: list[dict[str, Any]],
+    reference_ts: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return compact non-zero 15-min consumption buckets for the last 24h.
+
+    Suitable for entity attributes: a list of ``{"ts": iso, "liters": float}``
+    for buckets with non-zero consumption only. Reuses the same bucketing as
+    :meth:`TankWaterTracker.get_history_24h` so there is a single bucketer.
+    """
+    buckets = _build_buckets(reference_ts, 96, _BUCKET_15MIN)
+    _fill_buckets(buckets, events, _BUCKET_15MIN)
+    return [
+        {"ts": b["bucket_start"], "liters": round(b["liters_consumed"], 4)}
+        for b in buckets
+        if b["liters_consumed"] > 0
+    ]
 
 
 class TankWaterTracker:

--- a/tests/integration/test_growspace_view_model_coverage.py
+++ b/tests/integration/test_growspace_view_model_coverage.py
@@ -466,6 +466,46 @@ def test_compute_tank_water_summaries_recent_refills_capped_at_20() -> None:
     assert len(result["recent_refills"]) == 20
 
 
+def test_compute_tank_water_summaries_buckets_24h_not_truncated() -> None:
+    """buckets_24h must reflect ALL 24h consumption, not just the last 20 events.
+
+    Regression: the Water Analytics tab bucketed only the raw ``events[-20:]``
+    slice sent in attributes, so consumption from earlier in the day vanished
+    from the 24h chart while the headline "consumed today" (from ``daily_7d``,
+    full data) stayed correct. ``buckets_24h`` is a compact, full-data 15-min
+    summary so the chart no longer relies on the truncated raw events.
+    """
+    now = datetime.now(tz=UTC)
+    # 40 consumption events, one every 20 minutes (~13h back), all within 24h.
+    events = [
+        {
+            "timestamp": (now - timedelta(minutes=20 * i)).isoformat(),
+            "event_type": "consumption",
+            "liters": 1.0,
+        }
+        for i in range(40)
+    ]
+    result = _compute_tank_water_summaries(events)
+    buckets = result["buckets_24h"]
+
+    # Every event is within the 24h window, so the full 40 L must be present.
+    # Truncation to the last 20 events would yield only 20 L.
+    total = sum(b["liters"] for b in buckets)
+    assert total == pytest.approx(40.0)
+
+    # Earlier history must be present: the oldest bucket must predate the 20
+    # most-recent events (i.e. cover more than the last ~6 hours).
+    oldest_bucket_start = min(datetime.fromisoformat(b["ts"]) for b in buckets)
+    twentieth_event_ts = datetime.fromisoformat(events[19]["timestamp"])
+    assert oldest_bucket_start < twentieth_event_ts
+
+
+def test_compute_tank_water_summaries_buckets_24h_empty() -> None:
+    """Empty event list yields an empty buckets_24h list."""
+    result = _compute_tank_water_summaries([])
+    assert result["buckets_24h"] == []
+
+
 def test_compute_tank_water_summaries_invalid_event_skipped() -> None:
     """Events with missing or invalid timestamps must be skipped gracefully."""
     good_ts = datetime.now(tz=UTC).isoformat()


### PR DESCRIPTION
## Problem

The Irrigation dialog → **Water Analytics → Tank-Derived Water Usage** 24h (15-min bucket) chart was missing earlier-in-the-day consumption, while the **Consumed today** headline (e.g. 32.8 L) was correct. The graph appeared to not account for the litres it claimed.

## Root cause

Two data sources fed one panel and disagreed:

- **Headline figures** read the backend's full-data `daily_7d` summary → correct.
- **The 24h chart** was re-bucketed client-side from raw `events`, but the view model only shipped `tank.water_history.events[-20:]` (truncated for HA's 16384-byte attribute budget). Once a tank logged >20 events/day, only the most recent few hours had events to bucket.

This is **not** the restart-clobber persistence bug — events persist fine (the 7-day total of 130.9 L proves it). It is pure attribute-boundary truncation.

## Fix

- New `tank_water_tracker.consumption_buckets_24h()` — reuses the existing `_build_buckets`/`_fill_buckets` (no third bucketer); `_fill_buckets` now skips malformed-timestamp events.
- `_compute_tank_water_summaries` emits a compact, full-data `buckets_24h` (`[{ts, liters}]`, non-zero only).
- Raw `snapshots`/`events` are **no longer shipped** in attributes — the frontend renders only from the compact summaries (`daily_7d`, `recent_refills`, `buckets_24h`). Worst-case payload stays well under 8 KB/tank.

The companion card change consuming `buckets_24h` is in a separate PR on the card repo.

## Tests

- Regression test (written first, watched fail): the 24h buckets reflect **all** consumption, including events older than the last 20.
- Full suite: **4539 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)