### PR TITLE
feat: configure_environment round-trips AC Infinity bundles (unblocks card #410)

### DIFF
--- a/custom_components/growspace_manager/config_handlers/__init__.py
+++ b/custom_components/growspace_manager/config_handlers/__init__.py
@@ -98,6 +98,28 @@ class BaseConfigHandler(ABC, Generic[T]):
         updated.update(new_options)
         return updated
 
+    def preserve_ac_infinity_devices(
+        self, growspace: Any, env_config: dict[str, Any]
+    ) -> None:
+        """Carry existing AC Infinity bundles into a rebuilt env-config dict.
+
+        The config flow has no AC Infinity bundle editor, so its form payload
+        never carries these lists; rebuilding ``EnvironmentConfig`` from that
+        payload would silently wipe configured devices. Preserve any already on
+        the growspace unless the payload explicitly provides them (ADR-0022).
+        """
+        existing = getattr(growspace, "environment_config", None)
+        if not existing:
+            return
+        for key in (
+            "exhaust_fan_ac_infinity_devices",
+            "circulation_fan_ac_infinity_devices",
+            "humidifier_ac_infinity_devices",
+            "dehumidifier_ac_infinity_devices",
+        ):
+            if key not in env_config:
+                env_config[key] = [d.to_dict() for d in getattr(existing, key)]
+
 
 # Import handlers AFTER BaseConfigHandler is defined to avoid circular import
 from .ai_config_handler import AIConfigHandler  # noqa: E402

--- a/custom_components/growspace_manager/config_handlers/environment_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/environment_config_handler.py
@@ -700,6 +700,8 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
         env_config.pop("configure_advanced", None)
         env_config.pop("configure_dehumidifier", None)
 
+        self.preserve_ac_infinity_devices(growspace, env_config)
+
         growspace.environment_config = EnvironmentConfig.from_dict(env_config)
         await coordinator.services.save()
         await coordinator.async_refresh()

--- a/custom_components/growspace_manager/config_handlers/environment_sensors_handler.py
+++ b/custom_components/growspace_manager/config_handlers/environment_sensors_handler.py
@@ -279,6 +279,8 @@ class EnvironmentSensorsHandler(BaseConfigHandler[dict[str, Any]]):
         env_config.pop("configure_advanced", None)
         env_config.pop("configure_dehumidifier", None)
 
+        self.preserve_ac_infinity_devices(growspace, env_config)
+
         growspace.environment_config = EnvironmentConfig.from_dict(env_config)
         await coordinator.services.save()
         await coordinator.async_refresh()

--- a/custom_components/growspace_manager/presentation/growspace_view_model.py
+++ b/custom_components/growspace_manager/presentation/growspace_view_model.py
@@ -478,6 +478,16 @@ class GrowspaceViewModelBuilder:
 
         env_config = growspace.environment_config
 
+        # AC Infinity actuator bundles, surfaced so the card's config editor can
+        # read and round-trip them alongside the plain *_entities lists (ADR-0022).
+        for _ac_key in (
+            "exhaust_fan_ac_infinity_devices",
+            "circulation_fan_ac_infinity_devices",
+            "humidifier_ac_infinity_devices",
+            "dehumidifier_ac_infinity_devices",
+        ):
+            attributes[_ac_key] = [d.to_dict() for d in getattr(env_config, _ac_key)]
+
         # Dehumidifier
         dehumidifier_entity = env_config.dehumidifier_entity
         attributes[CONF_DEHUMIDIFIER_ENTITIES] = env_config.dehumidifier_entities

--- a/custom_components/growspace_manager/schemas.py
+++ b/custom_components/growspace_manager/schemas.py
@@ -488,6 +488,18 @@ DEBUG_RESET_SPECIAL_GROWSPACES_SCHEMA = vol.Schema(
 
 DEBUG_CONSOLIDATE_DUPLICATE_SPECIAL_SCHEMA = vol.Schema({})  # No parameters
 
+# An AC Infinity actuator bundle: a mode `select` + speed `number` entity, plus
+# the intensity used for the binary on path (ADR-0022).
+AC_INFINITY_DEVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required("mode_entity"): str,
+        vol.Required("speed_entity"): str,
+        vol.Optional("on_speed", default=10): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=10)
+        ),
+    }
+)
+
 CONFIGURE_ENVIRONMENT_SCHEMA = vol.Schema(
     {
         vol.Required("growspace_id"): str,
@@ -540,6 +552,13 @@ CONFIGURE_ENVIRONMENT_SCHEMA = vol.Schema(
         vol.Optional(CONF_ELECTRICITY_COST): vol.Coerce(float),
         vol.Optional("circulation_fan_config"): dict,
         vol.Optional("vpd_optimal_overrides"): dict,
+        # AC Infinity actuator bundles, parallel to the plain *_entities lists.
+        vol.Optional("exhaust_fan_ac_infinity_devices"): [AC_INFINITY_DEVICE_SCHEMA],
+        vol.Optional("circulation_fan_ac_infinity_devices"): [
+            AC_INFINITY_DEVICE_SCHEMA
+        ],
+        vol.Optional("humidifier_ac_infinity_devices"): [AC_INFINITY_DEVICE_SCHEMA],
+        vol.Optional("dehumidifier_ac_infinity_devices"): [AC_INFINITY_DEVICE_SCHEMA],
         vol.Optional(CONF_LST_OFFSET): vol.All(
             vol.Coerce(float), vol.Range(min=-10.0, max=10.0)
         ),

--- a/custom_components/growspace_manager/services.yaml
+++ b/custom_components/growspace_manager/services.yaml
@@ -683,6 +683,38 @@ configure_environment:
       required: false
       selector:
         object:
+    exhaust_fan_ac_infinity_devices:
+      name: Exhaust Fan AC Infinity Devices
+      description: >-
+        AC Infinity exhaust-fan ports as {mode_entity, speed_entity, on_speed}
+        bundles. Omit to preserve existing devices.
+      required: false
+      selector:
+        object:
+    circulation_fan_ac_infinity_devices:
+      name: Circulation Fan AC Infinity Devices
+      description: >-
+        AC Infinity circulation-fan ports as {mode_entity, speed_entity,
+        on_speed} bundles. Omit to preserve existing devices.
+      required: false
+      selector:
+        object:
+    humidifier_ac_infinity_devices:
+      name: Humidifier AC Infinity Devices
+      description: >-
+        AC Infinity humidifier ports as {mode_entity, speed_entity, on_speed}
+        bundles. Omit to preserve existing devices.
+      required: false
+      selector:
+        object:
+    dehumidifier_ac_infinity_devices:
+      name: Dehumidifier AC Infinity Devices
+      description: >-
+        AC Infinity dehumidifier ports as {mode_entity, speed_entity, on_speed}
+        bundles. Omit to preserve existing devices.
+      required: false
+      selector:
+        object:
 
 remove_environment:
   description: Remove environment configuration for a growspace

--- a/custom_components/growspace_manager/services/environment.py
+++ b/custom_components/growspace_manager/services/environment.py
@@ -52,6 +52,7 @@ from custom_components.growspace_manager.exhaust_migration import (
     evaluate_exhaust_migration_issues,
 )
 from custom_components.growspace_manager.models import (
+    ACInfinityDevice,
     CirculationFanConfig,
     EnvironmentConfig,
     ExhaustFanConfig,
@@ -212,6 +213,20 @@ async def handle_configure_environment(
             return cast(list[str], [val] if isinstance(val, str) else val)
         return []
 
+    existing_env = growspace.environment_config
+
+    def _get_ac_infinity_devices(key: str) -> list[ACInfinityDevice]:
+        """Parse the AC Infinity bundle list, preserving existing when omitted.
+
+        ``configure_environment`` is a full replace, so a caller that does not
+        send a bundle list must not have its configured AC Infinity devices wiped
+        (mirrors the ``exhaust_fan_config`` preservation). An explicitly sent list
+        — including an empty one — is honored as a deliberate change.
+        """
+        if key not in call.data:
+            return list(getattr(existing_env, key, []) or []) if existing_env else []
+        return [ACInfinityDevice.from_dict(d) for d in call.data[key]]
+
     # Process Sensor Groups
     sensor_groups_data = call.data.get("sensor_groups", [])
     sensor_groups = []
@@ -271,6 +286,18 @@ async def handle_configure_environment(
         humidifier_entities=_get_list(CONF_HUMIDIFIER_ENTITY, CONF_HUMIDIFIER_ENTITIES),
         dehumidifier_entities=_get_list(
             CONF_DEHUMIDIFIER_ENTITY, CONF_DEHUMIDIFIER_ENTITIES
+        ),
+        exhaust_fan_ac_infinity_devices=_get_ac_infinity_devices(
+            "exhaust_fan_ac_infinity_devices"
+        ),
+        circulation_fan_ac_infinity_devices=_get_ac_infinity_devices(
+            "circulation_fan_ac_infinity_devices"
+        ),
+        humidifier_ac_infinity_devices=_get_ac_infinity_devices(
+            "humidifier_ac_infinity_devices"
+        ),
+        dehumidifier_ac_infinity_devices=_get_ac_infinity_devices(
+            "dehumidifier_ac_infinity_devices"
         ),
         soil_moisture_sensor=call.data.get(CONF_SOIL_MOISTURE_SENSOR),
         control_dehumidifier=call.data.get(CONF_CONTROL_DEHUMIDIFIER, False),

--- a/tests/config_handlers/test_environment_sensors_handler.py
+++ b/tests/config_handlers/test_environment_sensors_handler.py
@@ -20,13 +20,19 @@ from custom_components.growspace_manager.const import (
     CONF_TEMP_SENSOR,
     CONF_TEMP_SENSORS,
 )
-from custom_components.growspace_manager.models import EnvironmentConfig, Growspace
+from custom_components.growspace_manager.models import (
+    ACInfinityDevice,
+    EnvironmentConfig,
+    Growspace,
+)
 from custom_components.growspace_manager.models.irrigation import IrrigationTank
 
 
-def _make_flow(configure_dehumidifier: bool = False,
-               configure_fan_controller: bool = False,
-               configure_advanced: bool = False) -> MagicMock:
+def _make_flow(
+    configure_dehumidifier: bool = False,
+    configure_fan_controller: bool = False,
+    configure_advanced: bool = False,
+) -> MagicMock:
     """Build a minimal flow stub with a growspace and async step mocks."""
     growspace = Growspace(
         id="gs1",
@@ -63,8 +69,12 @@ def _make_flow(configure_dehumidifier: bool = False,
     flow.async_step_configure_sensor_placement = AsyncMock(
         return_value={"type": "form", "step_id": "configure_sensor_placement"}
     )
-    flow.async_show_form = MagicMock(side_effect=lambda **kw: {"type": "form", "step_id": kw.get("step_id")})
-    flow.async_abort = MagicMock(side_effect=lambda reason: {"type": "abort", "reason": reason})
+    flow.async_show_form = MagicMock(
+        side_effect=lambda **kw: {"type": "form", "step_id": kw.get("step_id")}
+    )
+    flow.async_abort = MagicMock(
+        side_effect=lambda reason: {"type": "abort", "reason": reason}
+    )
 
     return flow
 
@@ -229,7 +239,9 @@ async def test_select_growspace_for_env_sets_id_and_advances_on_input() -> None:
     )
     handler = EnvironmentSensorsHandler(flow)
 
-    await handler.async_step_select_growspace_for_env(user_input={"growspace_id": "gs1"})
+    await handler.async_step_select_growspace_for_env(
+        user_input={"growspace_id": "gs1"}
+    )
 
     assert flow.selected_growspace_id == "gs1"
     flow.async_step_configure_environment.assert_awaited_once()
@@ -299,11 +311,15 @@ async def test_configure_environment_processes_user_input_and_advances() -> None
 async def test_configure_environment_loads_existing_irrigation_tanks() -> None:
     """Step reads irrigation_tanks from existing environment_config."""
     flow = _make_flow()
-    tank = IrrigationTank(sensor_entity="sensor.tank1", name="Tank 1", warning_level=25.0)
-    flow.config_entry.runtime_data.services.growspaces.get_growspace.return_value = Growspace(
-        id="gs1",
-        name="Test Tent",
-        environment_config=EnvironmentConfig(irrigation_tanks=[tank]),
+    tank = IrrigationTank(
+        sensor_entity="sensor.tank1", name="Tank 1", warning_level=25.0
+    )
+    flow.config_entry.runtime_data.services.growspaces.get_growspace.return_value = (
+        Growspace(
+            id="gs1",
+            name="Test Tent",
+            environment_config=EnvironmentConfig(irrigation_tanks=[tank]),
+        )
     )
     handler = EnvironmentSensorsHandler(flow)
 
@@ -321,7 +337,9 @@ async def test_configure_environment_no_existing_config_uses_empty_options() -> 
     flow = _make_flow()
     growspace = Growspace(id="gs1", name="Test Tent")
     growspace.environment_config = None  # type: ignore[assignment]
-    flow.config_entry.runtime_data.services.growspaces.get_growspace.return_value = growspace
+    flow.config_entry.runtime_data.services.growspaces.get_growspace.return_value = (
+        growspace
+    )
     handler = EnvironmentSensorsHandler(flow)
 
     result = await handler.async_step_configure_environment(user_input=None)
@@ -374,7 +392,10 @@ def test_process_irrigation_tanks_uses_friendly_name_from_state() -> None:
     handler = EnvironmentSensorsHandler(flow)
 
     result = handler._process_irrigation_tanks(
-        {CONF_IRRIGATION_TANK_SENSORS: ["sensor.tank1"], CONF_IRRIGATION_TANK_WARNING_LEVEL: 20.0}
+        {
+            CONF_IRRIGATION_TANK_SENSORS: ["sensor.tank1"],
+            CONF_IRRIGATION_TANK_WARNING_LEVEL: 20.0,
+        }
     )
 
     assert result["irrigation_tanks"][0]["name"] == "Main Reservoir"
@@ -393,7 +414,10 @@ def test_process_irrigation_tanks_preserves_existing_dataclass_tank_data() -> No
         peak_level=90.0,
     )
     result = handler._process_irrigation_tanks(
-        {CONF_IRRIGATION_TANK_SENSORS: ["sensor.tank1"], CONF_IRRIGATION_TANK_WARNING_LEVEL: 30.0},
+        {
+            CONF_IRRIGATION_TANK_SENSORS: ["sensor.tank1"],
+            CONF_IRRIGATION_TANK_WARNING_LEVEL: 30.0,
+        },
         existing_tanks=[existing_tank],
     )
 
@@ -416,7 +440,10 @@ def test_process_irrigation_tanks_preserves_existing_dict_tank_data() -> None:
         "water_history": {"some": "data"},
     }
     result = handler._process_irrigation_tanks(
-        {CONF_IRRIGATION_TANK_SENSORS: ["sensor.tank1"], CONF_IRRIGATION_TANK_WARNING_LEVEL: 30.0},
+        {
+            CONF_IRRIGATION_TANK_SENSORS: ["sensor.tank1"],
+            CONF_IRRIGATION_TANK_WARNING_LEVEL: 30.0,
+        },
         existing_tanks=[existing_tank_dict],  # type: ignore[list-item]
     )
 
@@ -449,6 +476,28 @@ async def test_async_save_and_finish_saves_env_config_and_returns_entry() -> Non
     assert growspace.environment_config is not None
     flow.config_entry.runtime_data.services.save.assert_awaited_once()
     flow.config_entry.runtime_data.async_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_save_and_finish_preserves_ac_infinity_devices() -> None:
+    """Saving env config via the flow must not wipe AC Infinity bundles (ADR-0022)."""
+    flow = _make_flow()
+    flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+    handler = EnvironmentSensorsHandler(flow)
+
+    device = ACInfinityDevice(
+        mode_entity="select.m", speed_entity="number.s", on_speed=7
+    )
+    growspace = Growspace(
+        id="gs1",
+        name="Test Tent",
+        environment_config=EnvironmentConfig(humidifier_ac_infinity_devices=[device]),
+    )
+    env_config = {"temp_sensor": "sensor.temp"}
+
+    await handler._async_save_and_finish(growspace, env_config)
+
+    assert growspace.environment_config.humidifier_ac_infinity_devices == [device]
 
 
 # ---------------------------------------------------------------------------
@@ -548,10 +597,12 @@ async def test_configure_environment_loads_volume_liters_from_existing_tank() ->
         warning_level=25.0,
         volume_liters=20.0,
     )
-    flow.config_entry.runtime_data.services.growspaces.get_growspace.return_value = Growspace(
-        id="gs1",
-        name="Test Tent",
-        environment_config=EnvironmentConfig(irrigation_tanks=[tank]),
+    flow.config_entry.runtime_data.services.growspaces.get_growspace.return_value = (
+        Growspace(
+            id="gs1",
+            name="Test Tent",
+            environment_config=EnvironmentConfig(irrigation_tanks=[tank]),
+        )
     )
     handler = EnvironmentSensorsHandler(flow)
 
@@ -639,8 +690,18 @@ def test_advanced_sensors_schema_order_is_feed_bulk_pore_runoff() -> None:
     options: dict = {}
     schema = handler.get_environment_schema_step1(options)
 
-    ec_sensor_keys = (CONF_FEED_EC_SENSORS, CONF_BULK_EC_SENSORS, CONF_PORE_EC_SENSORS, CONF_RUNOFF_EC_SENSORS)
+    ec_sensor_keys = (
+        CONF_FEED_EC_SENSORS,
+        CONF_BULK_EC_SENSORS,
+        CONF_PORE_EC_SENSORS,
+        CONF_RUNOFF_EC_SENSORS,
+    )
     keys = [k.schema if hasattr(k, "schema") else str(k) for k in schema.schema]
     ec_keys = [k for k in keys if k in ec_sensor_keys]
 
-    assert ec_keys == [CONF_FEED_EC_SENSORS, CONF_BULK_EC_SENSORS, CONF_PORE_EC_SENSORS, CONF_RUNOFF_EC_SENSORS]
+    assert ec_keys == [
+        CONF_FEED_EC_SENSORS,
+        CONF_BULK_EC_SENSORS,
+        CONF_PORE_EC_SENSORS,
+        CONF_RUNOFF_EC_SENSORS,
+    ]

--- a/tests/core/snapshots/test_presentation_snapshots.ambr
+++ b/tests/core/snapshots/test_presentation_snapshots.ambr
@@ -11,6 +11,8 @@
       ]),
       'camera_entities': list([
       ]),
+      'circulation_fan_ac_infinity_devices': list([
+      ]),
       'circulation_fan_config': dict({
         'critical_temp_high': None,
         'critical_temp_hysteresis': 1.0,
@@ -34,6 +36,8 @@
       }),
       'circulation_fan_entities': list([
       ]),
+      'dehumidifier_ac_infinity_devices': list([
+      ]),
       'dehumidifier_entities': list([
       ]),
       'drain_pump_state': None,
@@ -41,6 +45,8 @@
       ]),
       'electricity_cost_per_kwh': 0.0,
       'energy_sensors': list([
+      ]),
+      'exhaust_fan_ac_infinity_devices': list([
       ]),
       'exhaust_fan_config': dict({
         'critical_temp_high': None,
@@ -62,6 +68,8 @@
       'exhaust_fan_entities': list([
       ]),
       'feed_ec_sensors': list([
+      ]),
+      'humidifier_ac_infinity_devices': list([
       ]),
       'humidifier_control_enabled': False,
       'humidifier_entities': list([

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -48,7 +48,10 @@ def test_configure_environment_schema_accepts_vpd_optimal_overrides() -> None:
         CONF_TEMP_SENSOR: "sensor.temp",
         CONF_HUMIDITY_SENSOR: "sensor.humidity",
         "vpd_optimal_overrides": {
-            "flower_mid": {"day": {"low": 0.5, "high": 1.45}, "night": {"low": 0.6, "high": 1.0}},
+            "flower_mid": {
+                "day": {"low": 0.5, "high": 1.45},
+                "night": {"low": 0.6, "high": 1.0},
+            },
         },
     }
     try:
@@ -74,3 +77,51 @@ def test_configure_environment_schema_supports_single_entities() -> None:
         CONFIGURE_ENVIRONMENT_SCHEMA(payload)
     except vol.Error as e:
         pytest.fail(f"Schema validation failed for minimal payload: {e}")
+
+
+def test_configure_environment_schema_accepts_ac_infinity_devices() -> None:
+    """CONFIGURE_ENVIRONMENT_SCHEMA validates AC Infinity bundle lists (ADR-0022)."""
+    payload = {
+        "growspace_id": "test_growspace_id",
+        "exhaust_fan_ac_infinity_devices": [
+            {
+                "mode_entity": "select.tent_port1_mode",
+                "speed_entity": "number.tent_port1_on_speed",
+                "on_speed": 8,
+            }
+        ],
+        "humidifier_ac_infinity_devices": [
+            {"mode_entity": "select.hum_mode", "speed_entity": "number.hum_speed"}
+        ],
+    }
+    validated = CONFIGURE_ENVIRONMENT_SCHEMA(payload)
+
+    assert validated["exhaust_fan_ac_infinity_devices"][0]["on_speed"] == 8
+    # on_speed defaults to 10 when omitted
+    assert validated["humidifier_ac_infinity_devices"][0]["on_speed"] == 10
+
+
+def test_configure_environment_schema_rejects_incomplete_ac_infinity_device() -> None:
+    """An AC Infinity bundle missing required entities is rejected."""
+    payload = {
+        "growspace_id": "test_growspace_id",
+        "exhaust_fan_ac_infinity_devices": [{"mode_entity": "select.only_mode"}],
+    }
+    with pytest.raises(vol.Error):
+        CONFIGURE_ENVIRONMENT_SCHEMA(payload)
+
+
+def test_configure_environment_schema_rejects_out_of_range_on_speed() -> None:
+    """on_speed outside the 1-10 AC Infinity intensity range is rejected."""
+    payload = {
+        "growspace_id": "test_growspace_id",
+        "exhaust_fan_ac_infinity_devices": [
+            {
+                "mode_entity": "select.m",
+                "speed_entity": "number.s",
+                "on_speed": 11,
+            }
+        ],
+    }
+    with pytest.raises(vol.Error):
+        CONFIGURE_ENVIRONMENT_SCHEMA(payload)

--- a/tests/core/test_services_environment.py
+++ b/tests/core/test_services_environment.py
@@ -13,6 +13,7 @@ from custom_components.growspace_manager.const import (
     CONF_TEMP_SENSOR,
 )
 from custom_components.growspace_manager.models import (
+    ACInfinityDevice,
     CirculationFanConfig,
     EnvironmentConfig,
     ExhaustFanConfig,
@@ -992,3 +993,81 @@ async def test_handle_configure_circulation_fan_no_fan_controller(
 
     await handle_configure_circulation_fan(mock_hass, mock_coordinator, mock_call)
     assert mock_gs.environment_config.circulation_fan_config.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_handle_configure_environment_accepts_ac_infinity_devices(
+    mock_hass, mock_coordinator, mock_call
+) -> None:
+    """An AC Infinity bundle list in the payload is parsed and persisted."""
+    mock_gs = MagicMock()
+    mock_gs.name = "Test GS"
+    mock_gs.environment_config = None
+    mock_coordinator.growspaces = {"gs1": mock_gs}
+    mock_call.data = {
+        "growspace_id": "gs1",
+        "exhaust_fan_ac_infinity_devices": [
+            {
+                "mode_entity": "select.tent_port1_mode",
+                "speed_entity": "number.tent_port1_on_speed",
+                "on_speed": 8,
+            }
+        ],
+    }
+
+    await handle_configure_environment(mock_hass, mock_coordinator, mock_call)
+
+    devices = mock_gs.environment_config.exhaust_fan_ac_infinity_devices
+    assert devices == [
+        ACInfinityDevice(
+            mode_entity="select.tent_port1_mode",
+            speed_entity="number.tent_port1_on_speed",
+            on_speed=8,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handle_configure_environment_preserves_ac_infinity_when_omitted(
+    mock_hass, mock_coordinator, mock_call
+) -> None:
+    """A full-replace edit that omits the bundle list must not wipe it (ADR-0022)."""
+    existing = ACInfinityDevice(
+        mode_entity="select.hum_mode", speed_entity="number.hum_speed", on_speed=6
+    )
+    mock_gs = MagicMock()
+    mock_gs.name = "Test GS"
+    mock_gs.environment_config = EnvironmentConfig(
+        humidifier_ac_infinity_devices=[existing],
+    )
+    mock_coordinator.growspaces = {"gs1": mock_gs}
+    mock_call.data = {"growspace_id": "gs1", CONF_TEMP_SENSOR: "sensor.temp"}
+
+    await handle_configure_environment(mock_hass, mock_coordinator, mock_call)
+
+    assert mock_gs.environment_config.humidifier_ac_infinity_devices == [existing]
+
+
+@pytest.mark.asyncio
+async def test_handle_configure_environment_empty_ac_infinity_clears(
+    mock_hass, mock_coordinator, mock_call
+) -> None:
+    """An explicitly empty bundle list is honored as a deliberate clear."""
+    mock_gs = MagicMock()
+    mock_gs.name = "Test GS"
+    mock_gs.environment_config = EnvironmentConfig(
+        dehumidifier_ac_infinity_devices=[
+            ACInfinityDevice(
+                mode_entity="select.dehum_mode", speed_entity="number.dehum_speed"
+            )
+        ],
+    )
+    mock_coordinator.growspaces = {"gs1": mock_gs}
+    mock_call.data = {
+        "growspace_id": "gs1",
+        "dehumidifier_ac_infinity_devices": [],
+    }
+
+    await handle_configure_environment(mock_hass, mock_coordinator, mock_call)
+
+    assert mock_gs.environment_config.dehumidifier_ac_infinity_devices == []

--- a/tests/core/test_services_environment.py
+++ b/tests/core/test_services_environment.py
@@ -20,6 +20,7 @@ from custom_components.growspace_manager.models import (
     IrrigationTank,
     SensorGroup,
 )
+from custom_components.growspace_manager.schemas import CONFIGURE_ENVIRONMENT_SCHEMA
 from custom_components.growspace_manager.services.environment import (
     handle_configure_circulation_fan,
     handle_configure_environment,
@@ -1071,3 +1072,35 @@ async def test_handle_configure_environment_empty_ac_infinity_clears(
     await handle_configure_environment(mock_hass, mock_coordinator, mock_call)
 
     assert mock_gs.environment_config.dehumidifier_ac_infinity_devices == []
+
+
+@pytest.mark.asyncio
+async def test_schema_validated_payload_omitting_bundles_preserves(
+    mock_hass, mock_coordinator, mock_call
+) -> None:
+    """Regression guard: the schema must not inject default bundle keys.
+
+    A payload validated through CONFIGURE_ENVIRONMENT_SCHEMA that omits the bundle
+    lists must still reach the handler without those keys, so preserve-on-omit
+    fires. If a future default=[] were added to the schema keys, this would flip
+    silently to wipe-on-save — and every other test would still pass.
+    """
+    existing = ACInfinityDevice(
+        mode_entity="select.m", speed_entity="number.s", on_speed=6
+    )
+    mock_gs = MagicMock()
+    mock_gs.name = "Test GS"
+    mock_gs.environment_config = EnvironmentConfig(
+        humidifier_ac_infinity_devices=[existing]
+    )
+    mock_coordinator.growspaces = {"gs1": mock_gs}
+
+    validated = CONFIGURE_ENVIRONMENT_SCHEMA(
+        {"growspace_id": "gs1", CONF_TEMP_SENSOR: "sensor.temp"}
+    )
+    assert "humidifier_ac_infinity_devices" not in validated
+    mock_call.data = validated
+
+    await handle_configure_environment(mock_hass, mock_coordinator, mock_call)
+
+    assert mock_gs.environment_config.humidifier_ac_infinity_devices == [existing]

--- a/tests/integration/test_growspace_view_model_coverage.py
+++ b/tests/integration/test_growspace_view_model_coverage.py
@@ -6,6 +6,7 @@ import pytest
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.models import (
+    ACInfinityDevice,
     EnvironmentConfig,
     ExhaustFanConfig,
     Growspace,
@@ -203,6 +204,36 @@ def test_get_environment_attributes(hass: HomeAssistant, builder):
         assert len(attrs["irrigation_tanks"]) == 1
         assert attrs["irrigation_tanks"][0]["is_warning"] is True
         assert attrs["sensor_groups"][0]["id"] == "g1"
+
+
+def test_get_environment_attributes_exposes_ac_infinity_devices(
+    hass: HomeAssistant, builder
+):
+    """AC Infinity bundles are serialized into the environment payload (ADR-0022)."""
+    env_config = EnvironmentConfig(
+        exhaust_fan_ac_infinity_devices=[
+            ACInfinityDevice(
+                mode_entity="select.tent_port1_mode",
+                speed_entity="number.tent_port1_on_speed",
+                on_speed=8,
+            )
+        ],
+    )
+    growspace = Growspace(id="gs1", name="Test", environment_config=env_config)
+
+    attrs = builder._get_environment_attributes(growspace)
+
+    assert attrs["exhaust_fan_ac_infinity_devices"] == [
+        {
+            "mode_entity": "select.tent_port1_mode",
+            "speed_entity": "number.tent_port1_on_speed",
+            "on_speed": 8,
+        }
+    ]
+    # Unconfigured roles serialize as empty lists, not omitted
+    assert attrs["circulation_fan_ac_infinity_devices"] == []
+    assert attrs["humidifier_ac_infinity_devices"] == []
+    assert attrs["dehumidifier_ac_infinity_devices"] == []
 
 
 def test_build_special_growspace_types(builder):


### PR DESCRIPTION
## What to build

Backend prerequisite that unblocks the card's AC Infinity device editor (card **#410**). Discovered while picking up #410: the card was blocked on the integration in **two symmetric ways**, neither covered by #502–505.

> Based on `prerelease` (where #502–505 landed).

## The two gaps fixed

**Write path** — `configure_environment` is a full-replace that rebuilds `EnvironmentConfig` from the payload, and its schema is `PREVENT_EXTRA`. So the four `*_ac_infinity_devices` lists were *rejected* on send and *silently wiped* on any environment edit.
- `schemas.py`: `AC_INFINITY_DEVICE_SCHEMA` (`{mode_entity, speed_entity, on_speed 1–10}`) + four optional bundle-list keys.
- `services/environment.py`: parse into `ACInfinityDevice`, **preserving existing when a key is omitted** (mirrors `exhaust_fan_config`); an explicit list — including `[]` — is honored as a deliberate change.
- Config flow: a shared `BaseConfigHandler.preserve_ac_infinity_devices` guards **both** `EnvironmentConfig.from_dict` rebuild sites (`EnvironmentConfigHandler` + `EnvironmentSensorsHandler`), which have no bundle editor and would otherwise wipe.
- `services.yaml`: document the four object fields.

**Read path** — the card's `environment` object is hand-curated by `GrowspaceViewModelBuilder._get_environment_attributes` (not a wholesale `to_dict`), so the bundles were invisible to the card even once persisted.
- Serialize each `*_ac_infinity_devices` into the environment attributes (empty list when unconfigured).

## Verification

- Full suite green (**4641 passed**); new code at **100%** coverage; ruff + format clean; mypy adds no new errors (only pre-existing config-flow `no-any-return`/`union-attr` debt).
- Presentation snapshot updated for the new attributes.
- **Regression guard**: a payload validated through `CONFIGURE_ENVIRONMENT_SCHEMA` that omits the bundle keys is asserted to reach the handler *without* them, so preserve-on-omit fires — catching a future `default=[]` that would silently flip preserve into wipe-on-save.
- No new service or WS command, so `test_core_init.py` counts are untouched.

## Stack

Unblocks card **#410** (the Config Dialog AC Infinity editor), which builds on the card repo's `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)