### PR TITLE
Persist vision checkup snapshots to public www path

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -296,3 +296,10 @@ A dict of six timing/cooldown parameters stored in `config_entry.options["notifi
 
 **Timed Notification**
 A user-configured reminder that fires on a specific day of a plant's lifecycle stage. Stored as a list in `config_entry.options["timed_notifications"]`. Each entry has `id` (UUID), `message`, `trigger_type`, `day`, and `growspace_ids`. Managed by `NotificationSettingsManager`. Exposed as a top-level key in the global coordinator data payload alongside Notification Settings.
+
+**Camera Snapshot**
+A point-in-time image captured from a growspace camera. Can be triggered manually by the grower via the camera snapshots dialog or automatically as part of a scheduled [[Vision Checkup]]. Saved to the public directory `www/growspace_manager/snapshots/{growspace_id}/` as a JPEG file named with a local timestamp prefix for display in the frontend.
+
+**Vision Checkup**
+An AI-powered diagnostic task performed on one or more [[Camera Snapshot]]s from a growspace, scheduled at three key times in the light cycle (early, mid, late) or triggered manually. The snapshots are processed with a 4x4 grid overlay and canopy green-pixel coverage analysis before being sent to the AI model. The analysis results (severity, detected issues, recommendations) are stored as a `VisionCheckupResult` in the growspace's vision history.
+

--- a/custom_components/growspace_manager/vision_checkup_scheduler.py
+++ b/custom_components/growspace_manager/vision_checkup_scheduler.py
@@ -39,9 +39,7 @@ VISION_RESULT_SCHEMA = vol.Schema(
     {
         vol.Required("analysis"): str,
         vol.Required("issues_detected"): [str],
-        vol.Required("severity"): vol.In(
-            ["none", "low", "medium", "high", "critical"]
-        ),
+        vol.Required("severity"): vol.In(["none", "low", "medium", "high", "critical"]),
         vol.Required("recommendations"): [str],
     }
 )
@@ -93,6 +91,7 @@ class VisionCheckupScheduler:
         self.hass = hass
         self.coordinator = coordinator
         self._unsub_timers: dict[str, list[CALLBACK_TYPE]] = {}
+        self._latest_public_paths: dict[str, list[str]] = {}
 
     def _get_ai_task_entity_id(self) -> str | None:
         """Get the configured AI task entity ID from coordinator options."""
@@ -224,6 +223,7 @@ class VisionCheckupScheduler:
         """
         from homeassistant.components.camera import async_get_image  # noqa: PLC0415
 
+        self._latest_public_paths[growspace_id] = []
         processor = GrowspaceImageProcessor()
         timestamp = utcnow().strftime("%Y%m%d_%H%M%S")
 
@@ -233,7 +233,9 @@ class VisionCheckupScheduler:
         # (/media vs <config>/media), so we must write where the media source
         # will look, or the AI task fails with "<path> does not exist".
         media_dirs = self.hass.config.media_dirs
-        source_dir_id = "local" if "local" in media_dirs else next(iter(media_dirs), None)
+        source_dir_id = (
+            "local" if "local" in media_dirs else next(iter(media_dirs), None)
+        )
         if source_dir_id is None:
             _LOGGER.warning(
                 "No media directories configured; cannot save vision snapshots"
@@ -251,6 +253,22 @@ class VisionCheckupScheduler:
                 media_dir,
             )
             return [], None, []
+
+        snapshot_dir = (
+            Path(self.hass.config.path("www"))
+            / "growspace_manager"
+            / "snapshots"
+            / growspace_id
+        )
+        try:
+            await self.hass.async_add_executor_job(
+                lambda: snapshot_dir.mkdir(parents=True, exist_ok=True)
+            )
+        except OSError:
+            _LOGGER.exception(
+                "Failed to create snapshots directory %s, permanent copies will not be saved",
+                snapshot_dir,
+            )
 
         attachments: list[dict[str, str]] = []
         coverages: list[float] = []
@@ -279,12 +297,35 @@ class VisionCheckupScheduler:
             file_path = media_dir / filename
 
             try:
-                await self.hass.async_add_executor_job(file_path.write_bytes, processed_bytes)
+                await self.hass.async_add_executor_job(
+                    file_path.write_bytes, processed_bytes
+                )
             except OSError:
                 _LOGGER.exception("Failed to save processed image to %s", file_path)
                 continue
 
             temp_paths.append(file_path)
+
+            # Save a permanent copy to the www snapshots directory
+            try:
+                from homeassistant.util import dt as dt_util  # noqa: PLC0415
+
+                local_timestamp = dt_util.now().strftime("%Y%m%d_%H%M%S")
+                safe_name = cam_entity.replace(".", "_").replace(" ", "_")
+                snapshot_filename = f"{local_timestamp}_{safe_name}_processed.jpg"
+                snapshot_file_path = snapshot_dir / snapshot_filename
+
+                await self.hass.async_add_executor_job(
+                    snapshot_file_path.write_bytes, processed_bytes
+                )
+
+                public_path = f"/local/growspace_manager/snapshots/{growspace_id}/{snapshot_filename}"
+                self._latest_public_paths[growspace_id].append(public_path)
+            except Exception:
+                _LOGGER.exception(
+                    "Failed to save processed snapshot copy for %s", cam_entity
+                )
+
             attachments.append(
                 {
                     "media_content_id": (
@@ -416,10 +457,10 @@ class VisionCheckupScheduler:
         if not growspace or not growspace.notification_target:
             return
 
-        issues_str = ", ".join(result.issues_detected) if result.issues_detected else "unknown"
-        recommendations_str = "\n".join(
-            f"- {r}" for r in result.recommendations[:3]
+        issues_str = (
+            ", ".join(result.issues_detected) if result.issues_detected else "unknown"
         )
+        recommendations_str = "\n".join(f"- {r}" for r in result.recommendations[:3])
 
         message = (
             f"Vision checkup ({result.check_type}) for {growspace.name}:\n"
@@ -463,11 +504,15 @@ class VisionCheckupScheduler:
             _LOGGER.debug(
                 "No cameras configured for %s, skipping vision checkup", growspace_id
             )
-            raise ServiceValidationError("No cameras configured for this growspace. Please add cameras in the environment settings.")
+            raise ServiceValidationError(
+                "No cameras configured for this growspace. Please add cameras in the environment settings."
+            )
 
         entity_id = self._get_ai_task_entity_id()
         if not entity_id:
-            raise ServiceValidationError("No AI task entity configured. Please set up an AI agent in the integration options.")
+            raise ServiceValidationError(
+                "No AI task entity configured. Please set up an AI agent in the integration options."
+            )
 
         # Gather growspace context for the AI prompt
         try:
@@ -561,11 +606,15 @@ class VisionCheckupScheduler:
 
         data = task_result.data or {}
 
+        public_paths = self._latest_public_paths.pop(growspace_id, [])
+        if not public_paths:
+            public_paths = [f"media-source://camera/{c}" for c in camera_entities]
+
         result = VisionCheckupResult(
             timestamp=utcnow().isoformat(),
             growspace_id=growspace_id,
             check_type=check_type,
-            snapshot_paths=[f"media-source://camera/{c}" for c in camera_entities],
+            snapshot_paths=public_paths,
             analysis=data.get("analysis", "Analysis unavailable"),
             issues_detected=data.get("issues_detected", []),
             severity=data.get("severity", "none"),

--- a/tests/test_vision_checkup_scheduler.py
+++ b/tests/test_vision_checkup_scheduler.py
@@ -95,6 +95,7 @@ def test_vision_checkup_scheduler_initializes():
     assert scheduler.hass is hass
     assert scheduler.coordinator is coordinator
     assert scheduler._unsub_timers == {}
+    assert scheduler._latest_public_paths == {}
 
 
 @pytest.fixture
@@ -763,6 +764,15 @@ async def test_process_camera_images_saves_under_media_source_root(
     assert attachments[0]["media_content_id"].startswith(
         "media-source://media_source/local/growspace_vision/"
     )
+    # A permanent copy is also written under <config>/www for the frontend.
+    snapshot_dir = (
+        tmp_path / "config" / "www" / "growspace_manager" / "snapshots" / "tent1"
+    )
+    snapshots = list(snapshot_dir.glob("*_processed.jpg"))
+    assert len(snapshots) == 1
+    assert scheduler._latest_public_paths["tent1"] == [
+        f"/local/growspace_manager/snapshots/tent1/{snapshots[0].name}"
+    ]
 
 
 @pytest.mark.asyncio
@@ -1058,6 +1068,58 @@ async def test_run_vision_analysis_falls_back_to_raw_camera_uris_when_processing
     assert result is not None
     attachment_uri = mock_gen.call_args.kwargs["attachments"][0]["media_content_id"]
     assert "camera.tent1_cam" in attachment_uri
+
+
+@pytest.mark.asyncio
+async def test_run_vision_analysis_snapshot_paths_contain_public_uris(
+    hass_with_executor, mock_coordinator
+):
+    """snapshot_paths holds /local/... public URLs after real image processing."""
+    gs = _make_mock_growspace()
+    mock_coordinator.growspaces = {"tent1": gs}
+
+    mock_image = MagicMock()
+    mock_image.content = b"\xff\xd8\xff\xe0fake"
+
+    mock_ai_result = MagicMock()
+    mock_ai_result.data = {
+        "analysis": "OK",
+        "issues_detected": [],
+        "severity": "none",
+        "recommendations": [],
+    }
+
+    scheduler = VisionCheckupScheduler(hass_with_executor, mock_coordinator)
+
+    with (
+        patch(
+            "homeassistant.components.camera.async_get_image",
+            new_callable=AsyncMock,
+            return_value=mock_image,
+        ),
+        patch(
+            "custom_components.growspace_manager.image_processor.GrowspaceImageProcessor.process_snapshot",
+            return_value=(b"\xff\xd8\xff\xe0processed", 55.0),
+        ),
+        patch(
+            "custom_components.growspace_manager.vision_checkup_scheduler.async_generate_data",
+            new_callable=AsyncMock,
+            return_value=mock_ai_result,
+        ),
+        patch.object(
+            scheduler, "_gather_context_data", return_value=_minimal_context()
+        ),
+    ):
+        result = await scheduler.run_vision_analysis("tent1", "mid")
+
+    assert result is not None
+    assert len(result.snapshot_paths) == 1
+    assert result.snapshot_paths[0].startswith(
+        "/local/growspace_manager/snapshots/tent1/"
+    )
+    assert result.snapshot_paths[0].endswith("_processed.jpg")
+    # State is popped after use so it does not leak into the next run.
+    assert "tent1" not in scheduler._latest_public_paths
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Vision Checkup now saves a **permanent JPEG copy** of each processed camera snapshot to `www/growspace_manager/snapshots/{growspace_id}/` and populates `VisionCheckupResult.snapshot_paths` with the `/local/...` public URLs, so the frontend can render them. Previously `snapshot_paths` only held raw `media-source://camera/{entity_id}` URIs (camera references, not saved images).

