### PR TITLE
feat: route exhaust fan through ActuatorDriver seam (#502)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,3 +11,4 @@ exclude_lines =
     @overload
     def __repr__
     raise NotImplementedError
+    ^\s*\.\.\.$

--- a/custom_components/growspace_manager/CONTEXT.md
+++ b/custom_components/growspace_manager/CONTEXT.md
@@ -36,6 +36,18 @@ The canonical output of `classify_stages(StageDays)`, defined in `domain/stage.p
 
 The set of HA sensor entity IDs linked to a growspace. Covers: temperature, humidity, VPD, CO₂, substrate temperature, soil moisture, feed EC, bulk EC, pore EC, runoff EC, pH, drain volume, irrigation flow, power, energy, irrigation tanks, lights, fans, humidifier, dehumidifier. All sensor types can be linked to any growspace regardless of its `GrowspaceType`.
 
+## Actuator
+
+A device GSM *writes to* in order to change the environment — an exhaust fan, circulation fan, humidifier, or dehumidifier. Distinct from a sensor, which GSM only reads. Historically an actuator was a single HA `entity_id` string (a `fan.*` driven by percentage, or a `switch.*`/`input_boolean.*` driven on/off), inferred at each dispatch site by sniffing the entity's domain. The four actuator roles are stored on `EnvironmentConfig` as `exhaust_fan_entities`, `circulation_fan_entities`, `humidifier_entities`, `dehumidifier_entities`.
+
+## Actuator Driver
+
+The control abstraction that hides *how* an actuator is commanded behind a uniform interface — `set_speed(pct)`, `turn_on()`, `turn_off()`, `is_on()`. One driver implementation exists per actuator kind (plain `fan`, plain `switch`/on-off, AC Infinity device). The exhaust-fan, circulation-fan, and VPD on/off coordinators resolve a driver per configured actuator and command it through this interface, instead of branching on the entity domain themselves. Speed is always expressed to the driver as a 0–100 percentage; each driver maps it to its device's native control surface.
+
+## AC Infinity Device
+
+An actuator backed by the AC Infinity HACS integration (`ac_infinity`). Unlike a plain actuator it is **not** one entity but a *bundle* of two HA entities on one AC Infinity port: a mode `select` (Active Mode — `Off`/`On`/`Auto`/…) and a speed `number` (integer intensity 0–10). GSM seizes the port by setting the mode `select` to `On` (and, for binary on/off use, writing a configured on-speed to the number); it releases by setting the mode to `Off`. `is_on()` is read from the mode `select` (on = anything other than `Off`/`unavailable`/`unknown`) — `ac_infinity` is cloud-polled with no optimistic write-back, so the `select` and any power sensor lag equally; the `select` is preferred because its `Off` state is deterministic where a port's current-power reading is firmware-dependent. When GSM stops controlling, it leaves the port in its last commanded state. AC Infinity bundles are configured in fields parallel to the plain `*_entities` lists and merged by the driver resolver.
+
 ## Bulk EC
 
 Electrical conductivity measured by a TDR or capacitance probe that reads the combined water-and-media mixture at the roots. Stored as `bulk_ec_sensors` on `EnvironmentConfig`. Replaces the former `substrate_ec_sensors` field (silent migration on load).

--- a/custom_components/growspace_manager/actuator_driver.py
+++ b/custom_components/growspace_manager/actuator_driver.py
@@ -1,0 +1,170 @@
+"""Actuator drivers — a uniform control surface over HA actuator entities.
+
+GSM controls four kinds of actuator (exhaust fan, circulation fan, humidifier,
+dehumidifier). Historically each dispatch site decided *how* to command a device
+by sniffing the entity domain inline. This module hides that behind a single
+``ActuatorDriver`` interface — ``set_speed`` / ``turn_on`` / ``turn_off`` /
+``is_on`` — with one implementation per device kind, so the coordinators command
+actuators uniformly instead of branching on the domain themselves (ADR-0022).
+
+Speed is always expressed to a driver as a 0–100 percentage; each driver maps it
+to its device's native control surface.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+_LOGGER = logging.getLogger(__name__)
+
+# On/off domains driven via turn_on/turn_off rather than by percentage.
+_SWITCH_DOMAINS = ("switch", "input_boolean")
+
+
+async def _safe_service_call(
+    hass: HomeAssistant, domain: str, service: str, data: dict[str, object]
+) -> None:
+    """Call a Home Assistant service, logging device failures without raising."""
+    try:
+        await hass.services.async_call(domain, service, data, blocking=False)
+    except HomeAssistantError, TimeoutError:
+        _LOGGER.warning(
+            "Failed to call %s.%s on %s",
+            domain,
+            service,
+            data.get(ATTR_ENTITY_ID),
+            exc_info=True,
+        )
+
+
+class ActuatorDriver(Protocol):
+    """Uniform control surface over a single actuator.
+
+    ``set_speed`` takes a 0–100 percentage; ``turn_on`` / ``turn_off`` are the
+    binary path used by on/off controllers; ``is_on`` reports the current state.
+    """
+
+    async def set_speed(self, pct: int) -> None:
+        """Drive the actuator to a 0–100 percentage demand."""
+        ...
+
+    async def turn_on(self) -> None:
+        """Turn the actuator on."""
+        ...
+
+    async def turn_off(self) -> None:
+        """Turn the actuator off."""
+        ...
+
+    def is_on(self) -> bool:
+        """Return whether the actuator is currently on."""
+        ...
+
+
+class FanDriver:
+    """Drives a ``fan.*`` entity by percentage."""
+
+    def __init__(self, hass: HomeAssistant, entity_id: str) -> None:
+        """Initialize the driver for a single ``fan.*`` entity."""
+        self._hass = hass
+        self._entity_id = entity_id
+
+    async def set_speed(self, pct: int) -> None:
+        """Set the fan to ``pct`` percent."""
+        await _safe_service_call(
+            self._hass,
+            "fan",
+            "set_percentage",
+            {ATTR_ENTITY_ID: self._entity_id, "percentage": pct},
+        )
+
+    async def turn_on(self) -> None:
+        """Turn the fan on."""
+        await _safe_service_call(
+            self._hass, "fan", SERVICE_TURN_ON, {ATTR_ENTITY_ID: self._entity_id}
+        )
+
+    async def turn_off(self) -> None:
+        """Turn the fan off."""
+        await _safe_service_call(
+            self._hass, "fan", SERVICE_TURN_OFF, {ATTR_ENTITY_ID: self._entity_id}
+        )
+
+    def is_on(self) -> bool:
+        """Return whether the fan entity reports the ``on`` state."""
+        state = self._hass.states.get(self._entity_id)
+        return state is not None and state.state == STATE_ON
+
+
+class SwitchDriver:
+    """Drives an on/off entity (``switch.*`` / ``input_boolean.*``).
+
+    ``set_speed`` turns the device on when the demand exceeds ``off_threshold``
+    and off otherwise — exhaust uses the fan's ``min_speed`` as that threshold so
+    a switch rests off at the floor speed and engages only above it.
+    """
+
+    def __init__(
+        self, hass: HomeAssistant, entity_id: str, *, off_threshold: int = 0
+    ) -> None:
+        """Initialize the driver for a single on/off entity."""
+        self._hass = hass
+        self._entity_id = entity_id
+        self._domain = entity_id.split(".", 1)[0]
+        self._off_threshold = off_threshold
+
+    async def set_speed(self, pct: int) -> None:
+        """Turn on when ``pct`` exceeds the off threshold, otherwise off."""
+        if pct > self._off_threshold:
+            await self.turn_on()
+        else:
+            await self.turn_off()
+
+    async def turn_on(self) -> None:
+        """Turn the device on."""
+        await _safe_service_call(
+            self._hass,
+            self._domain,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: self._entity_id},
+        )
+
+    async def turn_off(self) -> None:
+        """Turn the device off."""
+        await _safe_service_call(
+            self._hass,
+            self._domain,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: self._entity_id},
+        )
+
+    def is_on(self) -> bool:
+        """Return whether the entity reports the ``on`` state."""
+        state = self._hass.states.get(self._entity_id)
+        return state is not None and state.state == STATE_ON
+
+
+def resolve_actuator_driver(
+    hass: HomeAssistant, entity_id: str, *, switch_off_threshold: int = 0
+) -> ActuatorDriver | None:
+    """Resolve a driver for ``entity_id`` by domain, or ``None`` if unsupported.
+
+    ``switch_off_threshold`` is the demand above which an on/off device engages
+    (exhaust passes its ``min_speed``); it is ignored for percentage fans.
+    """
+    domain = entity_id.split(".", 1)[0]
+    if domain == "fan":
+        return FanDriver(hass, entity_id)
+    if domain in _SWITCH_DOMAINS:
+        return SwitchDriver(hass, entity_id, off_threshold=switch_off_threshold)
+    return None

--- a/custom_components/growspace_manager/exhaust_fan_coordinator.py
+++ b/custom_components/growspace_manager/exhaust_fan_coordinator.py
@@ -17,17 +17,11 @@ import logging
 from typing import TYPE_CHECKING
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    SERVICE_TURN_OFF,
-    SERVICE_TURN_ON,
-    STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
-)
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_time_interval
 
+from .actuator_driver import resolve_actuator_driver
 from .const import FanRegulationMode
 from .domain.day_night import DayNightTracker
 from .domain.fan_control import (
@@ -44,9 +38,6 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 _TICK_INTERVAL = timedelta(seconds=10)
-
-# Entity domains driven on/off rather than by percentage.
-_SWITCH_DOMAINS = ("switch", "input_boolean")
 
 
 class ExhaustFanCoordinator:
@@ -187,37 +178,17 @@ class ExhaustFanCoordinator:
         )
 
     async def _dispatch(self, entity_id: str, speed: int, min_speed: int) -> None:
-        """Drive a single exhaust device by domain.
+        """Drive a single exhaust device through its resolved actuator driver.
 
         ``fan`` entities receive the speed as a percentage; ``switch`` and
         ``input_boolean`` devices are turned on when the demand exceeds
-        ``min_speed`` and off otherwise.
+        ``min_speed`` and off otherwise. Unsupported domains are skipped.
         """
-        domain = entity_id.split(".", 1)[0]
-        if domain == "fan":
-            await self._call_service(
-                "fan",
-                "set_percentage",
-                {ATTR_ENTITY_ID: entity_id, "percentage": speed},
-            )
-        elif domain in _SWITCH_DOMAINS:
-            service = SERVICE_TURN_ON if speed > min_speed else SERVICE_TURN_OFF
-            await self._call_service(domain, service, {ATTR_ENTITY_ID: entity_id})
-
-    async def _call_service(
-        self, domain: str, service: str, data: dict[str, object]
-    ) -> None:
-        """Call a Home Assistant service, logging device failures without raising."""
-        try:
-            await self.hass.services.async_call(domain, service, data, blocking=False)
-        except HomeAssistantError, TimeoutError:
-            _LOGGER.warning(
-                "Failed to call %s.%s on %s",
-                domain,
-                service,
-                data.get(ATTR_ENTITY_ID),
-                exc_info=True,
-            )
+        driver = resolve_actuator_driver(
+            self.hass, entity_id, switch_off_threshold=min_speed
+        )
+        if driver is not None:
+            await driver.set_speed(speed)
 
     def _read_sensor(self, mode: FanRegulationMode) -> float | None:
         """Read the first available sensor value for the given measurement."""

--- a/docs/adr/0022-actuator-driver-abstraction-and-ac-infinity-adapter.md
+++ b/docs/adr/0022-actuator-driver-abstraction-and-ac-infinity-adapter.md
@@ -1,0 +1,107 @@
+# 22. Actuator-driver abstraction and AC Infinity adapter
+
+Date: 2026-06-30
+
+## Status
+
+Accepted
+
+## Context
+
+GSM controls four kinds of actuator — exhaust fan, circulation fan, humidifier,
+dehumidifier — and historically modelled each as a single HA `entity_id` string
+stored on `EnvironmentConfig` (`exhaust_fan_entities`, `circulation_fan_entities`,
+`humidifier_entities`, `dehumidifier_entities`). Three separate dispatch sites each
+decided *how* to command a device by sniffing the entity domain inline:
+
+- `exhaust_fan_coordinator._dispatch` — `fan.set_percentage` for `fan.*`,
+  `turn_on`/`turn_off` for `switch.*`/`input_boolean.*`.
+- `circulation_fan_coordinator` — `fan.set_percentage`.
+- `vpd_on_off_controller._control_devices` — `turn_on`/`turn_off` over
+  `switch`/`humidifier`/`fan`/`input_boolean`, else `homeassistant.*`.
+
+Users increasingly run AC Infinity controllers via the `ac_infinity` HACS
+integration. That integration exposes **no `fan` platform**. Each port is a
+*bundle* of entities:
+
+- a mode `select` (Active Mode: `Off`, `On`, `Auto`, `Timer to On`,
+  `Timer to Off`, `Cycle`, `Schedule`, `VPD` — hardcoded English option strings),
+- a speed `number` (On Speed, integer **0–10**, step 1 — not a 0–100 percentage),
+- sensors for status/current power, temperature, humidity, VPD.
+
+To run a port at 60 %, you must set the mode `select` to `On` *and* write `6` to
+the speed `number`. To turn it off, set the mode to `Off`. There is no single
+`entity_id` whose `STATE_ON`/percentage GSM can read or write, so AC Infinity
+devices simply do not work with the domain-sniffing dispatch. We want them to
+work **optionally**, without breaking existing plain-`fan`/`switch` setups.
+
+`ac_infinity`'s `iot_class` is **`cloud_polling`** and it does **not** update
+local state optimistically after a control write — neither the mode `select` nor
+the `current_power` sensor reflects a change until the next cloud poll
+(`MIN_TIME_BETWEEN_UPDATES = 5 s` floor, interval user-configurable). The
+per-port power sensor (`current_power`, `POWER_FACTOR`, bare int) has no
+guaranteed `0` reading when the port is Off — its off value is firmware-dependent.
+
+## Decision
+
+**Introduce an `ActuatorDriver` abstraction** with a uniform interface
+(`set_speed(pct)`, `turn_on()`, `turn_off()`, `is_on()`) and one implementation
+per actuator kind: a `fan` driver, a `switch`/on-off driver, and an
+`ACInfinityDriver`. The exhaust-fan, circulation-fan, and VPD on/off coordinators
+resolve a driver per configured actuator and command it through this interface;
+the inline domain-sniffing is removed from all three sites. Speed is always
+passed to a driver as a 0–100 percentage; each driver maps it to the device's
+native surface.
+
+**`ACInfinityDriver` treats one port as a two-entity bundle** — mode `select`
+and speed `number` — with these semantics:
+
+- `set_speed(pct)`: `pct <= 0` → mode `select` → `Off`; otherwise mode → `On`
+  and number → `clamp(round(pct / 10), 1, 10)`. (Off threshold is `0`, matching
+  the `fan` driver — *not* the switch driver's `min_speed` — so an AC Infinity
+  exhaust keeps running at low intensity where a switch exhaust would already be
+  off.)
+- `turn_on()`: mode → `On` and number → a per-device configured **on-speed**
+  (default `10`). `turn_off()`: mode → `Off`.
+- `is_on()`: read the bound **mode `select`**; on = state not in
+  `{Off, unavailable, unknown}`. Chosen over the `current_power` sensor because,
+  under cloud polling, both readbacks lag a poll equally so the sensor buys no
+  freshness, while the `select` gives a deterministic `Off` where the power
+  reading is firmware-dependent. The bundle therefore needs only the `select`
+  and `number`; a power sensor is not required.
+- On teardown / control-flag-off / growspace deletion: **no action** — the port
+  is left in its last commanded state (documented).
+
+**Config model:** keep the existing `*_entities: list[str]` fields untouched and
+add parallel `*_ac_infinity_devices` fields holding the three-entity bundle plus
+on-speed. The driver resolver yields drivers from both lists. No storage
+migration.
+
+**Scope:** ship the backend (driver abstraction + `ACInfinityDriver` + config
+fields + serialization + tests) first; the Lovelace card's Config Dialog bundle
+editor is a separate follow-up. Until then, bundles are configured via
+storage/options.
+
+## Consequences
+
+- All three coordinators route writes through one tested seam; adding a future
+  device kind (e.g. another bundled controller) is a new driver, not edits to
+  three dispatch methods.
+- The 0–100 → 0–10 mapping and `select`+`number` choreography live in exactly
+  one place. Hardcoding `"On"`/`"Off"` is safe — `ac_infinity` mode options are
+  hardcoded English, not translated.
+- Because `ac_infinity` is cloud-polled with no optimistic write-back, `is_on()`
+  (from the `select`) **lags** a command by up to one poll interval. The
+  VpdOnOffController will therefore re-issue `On`/`Off` until the poll catches up;
+  these writes are idempotent and floored by `MIN_TIME_BETWEEN_UPDATES` (5 s) and
+  GSM's own min-runtime/off-time gating, so the effect is redundant API calls, not
+  incorrect control. (This lag is identical for either readback source, which is
+  why it does not favour the power sensor.)
+- GSM seizing a port suppresses the controller's own Auto/VPD/Schedule
+  automation while GSM drives it — intended, since GSM is the brain — and on
+  release the user must restore the native mode themselves.
+- Two code paths per actuator role (`*_entities` + `*_ac_infinity_devices`) until
+  a future unified binding model is justified; chosen over a migration to keep
+  this change non-breaking.
+- Reversal is costly: the driver interface and the parallel config fields become
+  part of stored config and the coordinators' control flow.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -653,6 +653,8 @@ exclude_lines = [
   # TYPE_CHECKING and @overload blocks are never executed during pytest run
   "if TYPE_CHECKING:",
   "@overload",
+  # Protocol / abstract method stub bodies (a bare ``...``) never execute
+  "^\\s*\\.\\.\\.$",
 ]
 
 [tool.ruff]

--- a/tests/integration/test_actuator_driver.py
+++ b/tests/integration/test_actuator_driver.py
@@ -1,0 +1,152 @@
+"""Unit tests for the actuator-driver abstraction (ADR-0022)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.growspace_manager.actuator_driver import (
+    FanDriver,
+    SwitchDriver,
+    resolve_actuator_driver,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+
+@pytest.fixture
+def mock_hass() -> MagicMock:
+    """Return a mock HomeAssistant with an async service caller."""
+    hass = MagicMock(spec=HomeAssistant)
+    hass.states = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    return hass
+
+
+def _state(value: str) -> MagicMock:
+    """Build a mock entity state carrying ``value``."""
+    state = MagicMock()
+    state.state = value
+    return state
+
+
+async def test_fan_driver_set_speed_calls_set_percentage(mock_hass: MagicMock) -> None:
+    """FanDriver.set_speed issues fan.set_percentage with the demand."""
+    await FanDriver(mock_hass, "fan.exhaust").set_speed(90)
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "fan",
+        "set_percentage",
+        {ATTR_ENTITY_ID: "fan.exhaust", "percentage": 90},
+        blocking=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("method", "service"),
+    [("turn_on", "turn_on"), ("turn_off", "turn_off")],
+)
+async def test_fan_driver_binary_calls(
+    mock_hass: MagicMock, method: str, service: str
+) -> None:
+    """FanDriver.turn_on/turn_off issue the matching fan service."""
+    await getattr(FanDriver(mock_hass, "fan.exhaust"), method)()
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "fan", service, {ATTR_ENTITY_ID: "fan.exhaust"}, blocking=False
+    )
+
+
+@pytest.mark.parametrize("driver_cls", [FanDriver, SwitchDriver])
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(STATE_ON, True), (STATE_OFF, False)],
+)
+async def test_driver_is_on_reflects_state(
+    mock_hass: MagicMock, driver_cls: type, value: str, expected: bool
+) -> None:
+    """is_on reflects the entity state for every driver kind."""
+    mock_hass.states.get.return_value = _state(value)
+    assert driver_cls(mock_hass, "domain.entity").is_on() is expected
+
+
+@pytest.mark.parametrize("driver_cls", [FanDriver, SwitchDriver])
+async def test_driver_is_on_missing_state(
+    mock_hass: MagicMock, driver_cls: type
+) -> None:
+    """is_on is False when the entity has no state."""
+    mock_hass.states.get.return_value = None
+    assert driver_cls(mock_hass, "domain.entity").is_on() is False
+
+
+@pytest.mark.parametrize(
+    ("pct", "service"),
+    [(11, "turn_on"), (10, "turn_off"), (0, "turn_off")],
+)
+async def test_switch_driver_set_speed_threshold(
+    mock_hass: MagicMock, pct: int, service: str
+) -> None:
+    """SwitchDriver engages only when demand exceeds the off threshold."""
+    await SwitchDriver(mock_hass, "switch.exhaust", off_threshold=10).set_speed(pct)
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "switch", service, {ATTR_ENTITY_ID: "switch.exhaust"}, blocking=False
+    )
+
+
+async def test_switch_driver_uses_entity_domain(mock_hass: MagicMock) -> None:
+    """SwitchDriver dispatches to the entity's own domain (e.g. input_boolean)."""
+    await SwitchDriver(mock_hass, "input_boolean.damper").turn_on()
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "input_boolean",
+        "turn_on",
+        {ATTR_ENTITY_ID: "input_boolean.damper"},
+        blocking=False,
+    )
+
+
+async def test_switch_driver_default_threshold_is_zero(mock_hass: MagicMock) -> None:
+    """With the default threshold any positive demand turns the device on."""
+    await SwitchDriver(mock_hass, "switch.damper").set_speed(1)
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "switch", "turn_on", {ATTR_ENTITY_ID: "switch.damper"}, blocking=False
+    )
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "expected_type"),
+    [
+        ("fan.exhaust", FanDriver),
+        ("switch.exhaust", SwitchDriver),
+        ("input_boolean.damper", SwitchDriver),
+    ],
+)
+async def test_resolve_actuator_driver_supported(
+    mock_hass: MagicMock, entity_id: str, expected_type: type
+) -> None:
+    """The resolver returns the right driver for supported domains."""
+    assert isinstance(resolve_actuator_driver(mock_hass, entity_id), expected_type)
+
+
+async def test_resolve_actuator_driver_unsupported(mock_hass: MagicMock) -> None:
+    """The resolver returns None for unsupported domains."""
+    assert resolve_actuator_driver(mock_hass, "light.grow") is None
+
+
+async def test_resolve_passes_switch_off_threshold(mock_hass: MagicMock) -> None:
+    """The resolver threshold reaches the switch driver's engage point."""
+    driver = resolve_actuator_driver(
+        mock_hass, "switch.exhaust", switch_off_threshold=20
+    )
+    await driver.set_speed(20)
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "switch", "turn_off", {ATTR_ENTITY_ID: "switch.exhaust"}, blocking=False
+    )
+
+
+@pytest.mark.parametrize("error", [HomeAssistantError("boom"), TimeoutError()])
+async def test_safe_service_call_swallows_device_errors(
+    mock_hass: MagicMock, error: Exception
+) -> None:
+    """A failing device call is logged, not raised, so one device can't break the tick."""
+    mock_hass.services.async_call.side_effect = error
+    await FanDriver(mock_hass, "fan.exhaust").set_speed(50)
+    mock_hass.services.async_call.assert_awaited_once()


### PR DESCRIPTION
## What to build

Walking-skeleton slice for the AC Infinity adapter work (ADR-0022). Introduces the `ActuatorDriver` seam and routes the **exhaust fan** coordinator through it, with **no behavior change** for existing plain devices.

Closes #502.

## Changes

- **`actuator_driver.py`** (new) — `ActuatorDriver` protocol (`set_speed`/`turn_on`/`turn_off`/`is_on`), `FanDriver` (`fan.set_percentage`), on/off `SwitchDriver` (`switch`/`input_boolean`), and `resolve_actuator_driver()` mapping an entity to a driver by domain (`None` for unsupported domains → no-op, preserving prior behavior).
- **`exhaust_fan_coordinator.py`** — dispatches through resolved drivers; inline domain-sniffing (`_dispatch` branches + `_call_service`) removed. The switch's `speed > min_speed` threshold is preserved as the driver's `off_threshold`.
- **Docs** — CONTEXT.md glossary (Actuator / Actuator Driver / AC Infinity Device) + ADR-0022.
- **Coverage config** — exclude bare `...` Protocol stubs (same rationale as the existing `@overload` exclusion).

## Verification

- The **21 existing exhaust integration tests** — which assert exact `async_call` args including `blocking=False` — stay green, so behavior is *proven* unchanged.
- **21 new** driver/resolver unit tests; **100%** coverage on the new module.
- Full suite: **4583 passed**, no regressions. No new service or WS command, so the test-count asserts in `test_core_init.py` are untouched.
- ruff + format clean; mypy clean on changed files (the `_read_sensor:204` unreachable-`else` is pre-existing).

## Stack

Base of the AC Infinity stack: #503 (`ACInfinityDriver`) builds on this branch; #504/#505/card#410 follow from #503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)