### PR TITLE
feat: AC Infinity humidifier + dehumidifier support (#505)

### DIFF
--- a/custom_components/growspace_manager/actuator_driver.py
+++ b/custom_components/growspace_manager/actuator_driver.py
@@ -33,6 +33,10 @@ _LOGGER = logging.getLogger(__name__)
 # On/off domains driven via turn_on/turn_off rather than by percentage.
 _SWITCH_DOMAINS = ("switch", "input_boolean")
 
+# Domains a binary on/off controller drives via their own turn_on/turn_off
+# service; any other domain falls back to the generic ``homeassistant`` service.
+_ON_OFF_NATIVE_DOMAINS = ("switch", "humidifier", "fan", "input_boolean")
+
 # AC Infinity Active Mode options (hardcoded English in the ac_infinity integration).
 _AC_INFINITY_MODE_ON = "On"
 _AC_INFINITY_MODE_OFF = "Off"
@@ -280,6 +284,83 @@ def resolve_actuator_drivers(
         )
         if driver is not None:
             drivers.append(driver)
+    drivers.extend(
+        ACInfinityDriver(
+            hass,
+            mode_entity=device.mode_entity,
+            speed_entity=device.speed_entity,
+            on_speed=device.on_speed,
+        )
+        for device in ac_infinity_devices
+    )
+    return drivers
+
+
+class GenericOnOffDriver:
+    """Binary on/off driver for the VPD controllers (humidifier/dehumidifier).
+
+    Drives ``switch``/``humidifier``/``fan``/``input_boolean`` via their own
+    ``turn_on``/``turn_off`` service and any other domain via the generic
+    ``homeassistant`` service — mirroring the controller's historical dispatch so
+    a humidifier entity or a climate/remote device is still driven. ``set_speed``
+    collapses to on (above ``off_threshold``) or off.
+    """
+
+    def __init__(
+        self, hass: HomeAssistant, entity_id: str, *, off_threshold: int = 0
+    ) -> None:
+        """Initialize the driver, resolving the service domain for ``entity_id``."""
+        self._hass = hass
+        self._entity_id = entity_id
+        domain = entity_id.split(".", 1)[0]
+        self._domain = domain if domain in _ON_OFF_NATIVE_DOMAINS else "homeassistant"
+        self._off_threshold = off_threshold
+
+    async def set_speed(self, pct: int) -> None:
+        """Turn on when ``pct`` exceeds the off threshold, otherwise off."""
+        if pct > self._off_threshold:
+            await self.turn_on()
+        else:
+            await self.turn_off()
+
+    async def turn_on(self) -> None:
+        """Turn the device on via its resolved service domain."""
+        await _safe_service_call(
+            self._hass,
+            self._domain,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: self._entity_id},
+        )
+
+    async def turn_off(self) -> None:
+        """Turn the device off via its resolved service domain."""
+        await _safe_service_call(
+            self._hass,
+            self._domain,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: self._entity_id},
+        )
+
+    def is_on(self) -> bool:
+        """Return whether the entity reports the ``on`` state."""
+        state = self._hass.states.get(self._entity_id)
+        return state is not None and state.state == STATE_ON
+
+
+def resolve_on_off_drivers(
+    hass: HomeAssistant,
+    entities: Iterable[str],
+    ac_infinity_devices: Iterable[ACInfinityDeviceConfig] = (),
+) -> list[ActuatorDriver]:
+    """Resolve binary on/off actuators (plain entities + AC Infinity bundles).
+
+    Used by the VPD on/off controllers. Every plain entity becomes a
+    ``GenericOnOffDriver`` (preserving the controller's own-domain/homeassistant
+    dispatch); each AC Infinity bundle becomes an ``ACInfinityDriver``.
+    """
+    drivers: list[ActuatorDriver] = [
+        GenericOnOffDriver(hass, entity_id) for entity_id in entities
+    ]
     drivers.extend(
         ACInfinityDriver(
             hass,

--- a/custom_components/growspace_manager/dehumidifier_coordinator.py
+++ b/custom_components/growspace_manager/dehumidifier_coordinator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from .const import (
     CATEGORY_DEHUMIDIFIER,
     DEFAULT_DEHUMIDIFIER_MIN_OFFTIME,
@@ -9,6 +11,9 @@ from .const import (
     PlantStage,
 )
 from .vpd_on_off_controller import VpdOnOffController
+
+if TYPE_CHECKING:
+    from .models import ACInfinityDevice
 
 # Default thresholds — dehumidifier turns ON when VPD falls below `on`, OFF when it rises above `off`.
 # Low VPD = high humidity = needs dehumidification.
@@ -74,3 +79,9 @@ class DehumidifierCoordinator(VpdOnOffController):
             return []
         env = self.growspace.environment_config
         return list(env.dehumidifier_entities or [])
+
+    def _get_ac_infinity_devices(self) -> list[ACInfinityDevice]:
+        if not self.growspace or not self.growspace.environment_config:
+            return []
+        env = self.growspace.environment_config
+        return list(env.dehumidifier_ac_infinity_devices or [])

--- a/custom_components/growspace_manager/humidifier_coordinator.py
+++ b/custom_components/growspace_manager/humidifier_coordinator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from .const import (
     CATEGORY_HUMIDIFIER,
     DEFAULT_HUMIDIFIER_MIN_OFFTIME,
@@ -9,6 +11,9 @@ from .const import (
     PlantStage,
 )
 from .vpd_on_off_controller import VpdOnOffController
+
+if TYPE_CHECKING:
+    from .models import ACInfinityDevice
 
 # Default thresholds — humidifier turns ON when VPD exceeds `on`, OFF when it drops below `off`.
 # High VPD = low humidity = needs humidification.
@@ -70,3 +75,10 @@ class HumidifierCoordinator(VpdOnOffController):
         if not self.growspace or not self.growspace.environment_config:
             return []
         return list(self.growspace.environment_config.humidifier_entities or [])
+
+    def _get_ac_infinity_devices(self) -> list[ACInfinityDevice]:
+        if not self.growspace or not self.growspace.environment_config:
+            return []
+        return list(
+            self.growspace.environment_config.humidifier_ac_infinity_devices or []
+        )

--- a/custom_components/growspace_manager/models/growspace.py
+++ b/custom_components/growspace_manager/models/growspace.py
@@ -202,6 +202,12 @@ class EnvironmentConfig(BaseModel):
     circulation_fan_ac_infinity_devices: list[ACInfinityDevice] = field(
         default_factory=list
     )
+    humidifier_ac_infinity_devices: list[ACInfinityDevice] = field(
+        default_factory=list
+    )
+    dehumidifier_ac_infinity_devices: list[ACInfinityDevice] = field(
+        default_factory=list
+    )
 
     # 3D Sensor Configuration
     sensor_coordinates: dict[str, dict[str, float]] = field(default_factory=dict)
@@ -307,6 +313,8 @@ class EnvironmentConfig(BaseModel):
             "dehumidifier_entities",
             "exhaust_fan_ac_infinity_devices",
             "circulation_fan_ac_infinity_devices",
+            "humidifier_ac_infinity_devices",
+            "dehumidifier_ac_infinity_devices",
             "sensor_groups",
             "substrate_temperature_sensors",
             "camera_entities",

--- a/custom_components/growspace_manager/vpd_on_off_controller.py
+++ b/custom_components/growspace_manager/vpd_on_off_controller.py
@@ -7,26 +7,21 @@ import time
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    SERVICE_TURN_OFF,
-    SERVICE_TURN_ON,
-    STATE_ON,
-    STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
-)
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_call_later, async_track_state_change_event
 from homeassistant.util import dt as dt_util
 
+from .actuator_driver import resolve_on_off_drivers
 from .const import PlantStage
 from .domain.day_night import DayNightTracker
 from .domain.stage_calculator import determine_coordinator_stage
 from .models import GrowspaceEvent
 
 if TYPE_CHECKING:
+    from .actuator_driver import ActuatorDriver
     from .coordinator import GrowspaceCoordinator
+    from .models import ACInfinityDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -95,10 +90,23 @@ class VpdOnOffController:
         """Return all entity IDs managed by this controller. Subclasses implement."""
         raise NotImplementedError
 
+    def _get_ac_infinity_devices(self) -> list[ACInfinityDevice]:
+        """Return AC Infinity bundles managed by this controller (none by default)."""
+        return []
+
+    def _resolve_drivers(self) -> list[ActuatorDriver]:
+        """Resolve every controlled actuator — plain entities and AC Infinity."""
+        return resolve_on_off_drivers(
+            self.hass,
+            self._get_all_controlled_entities(),
+            self._get_ac_infinity_devices(),
+        )
+
     async def async_setup(self) -> None:
         """Set up state-change listeners and run an initial check."""
         entities = self._get_all_controlled_entities()
-        if self.vpd_sensor and entities and self.control_enabled:
+        has_actuators = bool(entities or self._get_ac_infinity_devices())
+        if self.vpd_sensor and has_actuators and self.control_enabled:
             self._setup_listeners()
             await self.async_check_and_control()
             _LOGGER.info(
@@ -106,7 +114,7 @@ class VpdOnOffController:
                 type(self).__name__,
                 self.growspace.name,
                 self.vpd_sensor,
-                len(entities),
+                len(entities) + len(self._get_ac_infinity_devices()),
             )
         elif not self.control_enabled:
             _LOGGER.info(
@@ -258,21 +266,12 @@ class VpdOnOffController:
         )[day_key]
 
     async def _control_devices(self, turn_on: bool) -> None:
-        """Call turn_on or turn_off on every controlled entity."""
-        service = SERVICE_TURN_ON if turn_on else SERVICE_TURN_OFF
-        for entity_id in self._get_all_controlled_entities():
-            domain = entity_id.split(".")[0]
-            if domain not in ("switch", "humidifier", "fan", "input_boolean"):
-                domain = "homeassistant"
-            try:
-                await self.hass.services.async_call(
-                    domain,
-                    service,
-                    {ATTR_ENTITY_ID: entity_id},
-                    blocking=False,
-                )
-            except (HomeAssistantError, TimeoutError):
-                _LOGGER.warning("Failed to control device %s", entity_id, exc_info=True)
+        """Turn on or off every controlled actuator through its driver."""
+        for driver in self._resolve_drivers():
+            if turn_on:
+                await driver.turn_on()
+            else:
+                await driver.turn_off()
         if turn_on:
             self._last_turn_on_time = time.monotonic()
         else:
@@ -321,10 +320,7 @@ class VpdOnOffController:
             return None
 
     def _is_device_on(self) -> bool:
-        return any(
-            (s := self.hass.states.get(e)) is not None and s.state == STATE_ON
-            for e in self._get_all_controlled_entities()
-        )
+        return any(driver.is_on() for driver in self._resolve_drivers())
 
     def unload(self) -> None:
         """Stop listeners and cancel any pending retry."""

--- a/tests/core/snapshots/test_models_snapshots.ambr
+++ b/tests/core/snapshots/test_models_snapshots.ambr
@@ -74,6 +74,8 @@
     'co2_sensor': None,
     'control_dehumidifier': True,
     'control_humidifier': False,
+    'dehumidifier_ac_infinity_devices': list([
+    ]),
     'dehumidifier_entities': list([
     ]),
     'dehumidifier_thresholds': dict({
@@ -109,6 +111,8 @@
     'feed_ec_sensors': list([
     ]),
     'flower_day_hours': 12,
+    'humidifier_ac_infinity_devices': list([
+    ]),
     'humidifier_entities': list([
     ]),
     'humidifier_thresholds': dict({
@@ -228,6 +232,8 @@
       'co2_sensor': None,
       'control_dehumidifier': False,
       'control_humidifier': False,
+      'dehumidifier_ac_infinity_devices': list([
+      ]),
       'dehumidifier_entities': list([
       ]),
       'dehumidifier_thresholds': dict({
@@ -263,6 +269,8 @@
       'feed_ec_sensors': list([
       ]),
       'flower_day_hours': 12,
+      'humidifier_ac_infinity_devices': list([
+      ]),
       'humidifier_entities': list([
       ]),
       'humidifier_thresholds': dict({

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -1057,6 +1057,18 @@ def test_environment_config_ac_infinity_devices_round_trip() -> None:
                 speed_entity="number.tent_port2_on_speed",
             )
         ],
+        humidifier_ac_infinity_devices=[
+            ACInfinityDevice(
+                mode_entity="select.tent_port3_mode",
+                speed_entity="number.tent_port3_on_speed",
+            )
+        ],
+        dehumidifier_ac_infinity_devices=[
+            ACInfinityDevice(
+                mode_entity="select.tent_port4_mode",
+                speed_entity="number.tent_port4_on_speed",
+            )
+        ],
     )
     restored = EnvironmentConfig.from_dict(config.to_dict())
     assert restored.exhaust_fan_ac_infinity_devices == [
@@ -1072,17 +1084,35 @@ def test_environment_config_ac_infinity_devices_round_trip() -> None:
             speed_entity="number.tent_port2_on_speed",
         )
     ]
+    assert restored.humidifier_ac_infinity_devices == [
+        ACInfinityDevice(
+            mode_entity="select.tent_port3_mode",
+            speed_entity="number.tent_port3_on_speed",
+        )
+    ]
+    assert restored.dehumidifier_ac_infinity_devices == [
+        ACInfinityDevice(
+            mode_entity="select.tent_port4_mode",
+            speed_entity="number.tent_port4_on_speed",
+        )
+    ]
 
 
 def test_environment_config_ac_infinity_devices_default_empty() -> None:
     """The AC Infinity bundle lists default to empty and tolerate a null payload."""
     assert EnvironmentConfig().exhaust_fan_ac_infinity_devices == []
     assert EnvironmentConfig().circulation_fan_ac_infinity_devices == []
+    assert EnvironmentConfig().humidifier_ac_infinity_devices == []
+    assert EnvironmentConfig().dehumidifier_ac_infinity_devices == []
     restored = EnvironmentConfig.from_dict(
         {
             "exhaust_fan_ac_infinity_devices": None,
             "circulation_fan_ac_infinity_devices": None,
+            "humidifier_ac_infinity_devices": None,
+            "dehumidifier_ac_infinity_devices": None,
         }
     )
     assert restored.exhaust_fan_ac_infinity_devices == []
     assert restored.circulation_fan_ac_infinity_devices == []
+    assert restored.humidifier_ac_infinity_devices == []
+    assert restored.dehumidifier_ac_infinity_devices == []

--- a/tests/integration/snapshots/test_services_growspace_coverage.ambr
+++ b/tests/integration/snapshots/test_services_growspace_coverage.ambr
@@ -62,6 +62,8 @@
       'co2_sensor': None,
       'control_dehumidifier': False,
       'control_humidifier': False,
+      'dehumidifier_ac_infinity_devices': list([
+      ]),
       'dehumidifier_entities': list([
       ]),
       'dehumidifier_thresholds': dict({
@@ -97,6 +99,8 @@
       'feed_ec_sensors': list([
       ]),
       'flower_day_hours': 12,
+      'humidifier_ac_infinity_devices': list([
+      ]),
       'humidifier_entities': list([
       ]),
       'humidifier_thresholds': dict({

--- a/tests/integration/test_actuator_driver.py
+++ b/tests/integration/test_actuator_driver.py
@@ -7,9 +7,11 @@ import pytest
 from custom_components.growspace_manager.actuator_driver import (
     ACInfinityDriver,
     FanDriver,
+    GenericOnOffDriver,
     SwitchDriver,
     resolve_actuator_driver,
     resolve_actuator_drivers,
+    resolve_on_off_drivers,
 )
 from custom_components.growspace_manager.models import ACInfinityDevice
 from homeassistant.const import (
@@ -297,3 +299,84 @@ async def test_resolve_actuator_drivers_merges_and_skips_unsupported(
 async def test_resolve_actuator_drivers_empty(mock_hass: MagicMock) -> None:
     """No configured actuators yields no drivers."""
     assert resolve_actuator_drivers(mock_hass, [], []) == []
+
+
+# ---------------------------------------------------------------------------
+# GenericOnOffDriver (binary on/off controllers)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "domain"),
+    [
+        ("switch.humidifier", "switch"),
+        ("humidifier.unit", "humidifier"),
+        ("fan.inline", "fan"),
+        ("input_boolean.mister", "input_boolean"),
+        ("climate.tent", "homeassistant"),
+        ("remote.plug", "homeassistant"),
+    ],
+)
+async def test_generic_on_off_driver_domain_routing(
+    mock_hass: MagicMock, entity_id: str, domain: str
+) -> None:
+    """Native domains drive themselves; everything else falls back to homeassistant."""
+    await GenericOnOffDriver(mock_hass, entity_id).turn_on()
+    mock_hass.services.async_call.assert_awaited_once_with(
+        domain, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=False
+    )
+
+
+async def test_generic_on_off_driver_turn_off(mock_hass: MagicMock) -> None:
+    """turn_off issues the off service on the resolved domain."""
+    await GenericOnOffDriver(mock_hass, "climate.tent").turn_off()
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "homeassistant", "turn_off", {ATTR_ENTITY_ID: "climate.tent"}, blocking=False
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(STATE_ON, True), (STATE_OFF, False)],
+)
+async def test_generic_on_off_driver_is_on(
+    mock_hass: MagicMock, value: str, expected: bool
+) -> None:
+    """is_on reflects the entity state."""
+    mock_hass.states.get.return_value = _state(value)
+    assert GenericOnOffDriver(mock_hass, "switch.x").is_on() is expected
+
+
+async def test_resolve_on_off_drivers_merges_entities_and_bundles(
+    mock_hass: MagicMock,
+) -> None:
+    """Every plain entity becomes a GenericOnOffDriver; bundles become AC Infinity."""
+    drivers = resolve_on_off_drivers(
+        mock_hass,
+        ["switch.humidifier", "climate.tent"],
+        [ACInfinityDevice(mode_entity="select.m", speed_entity="number.s")],
+    )
+    assert [type(d) for d in drivers] == [
+        GenericOnOffDriver,
+        GenericOnOffDriver,
+        ACInfinityDriver,
+    ]
+
+
+async def test_resolve_on_off_drivers_empty(mock_hass: MagicMock) -> None:
+    """No configured actuators yields no drivers."""
+    assert resolve_on_off_drivers(mock_hass, []) == []
+
+
+@pytest.mark.parametrize(
+    ("pct", "service"),
+    [(1, "turn_on"), (0, "turn_off")],
+)
+async def test_generic_on_off_driver_set_speed(
+    mock_hass: MagicMock, pct: int, service: str
+) -> None:
+    """GenericOnOffDriver.set_speed collapses demand to on (>0) or off."""
+    await GenericOnOffDriver(mock_hass, "switch.x").set_speed(pct)
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "switch", service, {ATTR_ENTITY_ID: "switch.x"}, blocking=False
+    )

--- a/tests/integration/test_coverage_gap_fillers.py
+++ b/tests/integration/test_coverage_gap_fillers.py
@@ -182,8 +182,12 @@ async def test_dehumidifier_coordinator_control_exceptions(hass: HomeAssistant) 
     coordinator.hass = hass
     coordinator._last_turn_on_time = 0.0
     coordinator._last_turn_off_time = 0.0
-    # Bind the base-class method so self works
+    coordinator._get_ac_infinity_devices = MagicMock(return_value=[])
+    # Bind the base-class methods so self works (control delegates to _resolve_drivers)
     coordinator._control_devices = VpdOnOffController._control_devices.__get__(
+        coordinator, DehumidifierCoordinator
+    )
+    coordinator._resolve_drivers = VpdOnOffController._resolve_drivers.__get__(
         coordinator, DehumidifierCoordinator
     )
 
@@ -205,7 +209,8 @@ async def test_dehumidifier_coordinator_control_exceptions(hass: HomeAssistant) 
     # Test 2: Exception handling
     coordinator._get_all_controlled_entities = MagicMock(return_value=["switch.valid"])
     with patch(
-        "homeassistant.core.ServiceRegistry.async_call", side_effect=HomeAssistantError("Boom")
+        "homeassistant.core.ServiceRegistry.async_call",
+        side_effect=HomeAssistantError("Boom"),
     ):
         # Should not raise
         await coordinator._control_devices(True)
@@ -252,3 +257,8 @@ def test_dehumidifier_coordinator_is_day_logic(hass: HomeAssistant) -> None:
     # Test 4: String value "off"
     hass.states.async_set("sensor.light", "off")
     assert tracker.determine(hass, ["sensor.light"]) is False
+
+
+def test_vpd_controller_base_get_ac_infinity_devices_default() -> None:
+    """The base VpdOnOffController defaults to no AC Infinity devices."""
+    assert VpdOnOffController._get_ac_infinity_devices(Mock()) == []

--- a/tests/integration/test_dehumidifier_coordinator.py
+++ b/tests/integration/test_dehumidifier_coordinator.py
@@ -10,7 +10,7 @@ from custom_components.growspace_manager.const import PlantStage
 from custom_components.growspace_manager.dehumidifier_coordinator import (
     DehumidifierCoordinator,
 )
-from custom_components.growspace_manager.models import Plant
+from custom_components.growspace_manager.models import ACInfinityDevice, Plant
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
@@ -229,7 +229,10 @@ async def test_growth_stage_detection(coordinator, mock_main_coordinator) -> Non
     """Test correct growth stage detection based on plant days."""
     plant1 = MagicMock(spec=Plant)
     plant2 = MagicMock(spec=Plant)
-    mock_main_coordinator.services.growspaces.get_growspace_plants.return_value = [plant1, plant2]
+    mock_main_coordinator.services.growspaces.get_growspace_plants.return_value = [
+        plant1,
+        plant2,
+    ]
 
     # Case 1: Veg
     with patch(
@@ -543,7 +546,9 @@ async def test_growth_stage_detection_cure_dry_seedling(
 ) -> None:
     """Test detection of cure, dry, and seedling stages."""
     plant = MagicMock(spec=Plant)
-    mock_main_coordinator.services.growspaces.get_growspace_plants.return_value = [plant]
+    mock_main_coordinator.services.growspaces.get_growspace_plants.return_value = [
+        plant
+    ]
 
     # Test Cure
     with patch(
@@ -606,7 +611,7 @@ async def test_control_device_exception(
     with caplog.at_level(logging.WARNING):
         await coordinator._control_devices(True)
 
-    assert "Failed to control device" in caplog.text
+    assert "Failed to call" in caplog.text
 
 
 async def test_get_current_vpd_missing_sensor(
@@ -798,3 +803,63 @@ async def test_controlled_set_excludes_exhaust_when_both_configured(
     coordinator.growspace.environment_config.exhaust_fan_entities = ["fan.exhaust"]
 
     assert coordinator._get_all_controlled_entities() == ["switch.dehumidifier"]
+
+
+# ---------------------------------------------------------------------------
+# AC Infinity dehumidifier devices (ADR-0022)
+# ---------------------------------------------------------------------------
+
+
+async def test_ac_infinity_dehumidifier_turn_on(
+    mock_hass, mock_main_coordinator, mock_track_state_change_event
+) -> None:
+    """The dehumidifier override drives its AC Infinity port mode On + on-speed."""
+    growspace = MagicMock()
+    growspace.id = "gs1"
+    growspace.name = "Test Growspace"
+    env_config = MagicMock()
+    env_config.vpd_sensor = "sensor.vpd"
+    env_config.light_sensors = []
+    env_config.dehumidifier_entities = []
+    env_config.exhaust_fan_entities = []
+    env_config.dehumidifier_ac_infinity_devices = [
+        ACInfinityDevice(
+            mode_entity="select.dehum_mode",
+            speed_entity="number.dehum_speed",
+            on_speed=9,
+        )
+    ]
+    env_config.control_dehumidifier = True
+    env_config.dehumidifier_thresholds = {}
+    growspace.environment_config = env_config
+    growspace.dehumidifier_config = {}
+    mock_main_coordinator.growspaces = {"gs1": growspace}
+    coord = DehumidifierCoordinator(
+        mock_hass, mock_track_state_change_event, "gs1", mock_main_coordinator
+    )
+    mock_hass.services.async_call.reset_mock()
+    await coord._control_devices(True)
+    mock_hass.services.async_call.assert_any_await(
+        "select",
+        "select_option",
+        {ATTR_ENTITY_ID: "select.dehum_mode", "option": "On"},
+        blocking=False,
+    )
+    mock_hass.services.async_call.assert_any_await(
+        "number",
+        "set_value",
+        {ATTR_ENTITY_ID: "number.dehum_speed", "value": 9},
+        blocking=False,
+    )
+
+
+async def test_get_ac_infinity_devices_no_growspace(
+    mock_hass, mock_main_coordinator, mock_track_state_change_event
+) -> None:
+    """With no growspace, the AC Infinity bundle accessor returns an empty list."""
+    mock_main_coordinator.growspaces = {}
+    coord = DehumidifierCoordinator(
+        mock_hass, mock_track_state_change_event, "missing", mock_main_coordinator
+    )
+    assert coord._get_ac_infinity_devices() == []
+    assert coord._get_all_controlled_entities() == []

--- a/tests/integration/test_humidifier_coordinator.py
+++ b/tests/integration/test_humidifier_coordinator.py
@@ -10,7 +10,7 @@ from custom_components.growspace_manager.domain.stage import PlantStage
 from custom_components.growspace_manager.humidifier_coordinator import (
     HumidifierCoordinator,
 )
-from custom_components.growspace_manager.models import Plant
+from custom_components.growspace_manager.models import ACInfinityDevice, Plant
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
@@ -434,7 +434,7 @@ async def test_control_device_exception(
     with caplog.at_level(logging.WARNING):
         await coordinator._control_devices(True)
 
-    assert "Failed to control device" in caplog.text
+    assert "Failed to call" in caplog.text
 
 
 async def test_on_sensor_change(coordinator) -> None:
@@ -450,3 +450,101 @@ async def test_check_and_control_missing_vpd_sensor(coordinator) -> None:
     """Test async_check_and_control exits early with no VPD sensor."""
     coordinator.vpd_sensor = None
     await coordinator.async_check_and_control()
+
+
+# ---------------------------------------------------------------------------
+# AC Infinity humidifier devices (ADR-0022)
+# ---------------------------------------------------------------------------
+
+
+def _ac_infinity_humidifier(
+    mock_hass, mock_main_coordinator, mock_track_state_change_event
+) -> HumidifierCoordinator:
+    """Build a HumidifierCoordinator controlling one AC Infinity port (no plain entity)."""
+    growspace = MagicMock()
+    growspace.id = "gs1"
+    growspace.name = "Test Growspace"
+    env_config = MagicMock()
+    env_config.vpd_sensor = "sensor.vpd"
+    env_config.light_sensors = []
+    env_config.humidifier_entities = []
+    env_config.humidifier_ac_infinity_devices = [
+        ACInfinityDevice(
+            mode_entity="select.hum_mode",
+            speed_entity="number.hum_speed",
+            on_speed=8,
+        )
+    ]
+    env_config.control_humidifier = True
+    env_config.humidifier_thresholds = {}
+    growspace.environment_config = env_config
+    growspace.humidifier_config = {}
+    mock_main_coordinator.growspaces = {"gs1": growspace}
+    return HumidifierCoordinator(
+        mock_hass, mock_track_state_change_event, "gs1", mock_main_coordinator
+    )
+
+
+async def test_ac_infinity_humidifier_turn_on(
+    mock_hass, mock_main_coordinator, mock_track_state_change_event
+) -> None:
+    """Turning the humidifier on drives the port mode On at its configured on-speed."""
+    coord = _ac_infinity_humidifier(
+        mock_hass, mock_main_coordinator, mock_track_state_change_event
+    )
+    mock_hass.services.async_call.reset_mock()
+    await coord._control_devices(True)
+    mock_hass.services.async_call.assert_any_await(
+        "select",
+        "select_option",
+        {ATTR_ENTITY_ID: "select.hum_mode", "option": "On"},
+        blocking=False,
+    )
+    mock_hass.services.async_call.assert_any_await(
+        "number",
+        "set_value",
+        {ATTR_ENTITY_ID: "number.hum_speed", "value": 8},
+        blocking=False,
+    )
+
+
+async def test_ac_infinity_humidifier_turn_off(
+    mock_hass, mock_main_coordinator, mock_track_state_change_event
+) -> None:
+    """Turning the humidifier off sets the port mode to Off."""
+    coord = _ac_infinity_humidifier(
+        mock_hass, mock_main_coordinator, mock_track_state_change_event
+    )
+    mock_hass.services.async_call.reset_mock()
+    await coord._control_devices(False)
+    mock_hass.services.async_call.assert_awaited_once_with(
+        "select",
+        "select_option",
+        {ATTR_ENTITY_ID: "select.hum_mode", "option": "Off"},
+        blocking=False,
+    )
+
+
+async def test_ac_infinity_humidifier_is_on_reads_mode_select(
+    mock_hass, mock_main_coordinator, mock_track_state_change_event
+) -> None:
+    """is_on reads the AC Infinity mode select, not a plain entity state."""
+    coord = _ac_infinity_humidifier(
+        mock_hass, mock_main_coordinator, mock_track_state_change_event
+    )
+    mock_hass.states.get.return_value = MagicMock(state="On")
+    assert coord._is_device_on() is True
+    mock_hass.states.get.return_value = MagicMock(state="Off")
+    assert coord._is_device_on() is False
+
+
+async def test_get_ac_infinity_devices_no_growspace(
+    mock_hass, mock_main_coordinator, mock_track_state_change_event
+) -> None:
+    """With no growspace, the AC Infinity bundle accessor returns an empty list."""
+    mock_main_coordinator.growspaces = {}
+    coord = HumidifierCoordinator(
+        mock_hass, mock_track_state_change_event, "missing", mock_main_coordinator
+    )
+    assert coord._get_ac_infinity_devices() == []
+    assert coord._get_all_controlled_entities() == []


### PR DESCRIPTION
## What to build

Make AC Infinity ports usable as humidifiers and dehumidifiers (the binary VPD-controller path). Closes #505.

> **Stacked on #508** (`feat-ac-infinity-circulation`). Review/merge #506 → #507 → #508 first; this PR is based on #508 so the diff shows only #505's changes. Retarget to `prerelease` as the stack merges.

## Changes

Both coordinators share `VpdOnOffController`. Its on/off path is **broader** than the fan resolver — it drives `switch`/`humidifier`/`fan`/`input_boolean` via their own domain and any other domain via `homeassistant`. A fan-only resolver would silently drop `humidifier.*` and fallback entities (existing tests assert `homeassistant` + `input_boolean`). So:

- **`GenericOnOffDriver`** reproduces that exact own-domain / homeassistant-fallback mapping.
- **`resolve_on_off_drivers`** merges plain entities with AC Infinity bundles.
- Base `_get_ac_infinity_devices` (overridden per subclass); `_control_devices` / `_is_device_on` / setup-gate route through resolved drivers.
- New `humidifier_ac_infinity_devices` + `dehumidifier_ac_infinity_devices` fields.

For an AC Infinity port: on = mode `On` + configured on-speed, off = mode `Off`, `is_on` = mode select.

## Verification

- Plain-device behaviour unchanged — existing humidifier/dehumidifier tests stay green; new tests for AC Infinity turn_on/turn_off/is_on (both coordinators) and `GenericOnOffDriver` domain routing.
- Two test updates for the centralized dispatch: a log-message assertion (`Failed to control device` → `Failed to call`, same swallow-and-warn) and the coverage-gap test rebound to `_resolve_drivers`.
- Full suite green (4632); new code at 100% coverage. Three serialization snapshots updated. No new service or WS command.

## Stack

`#502 (#506)` → `#503 (#507)` → `#504 (#508)` → **this**. Remaining: card#410 (HITL config UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)