### PR TITLE
Surface grow light config in the environment payload (read-back fix)

### DIFF
--- a/custom_components/growspace_manager/presentation/growspace_view_model.py
+++ b/custom_components/growspace_manager/presentation/growspace_view_model.py
@@ -485,8 +485,15 @@ class GrowspaceViewModelBuilder:
             "circulation_fan_ac_infinity_devices",
             "humidifier_ac_infinity_devices",
             "dehumidifier_ac_infinity_devices",
+            "growlight_ac_infinity_devices",
         ):
             attributes[_ac_key] = [d.to_dict() for d in getattr(env_config, _ac_key)]
+
+        # Grow lights — surfaced so the card's Growlights tab can read and
+        # round-trip the configured entities and controller config on reopen,
+        # and so the grow-light chip can render (parallels the fan handling).
+        attributes["growlight_entities"] = env_config.growlight_entities
+        attributes["growlight_config"] = env_config.growlight_config.to_dict()
 
         # Dehumidifier
         dehumidifier_entity = env_config.dehumidifier_entity

--- a/tests/core/snapshots/test_presentation_snapshots.ambr
+++ b/tests/core/snapshots/test_presentation_snapshots.ambr
@@ -69,6 +69,16 @@
       ]),
       'feed_ec_sensors': list([
       ]),
+      'growlight_ac_infinity_devices': list([
+      ]),
+      'growlight_config': dict({
+        'enabled': False,
+        'power': 100,
+        'sunrise_enabled': False,
+        'sunrise_minutes': 0,
+      }),
+      'growlight_entities': list([
+      ]),
       'humidifier_ac_infinity_devices': list([
       ]),
       'humidifier_control_enabled': False,

--- a/tests/integration/test_growspace_view_model_coverage.py
+++ b/tests/integration/test_growspace_view_model_coverage.py
@@ -7,8 +7,10 @@ import pytest
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.models import (
     ACInfinityDevice,
+    ACInfinityGrowLight,
     EnvironmentConfig,
     ExhaustFanConfig,
+    GrowLightConfig,
     Growspace,
     IrrigationConfig,
     IrrigationTank,
@@ -234,6 +236,36 @@ def test_get_environment_attributes_exposes_ac_infinity_devices(
     assert attrs["circulation_fan_ac_infinity_devices"] == []
     assert attrs["humidifier_ac_infinity_devices"] == []
     assert attrs["dehumidifier_ac_infinity_devices"] == []
+
+
+def test_get_environment_attributes_exposes_growlight(hass: HomeAssistant, builder):
+    """Grow light entities + controller config round-trip to the card on reopen.
+
+    Without this the Growlights tab reads back empty and the grow-light chip
+    never renders, even though configure_environment persisted the config.
+    """
+    env_config = EnvironmentConfig(
+        growlight_entities=["light.sim_flower_grow_light"],
+        growlight_config=GrowLightConfig(enabled=True, power=80),
+        growlight_ac_infinity_devices=[
+            ACInfinityGrowLight(
+                mode_entity="select.tent_light_mode",
+                on_time_entity="time.tent_light_on",
+                off_time_entity="time.tent_light_off",
+                power_entity="number.tent_light_power",
+            )
+        ],
+    )
+    growspace = Growspace(id="gs1", name="Test", environment_config=env_config)
+
+    attrs = builder._get_environment_attributes(growspace)
+
+    assert attrs["growlight_entities"] == ["light.sim_flower_grow_light"]
+    assert attrs["growlight_config"]["enabled"] is True
+    assert attrs["growlight_config"]["power"] == 80
+    assert attrs["growlight_ac_infinity_devices"][0]["mode_entity"] == (
+        "select.tent_light_mode"
+    )
 
 
 def test_build_special_growspace_types(builder):


### PR DESCRIPTION
## Problem

`configure_environment` correctly persists `growlight_entities`, `growlight_config`,
and `growlight_ac_infinity_devices` (backend log confirms the `EnvironmentConfig` and
`GrowLightCoordinator` are set). But `_get_environment_attributes` — the card-facing
`environment` payload built by `GrowspaceViewModelBuilder` — never included any grow
light fields.

Consequences on the card:
- The **Config → Growlights tab** seeded from `undefined` on reopen, so a saved
  configuration appeared to be lost.
- The **grow-light chip** had no data and never rendered.

Every other actuator (exhaust / circulation fans, humidifier, dehumidifier) was already
surfaced here, including its AC-Infinity bundle — grow lights were simply missed.

## Fix

Serialize the three grow light fields in `_get_environment_attributes`, parallel to the
existing fan/AC-Infinity handling:

- `growlight_ac_infinity_devices` (added to the AC-Infinity serialization loop)
- `growlight_entities`
- `growlight_config` (via `.to_dict()`)

The card side needs **no change** — its adapter and zod schema already read these three
keys; they just weren't being sent.

## Tests

- Added `test_get_environment_attributes_exposes_growlight`.
- Regenerated `test_presentation_snapshots.ambr` (+10 lines, growlight keys only).
- Full suite: **4767 passed**, 46 snapshots passed.

Follow-up to `5c73f76` (configure_environment parses grow light config — the save side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)