## How

- `_process_camera_images` creates the `www/.../snapshots/{growspace_id}/` directory once and, after writing each temp file to the media-source dir for the AI task, writes a permanent JPEG copy named with a local timestamp. The public `/local/...` path is collected into `_latest_public_paths[growspace_id]`. A failed permanent copy is logged but does not abort the checkup.
- `run_vision_analysis` pops the collected public paths into `VisionCheckupResult.snapshot_paths`, falling back to raw `media-source://camera/...` URIs when processing yields no images.
- Added `Camera Snapshot` and `Vision Checkup` glossary entries to `CONTEXT.md`.

## Frontend follow-ups

The card side is tracked separately:
- Venosta-web/lovelace-growspace-manager-card#411 — render snapshots in the result detail view
- Venosta-web/lovelace-growspace-manager-card#412 — click-to-enlarge lightbox (blocked by #411)

## Testing

- `pytest tests/test_vision_checkup_scheduler.py` — 44 passed
- `ruff check` / `ruff format` clean

New/updated tests:
- `test_vision_checkup_scheduler_initializes` asserts `_latest_public_paths == {}`
- `test_process_camera_images_saves_under_media_source_root` extended to assert the permanent copy under `www/.../snapshots/tent1/` and the matching `_latest_public_paths` entry
- New `test_run_vision_analysis_snapshot_paths_contain_public_uris` runs the real `_process_camera_images` and verifies `result.snapshot_paths` holds a single `/local/...` URL and that state is popped after use

🤖 Generated with [Claude Code](https://claude.com/claude-code)