### PR TITLE
feat: AC Infinity circulation fan support (#504)

### DIFF
--- a/custom_components/growspace_manager/circulation_fan_coordinator.py
+++ b/custom_components/growspace_manager/circulation_fan_coordinator.py
@@ -9,11 +9,11 @@ import time
 from typing import TYPE_CHECKING
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_time_interval
 
+from .actuator_driver import resolve_actuator_drivers
 from .const import FanRegulationMode
 from .domain.day_night import DayNightTracker
 from .domain.fan_control import (
@@ -68,6 +68,18 @@ class CirculationFanCoordinator:
         gs = self.main_coordinator.growspaces.get(self.growspace_id)
         return gs.environment_config if gs else None
 
+    @property
+    def _has_circulation_actuators(self) -> bool:
+        """Whether any circulation actuator — plain or AC Infinity — is configured."""
+        env = self._env_config
+        return bool(
+            env
+            and (
+                env.circulation_fan_entities
+                or env.circulation_fan_ac_infinity_devices
+            )
+        )
+
     async def async_setup(self) -> None:
         """Start the 10-second polling tick."""
         if self._env_config is None:
@@ -80,7 +92,7 @@ class CirculationFanCoordinator:
             )
             return
 
-        if not self._env_config.circulation_fan_entities:
+        if not self._has_circulation_actuators:
             _LOGGER.debug(
                 "CirculationFanCoordinator: no fan entities for %s", self.growspace_id
             )
@@ -170,18 +182,14 @@ class CirculationFanCoordinator:
             )
             speed = max(cfg.min_speed, min(cfg.max_speed, round(speed + wind_offset)))
 
