### PR TITLE
feat: AC Infinity exhaust fan support (#503)

### DIFF
--- a/custom_components/growspace_manager/actuator_driver.py
+++ b/custom_components/growspace_manager/actuator_driver.py
@@ -13,6 +13,7 @@ to its device's native control surface.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 import logging
 from typing import Protocol
 
@@ -21,6 +22,8 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -29,6 +32,13 @@ _LOGGER = logging.getLogger(__name__)
 
 # On/off domains driven via turn_on/turn_off rather than by percentage.
 _SWITCH_DOMAINS = ("switch", "input_boolean")
+
+# AC Infinity Active Mode options (hardcoded English in the ac_infinity integration).
+_AC_INFINITY_MODE_ON = "On"
+_AC_INFINITY_MODE_OFF = "Off"
+# AC Infinity ports take an integer intensity in this range, not a 0–100 percentage.
+_AC_INFINITY_SPEED_MIN = 1
+_AC_INFINITY_SPEED_MAX = 10
 
 
 async def _safe_service_call(
@@ -168,3 +178,115 @@ def resolve_actuator_driver(
     if domain in _SWITCH_DOMAINS:
         return SwitchDriver(hass, entity_id, off_threshold=switch_off_threshold)
     return None
+
+
+def _scale_percentage_to_intensity(pct: int) -> int:
+    """Map a 0–100 percentage to the AC Infinity 1–10 intensity scale."""
+    return max(_AC_INFINITY_SPEED_MIN, min(_AC_INFINITY_SPEED_MAX, round(pct / 10)))
+
+
+class ACInfinityDriver:
+    """Drives an AC Infinity port (mode ``select`` + speed ``number`` bundle).
+
+    The ``ac_infinity`` integration exposes no ``fan`` entity, so GSM seizes a
+    port by setting its Active Mode ``select`` to ``On`` and writing the speed
+    ``number`` (mapping the 0–100 demand onto the device's 1–10 intensity), or to
+    ``Off`` to release it. ``is_on`` reads the mode ``select`` — under cloud
+    polling both the select and any power sensor lag equally, but the select's
+    ``Off`` state is deterministic where a port's current-power is not (ADR-0022).
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        mode_entity: str,
+        speed_entity: str,
+        on_speed: int = _AC_INFINITY_SPEED_MAX,
+    ) -> None:
+        """Initialize the driver for one AC Infinity port bundle."""
+        self._hass = hass
+        self._mode_entity = mode_entity
+        self._speed_entity = speed_entity
+        self._on_speed = on_speed
+
+    async def set_speed(self, pct: int) -> None:
+        """Turn the port off at zero demand, otherwise drive mode On + intensity."""
+        if pct <= 0:
+            await self._select_mode(_AC_INFINITY_MODE_OFF)
+        else:
+            await self._select_mode(_AC_INFINITY_MODE_ON)
+            await self._set_intensity(_scale_percentage_to_intensity(pct))
+
+    async def turn_on(self) -> None:
+        """Set the port to On at the configured on-speed."""
+        await self._select_mode(_AC_INFINITY_MODE_ON)
+        await self._set_intensity(self._on_speed)
+
+    async def turn_off(self) -> None:
+        """Set the port's mode to Off."""
+        await self._select_mode(_AC_INFINITY_MODE_OFF)
+
+    def is_on(self) -> bool:
+        """Return whether the port's mode is anything other than Off."""
+        state = self._hass.states.get(self._mode_entity)
+        return state is not None and state.state not in (
+            _AC_INFINITY_MODE_OFF,
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+        )
+
+    async def _select_mode(self, option: str) -> None:
+        await _safe_service_call(
+            self._hass,
+            "select",
+            "select_option",
+            {ATTR_ENTITY_ID: self._mode_entity, "option": option},
+        )
+
+    async def _set_intensity(self, value: int) -> None:
+        await _safe_service_call(
+            self._hass,
+            "number",
+            "set_value",
+            {ATTR_ENTITY_ID: self._speed_entity, "value": value},
+        )
+
+
+class ACInfinityDeviceConfig(Protocol):
+    """Structural type for a stored AC Infinity bundle (``models.ACInfinityDevice``)."""
+
+    mode_entity: str
+    speed_entity: str
+    on_speed: int
+
+
+def resolve_actuator_drivers(
+    hass: HomeAssistant,
+    entities: Iterable[str],
+    ac_infinity_devices: Iterable[ACInfinityDeviceConfig] = (),
+    *,
+    switch_off_threshold: int = 0,
+) -> list[ActuatorDriver]:
+    """Resolve every configured actuator for one role into drivers.
+
+    Merges the plain ``*_entities`` list (resolved by domain) with the parallel
+    AC Infinity bundle list; unsupported plain domains are skipped.
+    """
+    drivers: list[ActuatorDriver] = []
+    for entity_id in entities:
+        driver = resolve_actuator_driver(
+            hass, entity_id, switch_off_threshold=switch_off_threshold
+        )
+        if driver is not None:
+            drivers.append(driver)
+    drivers.extend(
+        ACInfinityDriver(
+            hass,
+            mode_entity=device.mode_entity,
+            speed_entity=device.speed_entity,
+            on_speed=device.on_speed,
+        )
+        for device in ac_infinity_devices
+    )
+    return drivers

--- a/custom_components/growspace_manager/exhaust_fan_coordinator.py
+++ b/custom_components/growspace_manager/exhaust_fan_coordinator.py
@@ -21,7 +21,7 @@ from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.event import async_track_time_interval
 
-from .actuator_driver import resolve_actuator_driver
+from .actuator_driver import resolve_actuator_drivers
 from .const import FanRegulationMode
 from .domain.day_night import DayNightTracker
 from .domain.fan_control import (
@@ -65,6 +65,14 @@ class ExhaustFanCoordinator:
         gs = self.main_coordinator.growspaces.get(self.growspace_id)
         return gs.environment_config if gs else None
 
+    @property
+    def _has_exhaust_actuators(self) -> bool:
+        """Whether any exhaust actuator — plain entity or AC Infinity — is configured."""
+        env = self._env_config
+        return bool(
+            env and (env.exhaust_fan_entities or env.exhaust_fan_ac_infinity_devices)
+        )
+
     async def async_setup(self) -> None:
         """Start the polling tick when enabled and exhaust entities are configured."""
         if self._env_config is None:
@@ -75,7 +83,7 @@ class ExhaustFanCoordinator:
             _LOGGER.debug("ExhaustFanCoordinator disabled for %s", self.growspace_id)
             return
 
-        if not self._env_config.exhaust_fan_entities:
+        if not self._has_exhaust_actuators:
             _LOGGER.debug(
                 "ExhaustFanCoordinator: no exhaust entities for %s", self.growspace_id
             )
@@ -99,7 +107,7 @@ class ExhaustFanCoordinator:
             return
 
         cfg = self._env_config.exhaust_fan_config
-        if not cfg.enabled or not self._env_config.exhaust_fan_entities:
+        if not cfg.enabled or not self._has_exhaust_actuators:
             return
 
         vpd_target = self._effective_vpd_target(cfg)
@@ -127,8 +135,14 @@ class ExhaustFanCoordinator:
         if speed is None:
             return
 
-        for entity_id in self._env_config.exhaust_fan_entities:
-            await self._dispatch(entity_id, speed, cfg.min_speed)
+        drivers = resolve_actuator_drivers(
+            self.hass,
+            self._env_config.exhaust_fan_entities,
+            self._env_config.exhaust_fan_ac_infinity_devices,
+            switch_off_threshold=cfg.min_speed,
+        )
+        for driver in drivers:
+            await driver.set_speed(speed)
 
     def _apply_critical_temp_override(
         self, cfg: ExhaustFanConfig, temperature: float | None, speed: int | None
@@ -176,19 +190,6 @@ class ExhaustFanCoordinator:
         return resolve_stage_vpd_target(
             plants, cfg.stage_vpd_overrides, cfg.vpd_target, is_day
         )
-
-    async def _dispatch(self, entity_id: str, speed: int, min_speed: int) -> None:
-        """Drive a single exhaust device through its resolved actuator driver.
-
-        ``fan`` entities receive the speed as a percentage; ``switch`` and
-        ``input_boolean`` devices are turned on when the demand exceeds
-        ``min_speed`` and off otherwise. Unsupported domains are skipped.
-        """
-        driver = resolve_actuator_driver(
-            self.hass, entity_id, switch_off_threshold=min_speed
-        )
-        if driver is not None:
-            await driver.set_speed(speed)
 
     def _read_sensor(self, mode: FanRegulationMode) -> float | None:
         """Read the first available sensor value for the given measurement."""

--- a/custom_components/growspace_manager/models/__init__.py
+++ b/custom_components/growspace_manager/models/__init__.py
@@ -10,6 +10,7 @@ from .base import BaseModel, BasePreset, _sanitize_numeric_fields
 from .contract import GrowspaceCoordinatorData
 from .genetics import PollinationEvent, SeedBatch
 from .growspace import (
+    ACInfinityDevice,
     CirculationFanConfig,
     DLIState,
     EnergyTracking,
@@ -66,6 +67,7 @@ from .types import (
 
 # Explicit __all__ list for documentation and IDE support
 __all__ = [
+    "ACInfinityDevice",
     # base
     "BaseModel",
     "BasePreset",

--- a/custom_components/growspace_manager/models/growspace.py
+++ b/custom_components/growspace_manager/models/growspace.py
@@ -84,6 +84,21 @@ class SensorGroup(BaseModel):
 
 
 @dataclass(slots=True)
+class ACInfinityDevice(BaseModel):
+    """A single AC Infinity port driven as one actuator (ADR-0022).
+
+    An AC Infinity port exposes no ``fan`` entity; it is a bundle of a mode
+    ``select`` (Active Mode) and a speed ``number`` (intensity 0–10). GSM seizes
+    the port by setting the mode to ``On`` and writing the number; ``on_speed`` is
+    the intensity used for the binary on path.
+    """
+
+    mode_entity: str
+    speed_entity: str
+    on_speed: int = 10
+
+
+@dataclass(slots=True)
 class VisionCheckupResult(BaseModel):
     """Result of an AI vision checkup analysis."""
 
@@ -179,6 +194,11 @@ class EnvironmentConfig(BaseModel):
     circulation_fan_entities: list[str] = field(default_factory=list)
     humidifier_entities: list[str] = field(default_factory=list)
     dehumidifier_entities: list[str] = field(default_factory=list)
+
+    # AC Infinity actuator bundles, parallel to the plain *_entities lists above.
+    exhaust_fan_ac_infinity_devices: list[ACInfinityDevice] = field(
+        default_factory=list
+    )
 
     # 3D Sensor Configuration
     sensor_coordinates: dict[str, dict[str, float]] = field(default_factory=dict)
@@ -282,6 +302,7 @@ class EnvironmentConfig(BaseModel):
             "circulation_fan_entities",
             "humidifier_entities",
             "dehumidifier_entities",
+            "exhaust_fan_ac_infinity_devices",
             "sensor_groups",
             "substrate_temperature_sensors",
             "camera_entities",

--- a/tests/core/snapshots/test_models_snapshots.ambr
+++ b/tests/core/snapshots/test_models_snapshots.ambr
@@ -83,6 +83,8 @@
     'electricity_cost_per_kwh': 0.0,
     'energy_sensors': list([
     ]),
+    'exhaust_fan_ac_infinity_devices': list([
+    ]),
     'exhaust_fan_config': dict({
       'critical_temp_high': None,
       'critical_temp_hysteresis': 1.0,
@@ -232,6 +234,8 @@
       ]),
       'electricity_cost_per_kwh': 0.0,
       'energy_sensors': list([
+      ]),
+      'exhaust_fan_ac_infinity_devices': list([
       ]),
       'exhaust_fan_config': dict({
         'critical_temp_high': None,

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -6,6 +6,7 @@ import pytest
 
 from custom_components.growspace_manager.const import FanRegulationMode
 from custom_components.growspace_manager.models import (
+    ACInfinityDevice,
     CirculationFanConfig,
     EnvironmentConfig,
     EnvironmentState,
@@ -1009,7 +1010,9 @@ def test_exhaust_fan_config_roundtrip() -> None:
     assert restored.critical_temp_hysteresis == 2.0
 
 
-def test_environment_config_missing_exhaust_fan_config_deserialises_to_default() -> None:
+def test_environment_config_missing_exhaust_fan_config_deserialises_to_default() -> (
+    None
+):
     """EnvironmentConfig stored without exhaust_fan_config key deserialises to default."""
     data: dict = {}
     env = EnvironmentConfig.from_dict(data)
@@ -1036,3 +1039,31 @@ def test_growspace_exhaust_fan_config_roundtrip() -> None:
     assert fan_cfg.enabled is True
     assert fan_cfg.min_speed == 10
     assert fan_cfg.max_speed == 90
+
+
+def test_environment_config_ac_infinity_devices_round_trip() -> None:
+    """AC Infinity exhaust bundles survive a to_dict/from_dict round trip."""
+    config = EnvironmentConfig(
+        exhaust_fan_ac_infinity_devices=[
+            ACInfinityDevice(
+                mode_entity="select.tent_port1_mode",
+                speed_entity="number.tent_port1_on_speed",
+                on_speed=7,
+            )
+        ],
+    )
+    restored = EnvironmentConfig.from_dict(config.to_dict())
+    assert restored.exhaust_fan_ac_infinity_devices == [
+        ACInfinityDevice(
+            mode_entity="select.tent_port1_mode",
+            speed_entity="number.tent_port1_on_speed",
+            on_speed=7,
+        )
+    ]
+
+
+def test_environment_config_ac_infinity_devices_default_empty() -> None:
+    """The AC Infinity bundle list defaults to empty and tolerates a null payload."""
+    assert EnvironmentConfig().exhaust_fan_ac_infinity_devices == []
+    restored = EnvironmentConfig.from_dict({"exhaust_fan_ac_infinity_devices": None})
+    assert restored.exhaust_fan_ac_infinity_devices == []

--- a/tests/integration/snapshots/test_services_growspace_coverage.ambr
+++ b/tests/integration/snapshots/test_services_growspace_coverage.ambr
@@ -71,6 +71,8 @@
       'electricity_cost_per_kwh': 0.0,
       'energy_sensors': list([
       ]),
+      'exhaust_fan_ac_infinity_devices': list([
+      ]),
       'exhaust_fan_config': dict({
         'critical_temp_high': None,
         'critical_temp_hysteresis': 1.0,

--- a/tests/integration/test_actuator_driver.py
+++ b/tests/integration/test_actuator_driver.py
@@ -5,11 +5,20 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.growspace_manager.actuator_driver import (
+    ACInfinityDriver,
     FanDriver,
     SwitchDriver,
     resolve_actuator_driver,
+    resolve_actuator_drivers,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from custom_components.growspace_manager.models import ACInfinityDevice
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
@@ -150,3 +159,141 @@ async def test_safe_service_call_swallows_device_errors(
     mock_hass.services.async_call.side_effect = error
     await FanDriver(mock_hass, "fan.exhaust").set_speed(50)
     mock_hass.services.async_call.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# ACInfinityDriver
+# ---------------------------------------------------------------------------
+
+
+def _ac_driver(mock_hass: MagicMock, on_speed: int = 10) -> ACInfinityDriver:
+    """Build an ACInfinityDriver over a standard mode+speed bundle."""
+    return ACInfinityDriver(
+        mock_hass,
+        mode_entity="select.port_mode",
+        speed_entity="number.port_speed",
+        on_speed=on_speed,
+    )
+
+
+async def test_ac_infinity_set_speed_drives_mode_and_intensity(
+    mock_hass: MagicMock,
+) -> None:
+    """A positive demand sets mode On and writes the scaled 1-10 intensity."""
+    await _ac_driver(mock_hass).set_speed(60)
+    mock_hass.services.async_call.assert_any_await(
+        "select",
+        "select_option",
+        {ATTR_ENTITY_ID: "select.port_mode", "option": "On"},
+        blocking=False,
+    )
+    mock_hass.services.async_call.assert_any_await(
+        "number",
+        "set_value",
+        {ATTR_ENTITY_ID: "number.port_speed", "value": 6},
+        blocking=False,
+    )
+    assert mock_hass.services.async_call.await_count == 2
+
+
+@pytest.mark.parametrize(
+    ("pct", "intensity"),
+    [(5, 1), (60, 6), (95, 10), (100, 10)],
+)
+async def test_ac_infinity_intensity_scaling(
+    mock_hass: MagicMock, pct: int, intensity: int
+) -> None:
+    """0-100 demand maps onto the clamped 1-10 intensity scale."""
+    await _ac_driver(mock_hass).set_speed(pct)
+    mock_hass.services.async_call.assert_any_await(
+        "number",
+        "set_value",
+        {ATTR_ENTITY_ID: "number.port_speed", "value": intensity},
+        blocking=False,
+    )
+
+
+async def test_ac_infinity_set_speed_zero_turns_off(mock_hass: MagicMock) -> None:
+    """Zero demand sets mode Off and never touches the intensity number."""
+    await _ac_driver(mock_hass).set_speed(0)
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "select",
+        "select_option",
+        {ATTR_ENTITY_ID: "select.port_mode", "option": "Off"},
+        blocking=False,
+    )
+
+
+async def test_ac_infinity_turn_on_uses_on_speed(mock_hass: MagicMock) -> None:
+    """turn_on sets mode On and writes the configured on-speed."""
+    await _ac_driver(mock_hass, on_speed=7).turn_on()
+    mock_hass.services.async_call.assert_any_await(
+        "select",
+        "select_option",
+        {ATTR_ENTITY_ID: "select.port_mode", "option": "On"},
+        blocking=False,
+    )
+    mock_hass.services.async_call.assert_any_await(
+        "number",
+        "set_value",
+        {ATTR_ENTITY_ID: "number.port_speed", "value": 7},
+        blocking=False,
+    )
+
+
+async def test_ac_infinity_turn_off_sets_mode_off(mock_hass: MagicMock) -> None:
+    """turn_off sets the mode select to Off."""
+    await _ac_driver(mock_hass).turn_off()
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "select",
+        "select_option",
+        {ATTR_ENTITY_ID: "select.port_mode", "option": "Off"},
+        blocking=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        ("On", True),
+        ("Auto", True),
+        ("VPD", True),
+        ("Off", False),
+        (STATE_UNAVAILABLE, False),
+        (STATE_UNKNOWN, False),
+    ],
+)
+async def test_ac_infinity_is_on_reads_mode_select(
+    mock_hass: MagicMock, mode: str, expected: bool
+) -> None:
+    """is_on is True whenever the mode select is anything other than Off."""
+    mock_hass.states.get.return_value = _state(mode)
+    assert _ac_driver(mock_hass).is_on() is expected
+
+
+async def test_ac_infinity_is_on_missing_state(mock_hass: MagicMock) -> None:
+    """is_on is False when the mode select has no state."""
+    mock_hass.states.get.return_value = None
+    assert _ac_driver(mock_hass).is_on() is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_actuator_drivers (plain + AC Infinity merge)
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_actuator_drivers_merges_and_skips_unsupported(
+    mock_hass: MagicMock,
+) -> None:
+    """The aggregator yields a driver per plain entity and AC Infinity bundle."""
+    drivers = resolve_actuator_drivers(
+        mock_hass,
+        ["fan.exhaust", "switch.damper", "light.unsupported"],
+        [ACInfinityDevice(mode_entity="select.m", speed_entity="number.s")],
+    )
+    assert [type(d) for d in drivers] == [FanDriver, SwitchDriver, ACInfinityDriver]
+
+
+async def test_resolve_actuator_drivers_empty(mock_hass: MagicMock) -> None:
+    """No configured actuators yields no drivers."""
+    assert resolve_actuator_drivers(mock_hass, [], []) == []

--- a/tests/integration/test_exhaust_fan_coordinator.py
+++ b/tests/integration/test_exhaust_fan_coordinator.py
@@ -7,7 +7,10 @@ import pytest
 from custom_components.growspace_manager.exhaust_fan_coordinator import (
     ExhaustFanCoordinator,
 )
-from custom_components.growspace_manager.models import EnvironmentConfig
+from custom_components.growspace_manager.models import (
+    ACInfinityDevice,
+    EnvironmentConfig,
+)
 from custom_components.growspace_manager.models.growspace import ExhaustFanConfig
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
@@ -41,6 +44,7 @@ def _make_env_config(
     vpd_sensors: list[str] | None = None,
     light_sensors: list[str] | None = None,
     exhaust_fan_entities: list[str] | None = None,
+    exhaust_fan_ac_infinity_devices: list[ACInfinityDevice] | None = None,
     temperature_target: float = 25.0,
     temperature_tolerance: float = 2.0,
     humidity_target: float = 60.0,
@@ -83,6 +87,7 @@ def _make_env_config(
         exhaust_fan_entities=exhaust_fan_entities
         if exhaust_fan_entities is not None
         else ["fan.exhaust"],
+        exhaust_fan_ac_infinity_devices=exhaust_fan_ac_infinity_devices or [],
         exhaust_fan_config=fan_cfg,
     )
 
@@ -663,3 +668,96 @@ async def test_override_inert_when_temp_unavailable(mock_hass: MagicMock) -> Non
         {ATTR_ENTITY_ID: "switch.exhaust"},
         blocking=False,
     )
+
+
+# ---------------------------------------------------------------------------
+# AC Infinity exhaust devices (ADR-0022)
+# ---------------------------------------------------------------------------
+
+
+async def test_ac_infinity_device_driven_by_mode_and_intensity(
+    mock_hass: MagicMock,
+) -> None:
+    """An AC Infinity exhaust port is driven via its mode select and speed number."""
+    env = _make_env_config(
+        exhaust_fan_entities=[],
+        exhaust_fan_ac_infinity_devices=[
+            ACInfinityDevice(
+                mode_entity="select.tent_port1_mode",
+                speed_entity="number.tent_port1_on_speed",
+            )
+        ],
+    )
+    mock_hass.states.get.side_effect = _states_from(
+        {
+            "sensor.temperature": "30.0",  # hot → demand = max_speed (90)
+            "sensor.humidity": "60.0",
+            "sensor.vpd": "1.0",
+        }
+    )
+    coord = ExhaustFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord._async_regulate()
+    mock_hass.services.async_call.assert_any_await(
+        "select",
+        "select_option",
+        {ATTR_ENTITY_ID: "select.tent_port1_mode", "option": "On"},
+        blocking=False,
+    )
+    mock_hass.services.async_call.assert_any_await(
+        "number",
+        "set_value",
+        {ATTR_ENTITY_ID: "number.tent_port1_on_speed", "value": 9},
+        blocking=False,
+    )
+    assert mock_hass.services.async_call.await_count == 2
+
+
+async def test_ac_infinity_and_plain_entities_both_dispatched(
+    mock_hass: MagicMock,
+) -> None:
+    """Plain entities and AC Infinity bundles for the exhaust role are all driven."""
+    env = _make_env_config(
+        exhaust_fan_entities=["fan.exhaust"],
+        exhaust_fan_ac_infinity_devices=[
+            ACInfinityDevice(
+                mode_entity="select.tent_port1_mode",
+                speed_entity="number.tent_port1_on_speed",
+            )
+        ],
+    )
+    mock_hass.states.get.side_effect = _states_from(
+        {
+            "sensor.temperature": "30.0",
+            "sensor.humidity": "60.0",
+            "sensor.vpd": "1.0",
+        }
+    )
+    coord = ExhaustFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord._async_regulate()
+    domains = {call[0][0] for call in mock_hass.services.async_call.await_args_list}
+    assert domains == {"fan", "select", "number"}
+
+
+async def test_async_setup_starts_tick_for_ac_infinity_only(
+    mock_hass: MagicMock, mock_track_time_interval: MagicMock
+) -> None:
+    """A growspace with only AC Infinity exhaust devices still starts the tick."""
+    env = _make_env_config(
+        enabled=True,
+        exhaust_fan_entities=[],
+        exhaust_fan_ac_infinity_devices=[
+            ACInfinityDevice(
+                mode_entity="select.tent_port1_mode",
+                speed_entity="number.tent_port1_on_speed",
+            )
+        ],
+    )
+    coord = ExhaustFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord.async_setup()
+    mock_track_time_interval.assert_called_once()


### PR DESCRIPTION
## What to build

Adds `ACInfinityDriver` (ADR-0022) and wires AC Infinity ports in as exhaust fans. Closes #503.

> **Stacked on #506** (`feat-actuator-driver-seam`). Review/merge that first; this PR is based on it so the diff shows only #503's changes. Retarget to `prerelease` once #506 merges.

## Changes

- **`ACInfinityDriver`** — an AC Infinity port exposes no `fan` entity; it's a bundle of a mode `select` (Active Mode) + speed `number` (0–10 intensity). The driver maps GSM intent onto it:
  - `set_speed(pct)`: `pct<=0` → mode `Off`; else mode `On` + number `clamp(round(pct/10),1,10)`. Off-threshold is `0` (follows the fan driver, **not** the switch's `min_speed`).
  - `turn_on()` → mode `On` + configured on-speed; `turn_off()` → mode `Off`.
  - `is_on()` → reads the mode `select` (deterministic `Off`; under cloud polling both select and any power sensor lag equally).
- **`ACInfinityDevice`** model + parallel `exhaust_fan_ac_infinity_devices` field on `EnvironmentConfig` (null-coercion + serialization round-trip).
- **`resolve_actuator_drivers`** aggregator merging plain `*_entities` with AC Infinity bundles; exhaust coordinator dispatches through it and gates setup/regulate on `_has_exhaust_actuators`.

## Verification

- **Upstream gate checked**: `managers/subsystem.py` constructs `ExhaustFanCoordinator` unconditionally; the only entity gate is the in-coordinator one updated here — so an **AC-Infinity-only** growspace gets a live, ticking coordinator. Locked with an `async_setup`-starts-tick test for that case.
- Full suite: **4609 passed**; `actuator_driver.py` **100%** coverage; ruff + format clean; mypy clean on changed files.
- 3 serialization snapshots updated for the new field (regenerated, then re-verified).
- No new service or WS command, so `test_core_init.py` count asserts are untouched.

## Stack

`#502 (#506)` → **this** → #504 / #505 / card#410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)