-        for entity_id in self._env_config.circulation_fan_entities:
-            try:
-                await self.hass.services.async_call(
-                    "fan",
-                    "set_percentage",
-                    {ATTR_ENTITY_ID: entity_id, "percentage": speed},
-                    blocking=False,
-                )
-            except (HomeAssistantError, TimeoutError):
-                _LOGGER.warning(
-                    "Failed to set percentage on %s", entity_id, exc_info=True
-                )
+        drivers = resolve_actuator_drivers(
+            self.hass,
+            self._env_config.circulation_fan_entities,
+            self._env_config.circulation_fan_ac_infinity_devices,
+            switch_off_threshold=cfg.min_speed,
+        )
+        for driver in drivers:
+            await driver.set_speed(speed)
 
     def _get_stage_vpd_target(self, cfg: CirculationFanConfig, is_day: bool) -> float:
         """Resolve the effective VPD target from stage defaults.

--- a/custom_components/growspace_manager/models/growspace.py
+++ b/custom_components/growspace_manager/models/growspace.py
@@ -199,6 +199,9 @@ class EnvironmentConfig(BaseModel):
     exhaust_fan_ac_infinity_devices: list[ACInfinityDevice] = field(
         default_factory=list
     )
+    circulation_fan_ac_infinity_devices: list[ACInfinityDevice] = field(
+        default_factory=list
+    )
 
     # 3D Sensor Configuration
     sensor_coordinates: dict[str, dict[str, float]] = field(default_factory=dict)
@@ -303,6 +306,7 @@ class EnvironmentConfig(BaseModel):
             "humidifier_entities",
             "dehumidifier_entities",
             "exhaust_fan_ac_infinity_devices",
+            "circulation_fan_ac_infinity_devices",
             "sensor_groups",
             "substrate_temperature_sensors",
             "camera_entities",

--- a/tests/core/snapshots/test_models_snapshots.ambr
+++ b/tests/core/snapshots/test_models_snapshots.ambr
@@ -46,6 +46,8 @@
     ]),
     'camera_entities': list([
     ]),
+    'circulation_fan_ac_infinity_devices': list([
+    ]),
     'circulation_fan_config': dict({
       'critical_temp_high': None,
       'critical_temp_hysteresis': 1.0,
@@ -197,6 +199,8 @@
       'bulk_ec_sensors': list([
       ]),
       'camera_entities': list([
+      ]),
+      'circulation_fan_ac_infinity_devices': list([
       ]),
       'circulation_fan_config': dict({
         'critical_temp_high': None,

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -1042,13 +1042,19 @@ def test_growspace_exhaust_fan_config_roundtrip() -> None:
 
 
 def test_environment_config_ac_infinity_devices_round_trip() -> None:
-    """AC Infinity exhaust bundles survive a to_dict/from_dict round trip."""
+    """AC Infinity exhaust and circulation bundles survive a to_dict/from_dict trip."""
     config = EnvironmentConfig(
         exhaust_fan_ac_infinity_devices=[
             ACInfinityDevice(
                 mode_entity="select.tent_port1_mode",
                 speed_entity="number.tent_port1_on_speed",
                 on_speed=7,
+            )
+        ],
+        circulation_fan_ac_infinity_devices=[
+            ACInfinityDevice(
+                mode_entity="select.tent_port2_mode",
+                speed_entity="number.tent_port2_on_speed",
             )
         ],
     )
@@ -1060,10 +1066,23 @@ def test_environment_config_ac_infinity_devices_round_trip() -> None:
             on_speed=7,
         )
     ]
+    assert restored.circulation_fan_ac_infinity_devices == [
+        ACInfinityDevice(
+            mode_entity="select.tent_port2_mode",
+            speed_entity="number.tent_port2_on_speed",
+        )
+    ]
 
 
 def test_environment_config_ac_infinity_devices_default_empty() -> None:
-    """The AC Infinity bundle list defaults to empty and tolerates a null payload."""
+    """The AC Infinity bundle lists default to empty and tolerate a null payload."""
     assert EnvironmentConfig().exhaust_fan_ac_infinity_devices == []
-    restored = EnvironmentConfig.from_dict({"exhaust_fan_ac_infinity_devices": None})
+    assert EnvironmentConfig().circulation_fan_ac_infinity_devices == []
+    restored = EnvironmentConfig.from_dict(
+        {
+            "exhaust_fan_ac_infinity_devices": None,
+            "circulation_fan_ac_infinity_devices": None,
+        }
+    )
     assert restored.exhaust_fan_ac_infinity_devices == []
+    assert restored.circulation_fan_ac_infinity_devices == []

--- a/tests/integration/snapshots/test_services_growspace_coverage.ambr
+++ b/tests/integration/snapshots/test_services_growspace_coverage.ambr
@@ -34,6 +34,8 @@
       ]),
       'camera_entities': list([
       ]),
+      'circulation_fan_ac_infinity_devices': list([
+      ]),
       'circulation_fan_config': dict({
         'critical_temp_high': None,
         'critical_temp_hysteresis': 1.0,

--- a/tests/integration/test_circulation_fan_coordinator.py
+++ b/tests/integration/test_circulation_fan_coordinator.py
@@ -9,7 +9,10 @@ from custom_components.growspace_manager.circulation_fan_coordinator import (
     CirculationFanCoordinator,
 )
 from custom_components.growspace_manager.const import FanRegulationMode, PlantStage
-from custom_components.growspace_manager.models import EnvironmentConfig
+from custom_components.growspace_manager.models import (
+    ACInfinityDevice,
+    EnvironmentConfig,
+)
 from custom_components.growspace_manager.models.growspace import CirculationFanConfig
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
@@ -51,6 +54,7 @@ def _make_env_config(
     vpd_sensors: list[str] | None = None,
     light_sensors: list[str] | None = None,
     circulation_fan_entities: list[str] | None = None,
+    circulation_fan_ac_infinity_devices: list[ACInfinityDevice] | None = None,
     humidity_target: float = 60.0,
     humidity_tolerance: float = 5.0,
     temperature_target: float = 25.0,
@@ -89,11 +93,18 @@ def _make_env_config(
         stage_vpd_overrides=stage_vpd_overrides or {},
     )
     return EnvironmentConfig(
-        humidity_sensors=humidity_sensors if humidity_sensors is not None else ["sensor.humidity"],
-        temperature_sensors=temperature_sensors if temperature_sensors is not None else ["sensor.temperature"],
+        humidity_sensors=humidity_sensors
+        if humidity_sensors is not None
+        else ["sensor.humidity"],
+        temperature_sensors=temperature_sensors
+        if temperature_sensors is not None
+        else ["sensor.temperature"],
         vpd_sensors=vpd_sensors if vpd_sensors is not None else ["sensor.vpd"],
         light_sensors=light_sensors if light_sensors is not None else [],
-        circulation_fan_entities=circulation_fan_entities if circulation_fan_entities is not None else ["fan.circ"],
+        circulation_fan_entities=circulation_fan_entities
+        if circulation_fan_entities is not None
+        else ["fan.circ"],
+        circulation_fan_ac_infinity_devices=circulation_fan_ac_infinity_devices or [],
         circulation_fan_config=fan_cfg,
     )
 
@@ -373,9 +384,7 @@ async def test_no_sensor_entities_skips_fan_call(
     mock_hass: MagicMock,
 ) -> None:
     """No humidity_sensors configured → no fan.set_percentage call."""
-    env = _make_env_config(
-        mode=FanRegulationMode.HUMIDITY, humidity_sensors=[]
-    )
+    env = _make_env_config(mode=FanRegulationMode.HUMIDITY, humidity_sensors=[])
     main_coord = _make_coordinator("gs1", env)
     coord = CirculationFanCoordinator(mock_hass, MagicMock(), "gs1", main_coord)
 
@@ -748,7 +757,9 @@ async def test_wind_enabled_applies_offset_at_quarter_period(
     coord = CirculationFanCoordinator(mock_hass, MagicMock(), "gs1", main_coord)
     coord._start_time = 0.0
 
-    with patch("custom_components.growspace_manager.circulation_fan_coordinator.time") as mock_time:
+    with patch(
+        "custom_components.growspace_manager.circulation_fan_coordinator.time"
+    ) as mock_time:
         mock_time.monotonic.return_value = 15.0  # quarter period
         await coord._async_regulate()
 
@@ -775,12 +786,16 @@ async def test_wind_output_clamped_to_max_speed(
         wind_period_seconds=60,
         wind_amplitude_pct=20,
     )
-    mock_hass.states.get.return_value = MagicMock(state="70.0")  # above band → max_speed=90
+    mock_hass.states.get.return_value = MagicMock(
+        state="70.0"
+    )  # above band → max_speed=90
     main_coord = _make_coordinator("gs1", env)
     coord = CirculationFanCoordinator(mock_hass, MagicMock(), "gs1", main_coord)
     coord._start_time = 0.0
 
-    with patch("custom_components.growspace_manager.circulation_fan_coordinator.time") as mock_time:
+    with patch(
+        "custom_components.growspace_manager.circulation_fan_coordinator.time"
+    ) as mock_time:
         mock_time.monotonic.return_value = 15.0  # quarter period → sin=1.0
         await coord._async_regulate()
 
@@ -807,12 +822,16 @@ async def test_wind_output_clamped_to_min_speed(
         wind_period_seconds=60,
         wind_amplitude_pct=20,
     )
-    mock_hass.states.get.return_value = MagicMock(state="50.0")  # below band → min_speed=10
+    mock_hass.states.get.return_value = MagicMock(
+        state="50.0"
+    )  # below band → min_speed=10
     main_coord = _make_coordinator("gs1", env)
     coord = CirculationFanCoordinator(mock_hass, MagicMock(), "gs1", main_coord)
     coord._start_time = 0.0
 
-    with patch("custom_components.growspace_manager.circulation_fan_coordinator.time") as mock_time:
+    with patch(
+        "custom_components.growspace_manager.circulation_fan_coordinator.time"
+    ) as mock_time:
         mock_time.monotonic.return_value = 45.0  # 3/4 period → sin=-1.0
         await coord._async_regulate()
 
@@ -842,7 +861,9 @@ async def test_wind_disabled_produces_stable_speed(
     coord._start_time = 0.0
 
     # At quarter period — if wind were enabled speed would be 60, not 50
-    with patch("custom_components.growspace_manager.circulation_fan_coordinator.time") as mock_time:
+    with patch(
+        "custom_components.growspace_manager.circulation_fan_coordinator.time"
+    ) as mock_time:
         mock_time.monotonic.return_value = 15.0
         await coord._async_regulate()
 
@@ -875,14 +896,18 @@ async def test_wind_applies_on_top_of_temp_override_speed(
     def _get_state(entity_id: str) -> MagicMock:
         if "temperature" in entity_id:
             return MagicMock(state="32.0")  # above threshold → override to max_speed=90
-        return MagicMock(state="0.5")  # VPD below band → would be min_speed without override
+        return MagicMock(
+            state="0.5"
+        )  # VPD below band → would be min_speed without override
 
     mock_hass.states.get.side_effect = _get_state
     main_coord = _make_coordinator("gs1", env)
     coord = CirculationFanCoordinator(mock_hass, MagicMock(), "gs1", main_coord)
     coord._start_time = 0.0
 
-    with patch("custom_components.growspace_manager.circulation_fan_coordinator.time") as mock_time:
+    with patch(
+        "custom_components.growspace_manager.circulation_fan_coordinator.time"
+    ) as mock_time:
         mock_time.monotonic.return_value = 15.0  # quarter period → wind_offset = +5
         await coord._async_regulate()
 
@@ -1066,18 +1091,37 @@ def test_fan_vpd_stage_defaults_covers_all_coordinator_stages() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("stage,is_day,expected_target", [
-    (PlantStage.VEG, True, FAN_VPD_STAGE_DEFAULTS[PlantStage.VEG]["day"]),
-    (PlantStage.VEG, False, FAN_VPD_STAGE_DEFAULTS[PlantStage.VEG]["night"]),
-    (PlantStage.FLOWER_EARLY, True, FAN_VPD_STAGE_DEFAULTS[PlantStage.FLOWER_EARLY]["day"]),
-    (PlantStage.FLOWER_MID, False, FAN_VPD_STAGE_DEFAULTS[PlantStage.FLOWER_MID]["night"]),
-    (PlantStage.FLOWER_LATE, True, FAN_VPD_STAGE_DEFAULTS[PlantStage.FLOWER_LATE]["day"]),
-    (PlantStage.DRY, False, FAN_VPD_STAGE_DEFAULTS[PlantStage.DRY]["night"]),
-    (PlantStage.CURE, True, FAN_VPD_STAGE_DEFAULTS[PlantStage.CURE]["day"]),
-    (PlantStage.SEEDLING, False, FAN_VPD_STAGE_DEFAULTS[PlantStage.SEEDLING]["night"]),
-    (PlantStage.CLONE, True, FAN_VPD_STAGE_DEFAULTS[PlantStage.CLONE]["day"]),
-    (PlantStage.MOTHER, True, FAN_VPD_STAGE_DEFAULTS[PlantStage.MOTHER]["day"]),
-])
+@pytest.mark.parametrize(
+    "stage,is_day,expected_target",
+    [
+        (PlantStage.VEG, True, FAN_VPD_STAGE_DEFAULTS[PlantStage.VEG]["day"]),
+        (PlantStage.VEG, False, FAN_VPD_STAGE_DEFAULTS[PlantStage.VEG]["night"]),
+        (
+            PlantStage.FLOWER_EARLY,
+            True,
+            FAN_VPD_STAGE_DEFAULTS[PlantStage.FLOWER_EARLY]["day"],
+        ),
+        (
+            PlantStage.FLOWER_MID,
+            False,
+            FAN_VPD_STAGE_DEFAULTS[PlantStage.FLOWER_MID]["night"],
+        ),
+        (
+            PlantStage.FLOWER_LATE,
+            True,
+            FAN_VPD_STAGE_DEFAULTS[PlantStage.FLOWER_LATE]["day"],
+        ),
+        (PlantStage.DRY, False, FAN_VPD_STAGE_DEFAULTS[PlantStage.DRY]["night"]),
+        (PlantStage.CURE, True, FAN_VPD_STAGE_DEFAULTS[PlantStage.CURE]["day"]),
+        (
+            PlantStage.SEEDLING,
+            False,
+            FAN_VPD_STAGE_DEFAULTS[PlantStage.SEEDLING]["night"],
+        ),
+        (PlantStage.CLONE, True, FAN_VPD_STAGE_DEFAULTS[PlantStage.CLONE]["day"]),
+        (PlantStage.MOTHER, True, FAN_VPD_STAGE_DEFAULTS[PlantStage.MOTHER]["day"]),
+    ],
+)
 def test_get_stage_vpd_target_returns_correct_value(
     mock_hass: MagicMock,
     stage: PlantStage,
@@ -1217,8 +1261,14 @@ def test_get_stage_vpd_target_override_present_uses_override(
     ):
         main_coord = _make_coordinator("gs1", env, plants=[plant])
         coord = CirculationFanCoordinator(mock_hass, MagicMock(), "gs1", main_coord)
-        assert coord._get_stage_vpd_target(env.circulation_fan_config, is_day=True) == override_day
-        assert coord._get_stage_vpd_target(env.circulation_fan_config, is_day=False) == override_night
+        assert (
+            coord._get_stage_vpd_target(env.circulation_fan_config, is_day=True)
+            == override_day
+        )
+        assert (
+            coord._get_stage_vpd_target(env.circulation_fan_config, is_day=False)
+            == override_night
+        )
 
 
 def test_get_stage_vpd_target_override_absent_uses_default(
@@ -1238,7 +1288,10 @@ def test_get_stage_vpd_target_override_absent_uses_default(
     ):
         main_coord = _make_coordinator("gs1", env, plants=[plant])
         coord = CirculationFanCoordinator(mock_hass, MagicMock(), "gs1", main_coord)
-        assert coord._get_stage_vpd_target(env.circulation_fan_config, is_day=True) == FAN_VPD_STAGE_DEFAULTS[PlantStage.VEG]["day"]
+        assert (
+            coord._get_stage_vpd_target(env.circulation_fan_config, is_day=True)
+            == FAN_VPD_STAGE_DEFAULTS[PlantStage.VEG]["day"]
+        )
 
 
 def test_get_stage_vpd_target_no_plants_falls_back_to_vpd_target(
@@ -1254,7 +1307,10 @@ def test_get_stage_vpd_target_no_plants_falls_back_to_vpd_target(
     )
     main_coord = _make_coordinator("gs1", env, plants=[])
     coord = CirculationFanCoordinator(mock_hass, MagicMock(), "gs1", main_coord)
-    assert coord._get_stage_vpd_target(env.circulation_fan_config, is_day=True) == static_target
+    assert (
+        coord._get_stage_vpd_target(env.circulation_fan_config, is_day=True)
+        == static_target
+    )
 
 
 def test_get_stage_vpd_target_unknown_stage_falls_back_to_vpd_target(
@@ -1285,24 +1341,27 @@ def test_get_stage_vpd_target_unknown_stage_falls_back_to_vpd_target(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("bad_overrides,match", [
-    (
-        {"veg": {"day": 0.0, "night": 0.7}},
-        "out of range",
-    ),
-    (
-        {"veg": {"day": 3.1, "night": 0.7}},
-        "out of range",
-    ),
-    (
-        {"not_a_stage": {"day": 0.8, "night": 0.7}},
-        "Unknown stage key",
-    ),
-    (
-        {"veg": {"day": 0.8}},
-        "both 'day' and 'night'",
-    ),
-])
+@pytest.mark.parametrize(
+    "bad_overrides,match",
+    [
+        (
+            {"veg": {"day": 0.0, "night": 0.7}},
+            "out of range",
+        ),
+        (
+            {"veg": {"day": 3.1, "night": 0.7}},
+            "out of range",
+        ),
+        (
+            {"not_a_stage": {"day": 0.8, "night": 0.7}},
+            "Unknown stage key",
+        ),
+        (
+            {"veg": {"day": 0.8}},
+            "both 'day' and 'night'",
+        ),
+    ],
+)
 def test_stage_vpd_overrides_validation(
     bad_overrides: dict,
     match: str,
@@ -1359,3 +1418,93 @@ async def test_async_restart_resets_state_and_restarts_tick(
     # Verify async_setup re-registered tick
     mock_track_time_interval.assert_called_once()
 
+
+# ---------------------------------------------------------------------------
+# AC Infinity circulation devices (ADR-0022)
+# ---------------------------------------------------------------------------
+
+
+async def test_ac_infinity_circulation_driven_by_mode_and_intensity(
+    mock_hass: MagicMock,
+) -> None:
+    """An AC Infinity circulation port is driven via its mode select and number."""
+    env = _make_env_config(
+        mode=FanRegulationMode.HUMIDITY,
+        humidity_target=60.0,
+        humidity_tolerance=5.0,
+        min_speed=10,
+        max_speed=90,
+        circulation_fan_entities=[],
+        circulation_fan_ac_infinity_devices=[
+            ACInfinityDevice(
+                mode_entity="select.tent_port2_mode",
+                speed_entity="number.tent_port2_on_speed",
+            )
+        ],
+    )
+    mock_hass.states.get.return_value = MagicMock(state="50.0")  # → min_speed (10)
+    coord = CirculationFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord._async_regulate()
+    mock_hass.services.async_call.assert_any_await(
+        "select",
+        "select_option",
+        {ATTR_ENTITY_ID: "select.tent_port2_mode", "option": "On"},
+        blocking=False,
+    )
+    mock_hass.services.async_call.assert_any_await(
+        "number",
+        "set_value",
+        {ATTR_ENTITY_ID: "number.tent_port2_on_speed", "value": 1},
+        blocking=False,
+    )
+    assert mock_hass.services.async_call.await_count == 2
+
+
+async def test_ac_infinity_and_plain_circulation_both_dispatched(
+    mock_hass: MagicMock,
+) -> None:
+    """Plain fans and AC Infinity bundles for the circulation role are all driven."""
+    env = _make_env_config(
+        mode=FanRegulationMode.HUMIDITY,
+        circulation_fan_entities=["fan.circ"],
+        circulation_fan_ac_infinity_devices=[
+            ACInfinityDevice(
+                mode_entity="select.tent_port2_mode",
+                speed_entity="number.tent_port2_on_speed",
+            )
+        ],
+    )
+    mock_hass.states.get.return_value = MagicMock(state="50.0")
+    coord = CirculationFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    await coord._async_regulate()
+    domains = {call[0][0] for call in mock_hass.services.async_call.await_args_list}
+    assert domains == {"fan", "select", "number"}
+
+
+async def test_async_setup_starts_tick_for_ac_infinity_only(
+    mock_hass: MagicMock,
+) -> None:
+    """A growspace with only AC Infinity circulation devices still starts the tick."""
+    env = _make_env_config(
+        enabled=True,
+        circulation_fan_entities=[],
+        circulation_fan_ac_infinity_devices=[
+            ACInfinityDevice(
+                mode_entity="select.tent_port2_mode",
+                speed_entity="number.tent_port2_on_speed",
+            )
+        ],
+    )
+    coord = CirculationFanCoordinator(
+        mock_hass, MagicMock(), "gs1", _make_coordinator("gs1", env)
+    )
+    with patch(
+        "custom_components.growspace_manager.circulation_fan_coordinator.async_track_time_interval"
+    ) as mock_tick:
+        mock_tick.return_value = MagicMock()
+        await coord.async_setup()
+    mock_tick.assert_called_once()


### PR DESCRIPTION
## What to build

Make AC Infinity ports usable as circulation fans, reusing the actuator-driver layer. Closes #504.

> **Stacked on #507** (`feat-ac-infinity-exhaust`). Review/merge #506 → #507 first; this PR is based on #507 so the diff shows only #504's changes. Retarget to `prerelease` as the stack merges.

## Changes

- `circulation_fan_coordinator` dispatches through `resolve_actuator_drivers` (plain entities + AC Infinity bundles) instead of the inline `fan.set_percentage` loop.
- New `circulation_fan_ac_infinity_devices` field on `EnvironmentConfig` (null-coercion + serialization).
- Setup/regulate gate on `_has_circulation_actuators` so an AC-Infinity-only growspace is operational.

## Verification

- 61 existing circulation tests stay green (FanDriver reproduces `fan.set_percentage` exactly); 3 new tests (AC Infinity dispatch, mixed, AC-Infinity-only setup).
- Full suite green (4612); `circulation_fan_coordinator.py` at 100% coverage. Three serialization snapshots updated for the new field. No new service or WS command.

## Stack

`#502 (#506)` → `#503 (#507)` → **this** → #505 / card#410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)