### PR TITLE
Environment Patch: one write seam for EnvironmentConfig (ADR-0026)

### DIFF
--- a/custom_components/growspace_manager/__init__.py
+++ b/custom_components/growspace_manager/__init__.py
@@ -114,6 +114,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: GrowspaceConfigEntry) ->
     # Register/Unregister Sidebar Panel
     await async_register_sidebar_panel(hass, entry)
 
+    # One-time ADR-0026 cleanup: per-growspace environment blobs in options are
+    # legacy — the growspace store is the single source of truth, and any blob
+    # worth keeping was adopted during coordinator load. Strip them before the
+    # update listener is registered so this options write cannot trigger a
+    # reload.
+    stale_blob_ids = [gid for gid in coordinator.growspaces if gid in entry.options]
+    if stale_blob_ids:
+        new_options = {
+            k: v for k, v in entry.options.items() if k not in stale_blob_ids
+        }
+        hass.config_entries.async_update_entry(entry, options=new_options)
+        _LOGGER.info(
+            "Removed %d legacy per-growspace environment blob(s) from config entry options",
+            len(stale_blob_ids),
+        )
+
     # Listen for options updates
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
@@ -136,7 +152,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GrowspaceConfigEntry) ->
             new_data.pop("pending_growspace")
             hass.config_entries.async_update_entry(entry, data=new_data)
 
-        except (KeyError, RuntimeError):
+        except KeyError, RuntimeError:
             _LOGGER.exception(
                 "Failed to create pending growspace %s",
                 pending.get("name", "unknown"),

--- a/custom_components/growspace_manager/config_handlers/__init__.py
+++ b/custom_components/growspace_manager/config_handlers/__init__.py
@@ -98,28 +98,6 @@ class BaseConfigHandler(ABC, Generic[T]):
         updated.update(new_options)
         return updated
 
-    def preserve_ac_infinity_devices(
-        self, growspace: Any, env_config: dict[str, Any]
-    ) -> None:
-        """Carry existing AC Infinity bundles into a rebuilt env-config dict.
-
-        The config flow has no AC Infinity bundle editor, so its form payload
-        never carries these lists; rebuilding ``EnvironmentConfig`` from that
-        payload would silently wipe configured devices. Preserve any already on
-        the growspace unless the payload explicitly provides them (ADR-0022).
-        """
-        existing = getattr(growspace, "environment_config", None)
-        if not existing:
-            return
-        for key in (
-            "exhaust_fan_ac_infinity_devices",
-            "circulation_fan_ac_infinity_devices",
-            "humidifier_ac_infinity_devices",
-            "dehumidifier_ac_infinity_devices",
-        ):
-            if key not in env_config:
-                env_config[key] = [d.to_dict() for d in getattr(existing, key)]
-
 
 # Import handlers AFTER BaseConfigHandler is defined to avoid circular import
 from .ai_config_handler import AIConfigHandler  # noqa: E402

--- a/custom_components/growspace_manager/config_handlers/environment_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/environment_config_handler.py
@@ -95,10 +95,15 @@ from custom_components.growspace_manager.const import (
 from custom_components.growspace_manager.dehumidifier_coordinator import (
     DEFAULT_THRESHOLDS,
 )
+from custom_components.growspace_manager.domain.environment_patch import (
+    patch_from_flow_options,
+)
 from custom_components.growspace_manager.humidifier_coordinator import (
     DEFAULT_THRESHOLDS as HUMIDIFIER_DEFAULT_THRESHOLDS,
 )
-from custom_components.growspace_manager.models import EnvironmentConfig
+from custom_components.growspace_manager.services.environment_patch_commit import (
+    async_commit_environment_patch,
+)
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.helpers import selector
 
@@ -195,14 +200,7 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
 
         if user_input is not None:
             env_config = self._clean_and_merge_input(user_input, growspace_options)
-            existing_tanks = (
-                growspace.environment_config.irrigation_tanks
-                if growspace.environment_config
-                else []
-            )
-            env_config = self._process_irrigation_tanks(
-                env_config, existing_tanks=existing_tanks
-            )
+            env_config = self._process_irrigation_tanks(env_config)
             self.flow.env_config_step1 = env_config
             return await self._determine_next_step(user_input)
 
@@ -243,27 +241,15 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
 
         return env_config
 
-    def _process_irrigation_tanks(
-        self,
-        env_config: dict[str, Any],
-        existing_tanks: list | None = None,
-    ) -> dict[str, Any]:
-        """Convert irrigation tank sensors to IrrigationTank instances."""
+    def _process_irrigation_tanks(self, env_config: dict[str, Any]) -> dict[str, Any]:
+        """Fold the flat tank form fields into irrigation_tanks dicts.
+
+        Runtime state (water_history etc.) is deliberately not carried here —
+        the Environment Patch merge preserves it per tank (ADR-0026).
+        """
         tank_sensors = env_config.get(CONF_IRRIGATION_TANK_SENSORS, [])
         warning_level = env_config.get(CONF_IRRIGATION_TANK_WARNING_LEVEL, 30.0)
         volume_liters = env_config.get(CONF_IRRIGATION_TANK_VOLUME)
-
-        # Build a lookup of existing tanks so we can preserve accumulated runtime data
-        existing_by_entity: dict[str, Any] = {}
-        if existing_tanks:
-            for t in existing_tanks:
-                entity = (
-                    t.sensor_entity
-                    if hasattr(t, "sensor_entity")
-                    else t.get("sensor_entity")
-                )
-                if entity:
-                    existing_by_entity[entity] = t
 
         if tank_sensors:
             irrigation_tanks = []
@@ -275,43 +261,17 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
                     if state_obj
                     else f"Tank {i}"
                 )
-                tank_dict: dict[str, Any] = {
-                    "sensor_entity": sensor_entity,
-                    "name": tank_name,
-                    "warning_level": warning_level,
-                    "enable_prediction": True,  # Enable by default
-                    "enable_lights_bias": False,  # Opt-in feature
-                    "enable_vpd_weighting": False,  # Opt-in feature
-                    "volume_liters": volume_liters,
-                }
-                # Preserve accumulated runtime data for tanks that already exist
-                existing = existing_by_entity.get(sensor_entity)
-                if existing is not None:
-                    water_history = (
-                        existing.water_history
-                        if hasattr(existing, "water_history")
-                        else existing.get("water_history")
-                    )
-                    last_level = (
-                        existing.last_recorded_level
-                        if hasattr(existing, "last_recorded_level")
-                        else existing.get("last_recorded_level")
-                    )
-                    peak_level = (
-                        existing.peak_level
-                        if hasattr(existing, "peak_level")
-                        else existing.get("peak_level")
-                    )
-                    if water_history is not None:
-                        try:
-                            tank_dict["water_history"] = asdict(water_history)
-                        except TypeError:
-                            tank_dict["water_history"] = water_history
-                    if last_level is not None:
-                        tank_dict["last_recorded_level"] = last_level
-                    if peak_level is not None:
-                        tank_dict["peak_level"] = peak_level
-                irrigation_tanks.append(tank_dict)
+                irrigation_tanks.append(
+                    {
+                        "sensor_entity": sensor_entity,
+                        "name": tank_name,
+                        "warning_level": warning_level,
+                        "enable_prediction": True,  # Enable by default
+                        "enable_lights_bias": False,  # Opt-in feature
+                        "enable_vpd_weighting": False,  # Opt-in feature
+                        "volume_liters": volume_liters,
+                    }
+                )
             env_config["irrigation_tanks"] = irrigation_tanks
         else:
             env_config["irrigation_tanks"] = []
@@ -472,7 +432,7 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
 
                 self.flow.env_config_step1 = env_config
 
-            except (ValueError, SyntaxError, TypeError):
+            except ValueError, SyntaxError, TypeError:
                 _LOGGER.warning("Invalid tuple format submitted", exc_info=True)
                 return self.flow.async_show_form(
                     step_id="configure_advanced_bayesian",
@@ -693,23 +653,14 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
         return schema_dict
 
     async def _async_save_and_finish(self, growspace, env_config):
-        """Helper to save config and finish flow."""
+        """Apply the assembled form dict through the Environment Patch seam."""
         coordinator = self.config_entry.runtime_data
 
-        # Clean up temporary keys strictly
-        env_config.pop("configure_advanced", None)
-        env_config.pop("configure_dehumidifier", None)
-
-        self.preserve_ac_infinity_devices(growspace, env_config)
-
-        growspace.environment_config = EnvironmentConfig.from_dict(env_config)
-        await coordinator.services.save()
-        await coordinator.async_refresh()
-
-        _LOGGER.info(
-            "Environment configuration saved for growspace %s: %s",
-            growspace.name,
-            env_config,
+        await async_commit_environment_patch(
+            coordinator.hass,
+            coordinator,
+            growspace,
+            patch_from_flow_options(env_config),
         )
         return self.flow.async_create_entry(title="", data=self.config_entry.options)
 

--- a/custom_components/growspace_manager/config_handlers/environment_sensors_handler.py
+++ b/custom_components/growspace_manager/config_handlers/environment_sensors_handler.py
@@ -49,7 +49,12 @@ from custom_components.growspace_manager.const import (
     CONF_VPD_SENSOR,
     CONF_VPD_SENSORS,
 )
-from custom_components.growspace_manager.models import EnvironmentConfig
+from custom_components.growspace_manager.domain.environment_patch import (
+    patch_from_flow_options,
+)
+from custom_components.growspace_manager.services.environment_patch_commit import (
+    async_commit_environment_patch,
+)
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.helpers import selector
 
@@ -70,7 +75,9 @@ class EnvironmentSensorsHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
 
-        growspace_options = coordinator.services.growspaces.get_sorted_growspace_options()
+        growspace_options = (
+            coordinator.services.growspaces.get_sorted_growspace_options()
+        )
 
         if not growspace_options:
             return self.flow.async_abort(reason="no_growspaces")
@@ -138,14 +145,7 @@ class EnvironmentSensorsHandler(BaseConfigHandler[dict[str, Any]]):
 
         if user_input is not None:
             env_config = self._clean_and_merge_input(user_input, growspace_options)
-            existing_tanks = (
-                growspace.environment_config.irrigation_tanks
-                if growspace.environment_config
-                else []
-            )
-            env_config = self._process_irrigation_tanks(
-                env_config, existing_tanks=existing_tanks
-            )
+            env_config = self._process_irrigation_tanks(env_config)
             self.flow.env_config_step1 = env_config
             return await self._determine_next_step(user_input)
 
@@ -167,7 +167,12 @@ class EnvironmentSensorsHandler(BaseConfigHandler[dict[str, Any]]):
         env_config = {
             k: v
             for k, v in merged.items()
-            if k not in ("configure_dehumidifier", "configure_advanced", CONF_CONFIGURE_FAN_CONTROLLER)
+            if k
+            not in (
+                "configure_dehumidifier",
+                "configure_advanced",
+                CONF_CONFIGURE_FAN_CONTROLLER,
+            )
         }
 
         if "sensor_groups" in cleaned_input:
@@ -178,26 +183,15 @@ class EnvironmentSensorsHandler(BaseConfigHandler[dict[str, Any]]):
 
         return env_config
 
-    def _process_irrigation_tanks(
-        self,
-        env_config: dict[str, Any],
-        existing_tanks: list | None = None,
-    ) -> dict[str, Any]:
-        """Convert irrigation tank sensors to IrrigationTank instances."""
+    def _process_irrigation_tanks(self, env_config: dict[str, Any]) -> dict[str, Any]:
+        """Fold the flat tank form fields into irrigation_tanks dicts.
+
+        Runtime state (water_history etc.) is deliberately not carried here —
+        the Environment Patch merge preserves it per tank (ADR-0026).
+        """
         tank_sensors = env_config.get(CONF_IRRIGATION_TANK_SENSORS, [])
         warning_level = env_config.get(CONF_IRRIGATION_TANK_WARNING_LEVEL, 30.0)
         volume_liters = env_config.get(CONF_IRRIGATION_TANK_VOLUME)
-
-        existing_by_entity: dict[str, Any] = {}
-        if existing_tanks:
-            for t in existing_tanks:
-                entity = (
-                    t.sensor_entity
-                    if hasattr(t, "sensor_entity")
-                    else t.get("sensor_entity")
-                )
-                if entity:
-                    existing_by_entity[entity] = t
 
         if tank_sensors:
             irrigation_tanks = []
@@ -208,42 +202,17 @@ class EnvironmentSensorsHandler(BaseConfigHandler[dict[str, Any]]):
                     if state_obj
                     else f"Tank {i}"
                 )
-                tank_dict: dict[str, Any] = {
-                    "sensor_entity": sensor_entity,
-                    "name": tank_name,
-                    "warning_level": warning_level,
-                    "enable_prediction": True,
-                    "enable_lights_bias": False,
-                    "enable_vpd_weighting": False,
-                    "volume_liters": volume_liters,
-                }
-                existing = existing_by_entity.get(sensor_entity)
-                if existing is not None:
-                    water_history = (
-                        existing.water_history
-                        if hasattr(existing, "water_history")
-                        else existing.get("water_history")
-                    )
-                    last_level = (
-                        existing.last_recorded_level
-                        if hasattr(existing, "last_recorded_level")
-                        else existing.get("last_recorded_level")
-                    )
-                    peak_level = (
-                        existing.peak_level
-                        if hasattr(existing, "peak_level")
-                        else existing.get("peak_level")
-                    )
-                    if water_history is not None:
-                        try:
-                            tank_dict["water_history"] = asdict(water_history)
-                        except TypeError:
-                            tank_dict["water_history"] = water_history
-                    if last_level is not None:
-                        tank_dict["last_recorded_level"] = last_level
-                    if peak_level is not None:
-                        tank_dict["peak_level"] = peak_level
-                irrigation_tanks.append(tank_dict)
+                irrigation_tanks.append(
+                    {
+                        "sensor_entity": sensor_entity,
+                        "name": tank_name,
+                        "warning_level": warning_level,
+                        "enable_prediction": True,
+                        "enable_lights_bias": False,
+                        "enable_vpd_weighting": False,
+                        "volume_liters": volume_liters,
+                    }
+                )
             env_config["irrigation_tanks"] = irrigation_tanks
         else:
             env_config["irrigation_tanks"] = []
@@ -272,23 +241,17 @@ class EnvironmentSensorsHandler(BaseConfigHandler[dict[str, Any]]):
 
         return await self.flow.async_step_configure_sensor_placement()
 
-    async def _async_save_and_finish(self, growspace: Any, env_config: dict[str, Any]) -> ConfigFlowResult:
-        """Save env config and finish the flow."""
+    async def _async_save_and_finish(
+        self, growspace: Any, env_config: dict[str, Any]
+    ) -> ConfigFlowResult:
+        """Apply the assembled form dict through the Environment Patch seam."""
         coordinator = self.config_entry.runtime_data
 
-        env_config.pop("configure_advanced", None)
-        env_config.pop("configure_dehumidifier", None)
-
-        self.preserve_ac_infinity_devices(growspace, env_config)
-
-        growspace.environment_config = EnvironmentConfig.from_dict(env_config)
-        await coordinator.services.save()
-        await coordinator.async_refresh()
-
-        _LOGGER.info(
-            "Environment configuration saved for growspace %s: %s",
-            growspace.name,
-            env_config,
+        await async_commit_environment_patch(
+            coordinator.hass,
+            coordinator,
+            growspace,
+            patch_from_flow_options(env_config),
         )
         return self.flow.async_create_entry(title="", data=self.config_entry.options)
 

--- a/custom_components/growspace_manager/domain/environment_patch.py
+++ b/custom_components/growspace_manager/domain/environment_patch.py
@@ -454,7 +454,11 @@ def _build_patch(
             warnings.append(PatchWarning(key, "runtime-accumulated field ignored"))
             continue
         if key in _SUB_CONFIG_TYPES:
-            values[key] = _parse_sub_config(key, val)
+            # Explicit null sub-config means "keep existing" — the historic
+            # service contract (callers could never distinguish null from
+            # absent). Reset-to-defaults is an explicit empty dict.
+            if val is not None:
+                values[key] = _parse_sub_config(key, val)
         elif key in _ITEM_TYPES:
             items, item_warnings = _parse_item_list(key, val)
             values[key] = items
@@ -510,8 +514,6 @@ def _parse_sub_config(key: str, val: Any) -> Any:
     sub_type = _SUB_CONFIG_TYPES[key]
     if isinstance(val, sub_type):
         return val
-    if val is None:
-        return sub_type()
     if not isinstance(val, Mapping):
         raise EnvironmentPatchError(f"Field '{key}' must be a dictionary")
     if key == "circulation_fan_config":

--- a/custom_components/growspace_manager/services.yaml
+++ b/custom_components/growspace_manager/services.yaml
@@ -532,7 +532,10 @@ switch_plants:
 
 configure_environment:
   name: Configure Environment Monitoring
-  description: Set up environment sensors for Bayesian monitoring on a growspace
+  description: >-
+    Update environment sensors and settings for a growspace. Patch semantics:
+    a field omitted from the call keeps its current value; send an explicit
+    empty value (e.g. an empty list) to deliberately clear a field.
   fields:
     growspace_id:
       name: Growspace ID

--- a/custom_components/growspace_manager/services/environment.py
+++ b/custom_components/growspace_manager/services/environment.py
@@ -1,66 +1,27 @@
-"""Service handlers for environment configuration."""
+"""Service handlers for environment configuration.
+
+Every EnvironmentConfig write routes through the Environment Patch seam
+(ADR-0026): a writer-specific builder in ``domain/environment_patch.py``
+validates and normalises the payload, and ``async_commit_environment_patch``
+performs the assign → save → refresh → controller-restart → repair sequence.
+Patch semantics: an omitted field keeps its current value; an explicitly sent
+empty value is a deliberate clear.
+"""
 
 from __future__ import annotations
 
-from dataclasses import fields
 import logging
-from typing import cast
 
-from custom_components.growspace_manager.circulation_fan_coordinator import (
-    FAN_VPD_STAGE_DEFAULTS,
-)
-from custom_components.growspace_manager.const import (
-    CONF_BULK_EC_SENSORS,
-    CONF_CAMERA_ENTITIES,
-    CONF_CIRCULATION_FAN_ENTITIES,
-    CONF_CIRCULATION_FAN_ENTITY,
-    CONF_CO2_SENSOR,
-    CONF_CONTROL_DEHUMIDIFIER,
-    CONF_CONTROL_HUMIDIFIER,
-    CONF_DEHUMIDIFIER_ENTITIES,
-    CONF_DEHUMIDIFIER_ENTITY,
-    CONF_DEHUMIDIFIER_THRESHOLDS,
-    CONF_DRAIN_VOLUME_SENSORS,
-    CONF_ELECTRICITY_COST,
-    CONF_ENERGY_SENSORS,
-    CONF_EXHAUST_ENTITY,
-    CONF_EXHAUST_FAN_ENTITIES,
-    CONF_FEED_EC_SENSORS,
-    CONF_HUMIDIFIER_ENTITIES,
-    CONF_HUMIDIFIER_ENTITY,
-    CONF_HUMIDIFIER_THRESHOLDS,
-    CONF_HUMIDITY_SENSOR,
-    CONF_IRRIGATION_FLOW_SENSORS,
-    CONF_LIGHT_SENSOR,
-    CONF_LIGHT_SENSORS,
-    CONF_LUNG_ROOM_TEMP_SENSORS,
-    CONF_MOLD_THRESHOLD,
-    CONF_PH_SENSORS,
-    CONF_PORE_EC_SENSORS,
-    CONF_POWER_SENSORS,
-    CONF_RUNOFF_EC_SENSORS,
-    CONF_SOIL_MOISTURE_SENSOR,
-    CONF_STRESS_THRESHOLD,
-    CONF_SUBSTRATE_TEMP_SENSORS,
-    CONF_TEMP_SENSOR,
-    CONF_VPD_SENSOR,
-    FanRegulationMode,
-    GrowspaceService,
-)
+from custom_components.growspace_manager.const import GrowspaceService
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
-from custom_components.growspace_manager.exhaust_migration import (
-    evaluate_exhaust_migration_issues,
+from custom_components.growspace_manager.domain.environment_patch import (
+    EnvironmentPatch,
+    EnvironmentPatchError,
+    circulation_fan_patch,
+    exhaust_fan_patch,
+    patch_from_service_call,
 )
-from custom_components.growspace_manager.models import (
-    ACInfinityDevice,
-    ACInfinityGrowLight,
-    CirculationFanConfig,
-    EnvironmentConfig,
-    ExhaustFanConfig,
-    GrowLightConfig,
-    IrrigationTank,
-    SensorGroup,
-)
+from custom_components.growspace_manager.models import EnvironmentConfig, Growspace
 from custom_components.growspace_manager.schemas import (
     CONFIGURE_CIRCULATION_FAN_SCHEMA,
     CONFIGURE_ENVIRONMENT_SCHEMA,
@@ -68,6 +29,9 @@ from custom_components.growspace_manager.schemas import (
     REMOVE_ENVIRONMENT_SCHEMA,
     SET_DEHUMIDIFIER_CONTROL_SCHEMA,
     SET_HUMIDIFIER_CONTROL_SCHEMA,
+)
+from custom_components.growspace_manager.services.environment_patch_commit import (
+    async_commit_environment_patch,
 )
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
@@ -77,120 +41,27 @@ from ._definition import ServiceDefinition
 _LOGGER = logging.getLogger(__name__)
 
 
-_VALID_STAGE_KEYS = {stage.value for stage in FAN_VPD_STAGE_DEFAULTS}
-_VPD_OVERRIDE_MIN = 0.1
-_VPD_OVERRIDE_MAX = 3.0
+def _get_growspace(coordinator: GrowspaceCoordinator, call: ServiceCall) -> Growspace:
+    """Resolve the target growspace or raise a user-facing error."""
+    growspace_id = call.data.get("growspace_id")
+    if growspace_id not in coordinator.growspaces:
+        error_msg = f"Growspace '{growspace_id}' not found"
+        _LOGGER.error(error_msg)
+        raise ServiceValidationError(error_msg)
+    return coordinator.growspaces[growspace_id]
 
 
-def _validate_stage_vpd_overrides(
-    overrides: dict | None,
-) -> dict[str, dict[str, float]]:
-    """Validate and return stage_vpd_overrides, raising ServiceValidationError on bad input."""
-    if overrides is None:
-        return {}
-    if not isinstance(overrides, dict):
-        raise ServiceValidationError("stage_vpd_overrides must be a dictionary.")
-    for stage_key, entry in overrides.items():
-        if stage_key not in _VALID_STAGE_KEYS:
-            raise ServiceValidationError(
-                f"Unknown stage key '{stage_key}' in stage_vpd_overrides. "
-                f"Valid keys: {sorted(_VALID_STAGE_KEYS)}"
-            )
-        if not isinstance(entry, dict) or "day" not in entry or "night" not in entry:
-            raise ServiceValidationError(
-                f"Stage '{stage_key}' entry must contain both 'day' and 'night' keys."
-            )
-        for period in ("day", "night"):
-            val = entry[period]
-            if not isinstance(val, (int, float)):
-                raise ServiceValidationError(
-                    f"Stage '{stage_key}' {period} VPD override must be a number."
-                )
-            if not (_VPD_OVERRIDE_MIN <= val <= _VPD_OVERRIDE_MAX):
-                raise ServiceValidationError(
-                    f"Stage '{stage_key}' {period} VPD override {val} kPa is out of range "
-                    f"({_VPD_OVERRIDE_MIN}–{_VPD_OVERRIDE_MAX} kPa)."
-                )
-    return overrides
-
-
-def _validate_vpd_optimal_overrides(
-    overrides: dict | None,
-) -> dict[str, dict[str, dict[str, float]]]:
-    """Validate vpd_optimal_overrides, raising ServiceValidationError on bad input."""
-    if overrides is None:
-        return {}
-    if not isinstance(overrides, dict):
-        raise ServiceValidationError("vpd_optimal_overrides must be a dictionary.")
-    for stage_key, entry in overrides.items():
-        if stage_key not in _VALID_STAGE_KEYS:
-            raise ServiceValidationError(
-                f"Unknown stage key '{stage_key}' in vpd_optimal_overrides. "
-                f"Valid keys: {sorted(_VALID_STAGE_KEYS)}"
-            )
-        if not isinstance(entry, dict) or "day" not in entry or "night" not in entry:
-            raise ServiceValidationError(
-                f"Stage '{stage_key}' entry must contain both 'day' and 'night' keys."
-            )
-        for period in ("day", "night"):
-            period_entry = entry[period]
-            if (
-                not isinstance(period_entry, dict)
-                or "low" not in period_entry
-                or "high" not in period_entry
-            ):
-                raise ServiceValidationError(
-                    f"Stage '{stage_key}' {period} entry must contain both 'low' and 'high' keys."
-                )
-            low = period_entry["low"]
-            high = period_entry["high"]
-            if not (_VPD_OVERRIDE_MIN <= low <= _VPD_OVERRIDE_MAX) or not (
-                _VPD_OVERRIDE_MIN <= high <= _VPD_OVERRIDE_MAX
-            ):
-                raise ServiceValidationError(
-                    f"Stage '{stage_key}' {period} VPD values out of range "
-                    f"({_VPD_OVERRIDE_MIN}–{_VPD_OVERRIDE_MAX} kPa). Got low={low}, high={high}."
-                )
-            if low >= high:
-                raise ServiceValidationError(
-                    f"Stage '{stage_key}' {period}: low ({low}) must be < high ({high})."
-                )
-    return overrides
-
-
-def _parse_fan_config(
-    raw: dict | None,
-    existing_env: EnvironmentConfig | None,
-) -> CirculationFanConfig:
-    """Return a CirculationFanConfig from a raw dict payload, falling back to the existing config."""
-    if raw:
-        return CirculationFanConfig(
-            enabled=bool(raw.get("enabled", False)),
-            regulation_mode=FanRegulationMode(
-                raw.get("regulation_mode", FanRegulationMode.VPD)
-            ),
-            min_speed=int(raw.get("min_speed", 0)),
-            max_speed=int(raw.get("max_speed", 100)),
-            vpd_target=float(raw.get("vpd_target", 1.0)),
-            vpd_tolerance=float(raw.get("vpd_tolerance", 0.2)),
-            humidity_target=float(raw.get("humidity_target", 60.0)),
-            humidity_tolerance=float(raw.get("humidity_tolerance", 5.0)),
-            temperature_target=float(raw.get("temperature_target", 25.0)),
-            temperature_tolerance=float(raw.get("temperature_tolerance", 2.0)),
-            critical_temp_low=raw.get("critical_temp_low"),
-            critical_temp_high=raw.get("critical_temp_high"),
-            critical_temp_hysteresis=float(raw.get("critical_temp_hysteresis", 1.0)),
-            wind_enabled=bool(raw.get("wind_enabled", False)),
-            wind_period_seconds=int(raw.get("wind_period_seconds", 60)),
-            wind_amplitude_pct=int(raw.get("wind_amplitude_pct", 10)),
-            stage_vpd_enabled=bool(raw.get("stage_vpd_enabled", False)),
-            stage_vpd_overrides=_validate_stage_vpd_overrides(
-                raw.get("stage_vpd_overrides", {})
-            ),
-        )
-    if existing_env is not None:
-        return existing_env.circulation_fan_config
-    return CirculationFanConfig()
+async def _commit_or_raise(
+    hass: HomeAssistant,
+    coordinator: GrowspaceCoordinator,
+    growspace: Growspace,
+    patch: EnvironmentPatch,
+) -> None:
+    """Commit a built patch, mapping seam errors to ServiceValidationError."""
+    try:
+        await async_commit_environment_patch(hass, coordinator, growspace, patch)
+    except EnvironmentPatchError as err:
+        raise ServiceValidationError(str(err)) from err
 
 
 async def handle_configure_environment(
@@ -198,213 +69,13 @@ async def handle_configure_environment(
     coordinator: GrowspaceCoordinator,
     call: ServiceCall,
 ) -> None:
-    """Handle the configure_environment service call."""
-    growspace_id = call.data.get("growspace_id")
-
-    if growspace_id not in coordinator.growspaces:
-        error_msg = f"Growspace '{growspace_id}' not found"
-        _LOGGER.error(error_msg)
-        raise ServiceValidationError(error_msg)
-
-    growspace = coordinator.growspaces[growspace_id]
-
-    def _get_list(key_singular: str, key_plural: str) -> list[str]:
-        if val := call.data.get(key_plural):
-            return cast(list[str], val)
-        if val := call.data.get(key_singular):
-            return cast(list[str], [val] if isinstance(val, str) else val)
-        return []
-
-    existing_env = growspace.environment_config
-
-    def _get_ac_infinity_devices(key: str) -> list[ACInfinityDevice]:
-        """Parse the AC Infinity bundle list, preserving existing when omitted.
-
-        ``configure_environment`` is a full replace, so a caller that does not
-        send a bundle list must not have its configured AC Infinity devices wiped
-        (mirrors the ``exhaust_fan_config`` preservation). An explicitly sent list
-        — including an empty one — is honored as a deliberate change.
-        """
-        if key not in call.data:
-            return list(getattr(existing_env, key, []) or []) if existing_env else []
-        return [ACInfinityDevice.from_dict(d) for d in call.data[key]]
-
-    def _get_growlight_ac_infinity(key: str) -> list[ACInfinityGrowLight]:
-        """Parse the grow-light AC Infinity bundle, preserving existing when omitted."""
-        if key not in call.data:
-            return list(getattr(existing_env, key, []) or []) if existing_env else []
-        return [ACInfinityGrowLight.from_dict(d) for d in call.data[key]]
-
-    def _get_growlight_config() -> GrowLightConfig:
-        """Parse growlight_config from the call, preserving existing when omitted."""
-        raw = call.data.get("growlight_config")
-        if raw is not None:
-            return GrowLightConfig.from_dict(raw)
-        return existing_env.growlight_config if existing_env else GrowLightConfig()
-
-    # Process Sensor Groups
-    sensor_groups_data = call.data.get("sensor_groups", [])
-    sensor_groups = []
-
-    valid_keys = {f.name for f in fields(SensorGroup)}
-
-    for g_data in sensor_groups_data:
-        try:
-            # Filter keys
-            filtered_data = {k: v for k, v in g_data.items() if k in valid_keys}
-            # simple dict to SensorGroup conversion
-            sensor_groups.append(SensorGroup.from_dict(filtered_data))
-        except (TypeError, ValueError, LookupError) as e:
-            _LOGGER.warning("Invalid sensor group data: %s (%s)", g_data, e)
-
-    # Process Irrigation Tanks
-    tanks_data = call.data.get("irrigation_tanks", [])
-    irrigation_tanks = []
-
-    tank_valid_keys = {f.name for f in fields(IrrigationTank)}
-
-    # Build map of existing tanks to preserve runtime data (water_history, last_recorded_level)
-    existing_tanks_by_entity: dict[str, IrrigationTank] = {}
-    if growspace.environment_config and growspace.environment_config.irrigation_tanks:
-        existing_tanks_by_entity = {
-            t.sensor_entity: t for t in growspace.environment_config.irrigation_tanks
-        }
-
-    for t_data in tanks_data:
-        try:
-            filtered_tank = {k: v for k, v in t_data.items() if k in tank_valid_keys}
-            new_tank = IrrigationTank.from_dict(filtered_tank)
-            # Preserve accumulated runtime data for tanks that already exist
-            existing = existing_tanks_by_entity.get(new_tank.sensor_entity)
-            if existing is not None:
-                new_tank.water_history = existing.water_history
-                new_tank.last_recorded_level = existing.last_recorded_level
-                new_tank.peak_level = existing.peak_level
-            irrigation_tanks.append(new_tank)
-        except (TypeError, ValueError, LookupError) as e:
-            _LOGGER.warning("Invalid irrigation tank data: %s (%s)", t_data, e)
-
-    # Build environment config from service call
-    env_config = EnvironmentConfig(
-        temperature_sensor=call.data.get(CONF_TEMP_SENSOR),
-        temperature_sensors=_get_list(CONF_TEMP_SENSOR, "temperature_sensors"),
-        humidity_sensor=call.data.get(CONF_HUMIDITY_SENSOR),
-        humidity_sensors=_get_list(CONF_HUMIDITY_SENSOR, "humidity_sensors"),
-        vpd_sensor=call.data.get(CONF_VPD_SENSOR),
-        vpd_sensors=_get_list(CONF_VPD_SENSOR, "vpd_sensors"),
-        co2_sensor=call.data.get(CONF_CO2_SENSOR),
-        circulation_fan_entities=_get_list(
-            CONF_CIRCULATION_FAN_ENTITY, CONF_CIRCULATION_FAN_ENTITIES
-        ),
-        light_sensors=_get_list(CONF_LIGHT_SENSOR, CONF_LIGHT_SENSORS),
-        exhaust_fan_entities=_get_list(CONF_EXHAUST_ENTITY, CONF_EXHAUST_FAN_ENTITIES),
-        humidifier_entities=_get_list(CONF_HUMIDIFIER_ENTITY, CONF_HUMIDIFIER_ENTITIES),
-        dehumidifier_entities=_get_list(
-            CONF_DEHUMIDIFIER_ENTITY, CONF_DEHUMIDIFIER_ENTITIES
-        ),
-        exhaust_fan_ac_infinity_devices=_get_ac_infinity_devices(
-            "exhaust_fan_ac_infinity_devices"
-        ),
-        circulation_fan_ac_infinity_devices=_get_ac_infinity_devices(
-            "circulation_fan_ac_infinity_devices"
-        ),
-        humidifier_ac_infinity_devices=_get_ac_infinity_devices(
-            "humidifier_ac_infinity_devices"
-        ),
-        dehumidifier_ac_infinity_devices=_get_ac_infinity_devices(
-            "dehumidifier_ac_infinity_devices"
-        ),
-        soil_moisture_sensor=call.data.get(CONF_SOIL_MOISTURE_SENSOR),
-        control_dehumidifier=call.data.get(CONF_CONTROL_DEHUMIDIFIER, False),
-        control_humidifier=call.data.get(CONF_CONTROL_HUMIDIFIER, False),
-        dehumidifier_thresholds=call.data.get(CONF_DEHUMIDIFIER_THRESHOLDS, {}),
-        humidifier_thresholds=call.data.get(CONF_HUMIDIFIER_THRESHOLDS, {}),
-        stress_threshold=call.data.get(CONF_STRESS_THRESHOLD, 0.70),
-        mold_threshold=call.data.get(CONF_MOLD_THRESHOLD, 0.75),
-        veg_day_hours=call.data.get("veg_day_hours", 18),
-        flower_day_hours=call.data.get("flower_day_hours", 12),
-        minimum_source_air_temperature=call.data.get(
-            "minimum_source_air_temperature", 18.0
-        ),
-        sensor_groups=sensor_groups,
-        sensor_coordinates=call.data.get("sensor_coordinates", {}),
-        irrigation_tanks=irrigation_tanks,
-        substrate_temperature_sensors=call.data.get(CONF_SUBSTRATE_TEMP_SENSORS, []),
-        camera_entities=call.data.get(CONF_CAMERA_ENTITIES, []),
-        lung_room_temp_sensors=call.data.get(CONF_LUNG_ROOM_TEMP_SENSORS, []),
-        ph_sensors=call.data.get(CONF_PH_SENSORS, []),
-        feed_ec_sensors=call.data.get(CONF_FEED_EC_SENSORS, []),
-        bulk_ec_sensors=call.data.get(CONF_BULK_EC_SENSORS, []),
-        pore_ec_sensors=call.data.get(CONF_PORE_EC_SENSORS, []),
-        runoff_ec_sensors=call.data.get(CONF_RUNOFF_EC_SENSORS, []),
-        drain_volume_sensors=call.data.get(CONF_DRAIN_VOLUME_SENSORS, []),
-        irrigation_flow_sensors=call.data.get(CONF_IRRIGATION_FLOW_SENSORS, []),
-        power_sensors=call.data.get(CONF_POWER_SENSORS, []),
-        energy_sensors=call.data.get(CONF_ENERGY_SENSORS, []),
-        electricity_cost_per_kwh=call.data.get(CONF_ELECTRICITY_COST),
-        lst_offset=call.data.get("lst_offset", -2.0),
-        circulation_fan_config=_parse_fan_config(
-            call.data.get("circulation_fan_config"),
-            growspace.environment_config,
-        ),
-        # configure_environment carries no exhaust_fan_config payload; preserve the
-        # existing controller settings so an environment edit doesn't silently reset
-        # the exhaust controller to enabled=False (ADR-0019).
-        exhaust_fan_config=(
-            growspace.environment_config.exhaust_fan_config
-            if growspace.environment_config
-            else ExhaustFanConfig()
-        ),
-        # Like the exhaust config, configure_environment carries no grow-light
-        # from the call when present, else preserve the existing settings so an
-        # unrelated environment edit doesn't reset the grow light.
-        growlight_entities=(
-            _get_list("growlight_entity", "growlight_entities")
-            or (
-                growspace.environment_config.growlight_entities
-                if growspace.environment_config
-                else []
-            )
-        ),
-        growlight_config=_get_growlight_config(),
-        growlight_ac_infinity_devices=_get_growlight_ac_infinity(
-            "growlight_ac_infinity_devices"
-        ),
-        vpd_optimal_overrides=_validate_vpd_optimal_overrides(
-            call.data.get("vpd_optimal_overrides")
-        ),
-    )
-
-    # Store in growspace
-    growspace.environment_config = env_config
-
-    # Save to storage
-    await coordinator.services.save()
-
-    # Trigger coordinator update to create/update binary sensors
-    await coordinator.services.request_refresh()
-
-    fan_coord = coordinator._subsystem_manager.get_circulation_fan_controller(
-        growspace_id
-    )
-    if fan_coord:
-        await fan_coord.async_restart()
-
-    # configure_environment applies via targeted restart, not a full reload, so
-    # the grow light controller must be restarted to pick up an enable/disable.
-    growlight_coord = coordinator._subsystem_manager.get_growlight_controller(
-        growspace_id
-    )
-    if growlight_coord:
-        await growlight_coord.async_restart()
-
-    # Re-evaluate the exhaust-migration repair (ADR-0019): this rebuilds the
-    # environment config (control_dehumidifier, exhaust_fan_entities) without a
-    # full reload, so the repair must be re-checked here too.
-    evaluate_exhaust_migration_issues(hass, coordinator)
-
-    success_msg = f"Environment monitoring configured for '{growspace.name}'"
-    _LOGGER.info("%s: %s", success_msg, env_config)
+    """Handle the configure_environment service call (patch semantics)."""
+    growspace = _get_growspace(coordinator, call)
+    try:
+        patch = patch_from_service_call(call.data)
+    except EnvironmentPatchError as err:
+        raise ServiceValidationError(str(err)) from err
+    await _commit_or_raise(hass, coordinator, growspace, patch)
 
 
 async def handle_remove_environment(
@@ -413,26 +84,16 @@ async def handle_remove_environment(
     call: ServiceCall,
 ) -> None:
     """Handle the remove_environment service call."""
-    growspace_id = call.data.get("growspace_id")
+    growspace = _get_growspace(coordinator, call)
 
-    if growspace_id not in coordinator.growspaces:
-        error_msg = f"Growspace '{growspace_id}' not found"
-        _LOGGER.error(error_msg)
-        raise ServiceValidationError(error_msg)
-
-    growspace = coordinator.growspaces[growspace_id]
-
-    # Remove environment config
+    # A deliberate whole reset, not a merge — the one writer that bypasses
+    # the patch seam by design.
     growspace.environment_config = EnvironmentConfig()
 
-    # Save to storage
     await coordinator.services.save()
-
-    # Trigger coordinator update
     await coordinator.services.request_refresh()
 
-    success_msg = f"Environment monitoring removed for '{growspace.name}'"
-    _LOGGER.info(success_msg)
+    _LOGGER.info("Environment monitoring removed for '%s'", growspace.name)
 
 
 async def handle_set_dehumidifier_control(
@@ -441,30 +102,14 @@ async def handle_set_dehumidifier_control(
     call: ServiceCall,
 ) -> None:
     """Handle the set_dehumidifier_control service call."""
-    growspace_id = call.data.get("growspace_id")
-    enabled = call.data.get("enabled")
-
-    if growspace_id not in coordinator.growspaces:
-        error_msg = f"Growspace '{growspace_id}' not found"
-        _LOGGER.error(error_msg)
-        raise ServiceValidationError(error_msg)
-
-    growspace = coordinator.growspaces[growspace_id]
-
-    # Update configuration
-    growspace.environment_config.control_dehumidifier = bool(enabled)
-
-    # Save to storage
-    await coordinator.services.save()
-
-    # Trigger coordinator update
-    await coordinator.services.request_refresh()
-
-    # Re-evaluate the exhaust-migration repair (ADR-0019): this service mutates
-    # config via async_restart, not a full reload, so the setup-time check won't
-    # re-run on its own.
-    evaluate_exhaust_migration_issues(hass, coordinator)
-
+    growspace = _get_growspace(coordinator, call)
+    enabled = bool(call.data.get("enabled"))
+    await _commit_or_raise(
+        hass,
+        coordinator,
+        growspace,
+        EnvironmentPatch(values={"control_dehumidifier": enabled}),
+    )
     status = "enabled" if enabled else "disabled"
     _LOGGER.info("Dehumidifier control %s for '%s'", status, growspace.name)
 
@@ -475,20 +120,14 @@ async def handle_set_humidifier_control(
     call: ServiceCall,
 ) -> None:
     """Handle the set_humidifier_control service call."""
-    growspace_id = call.data.get("growspace_id")
-    enabled = call.data.get("enabled")
-
-    if growspace_id not in coordinator.growspaces:
-        error_msg = f"Growspace '{growspace_id}' not found"
-        _LOGGER.error(error_msg)
-        raise ServiceValidationError(error_msg)
-
-    growspace = coordinator.growspaces[growspace_id]
-    growspace.environment_config.control_humidifier = bool(enabled)
-
-    await coordinator.services.save()
-    await coordinator.services.request_refresh()
-
+    growspace = _get_growspace(coordinator, call)
+    enabled = bool(call.data.get("enabled"))
+    await _commit_or_raise(
+        hass,
+        coordinator,
+        growspace,
+        EnvironmentPatch(values={"control_humidifier": enabled}),
+    )
     status = "enabled" if enabled else "disabled"
     _LOGGER.info("Humidifier control %s for '%s'", status, growspace.name)
 
@@ -499,54 +138,12 @@ async def handle_configure_circulation_fan(
     call: ServiceCall,
 ) -> None:
     """Handle the configure_circulation_fan service call."""
-    growspace_id = call.data.get("growspace_id")
-
-    if growspace_id not in coordinator.growspaces:
-        error_msg = f"Growspace '{growspace_id}' not found"
-        _LOGGER.error(error_msg)
-        raise ServiceValidationError(error_msg)
-
-    growspace = coordinator.growspaces[growspace_id]
-
-    fan_cfg = CirculationFanConfig(
-        enabled=bool(call.data.get("enabled", False)),
-        regulation_mode=FanRegulationMode(
-            call.data.get("regulation_mode", FanRegulationMode.VPD)
-        ),
-        min_speed=int(call.data.get("min_speed", 0)),
-        max_speed=int(call.data.get("max_speed", 100)),
-        vpd_target=float(call.data.get("vpd_target", 1.0)),
-        vpd_tolerance=float(call.data.get("vpd_tolerance", 0.2)),
-        humidity_target=float(call.data.get("humidity_target", 60.0)),
-        humidity_tolerance=float(call.data.get("humidity_tolerance", 5.0)),
-        temperature_target=float(call.data.get("temperature_target", 25.0)),
-        temperature_tolerance=float(call.data.get("temperature_tolerance", 2.0)),
-        critical_temp_low=call.data.get("critical_temp_low"),
-        critical_temp_high=call.data.get("critical_temp_high"),
-        critical_temp_hysteresis=float(call.data.get("critical_temp_hysteresis", 1.0)),
-        wind_enabled=bool(call.data.get("wind_enabled", False)),
-        wind_period_seconds=int(call.data.get("wind_period_seconds", 60)),
-        wind_amplitude_pct=int(call.data.get("wind_amplitude_pct", 10)),
-        stage_vpd_enabled=bool(call.data.get("stage_vpd_enabled", False)),
-        stage_vpd_overrides=_validate_stage_vpd_overrides(
-            call.data.get("stage_vpd_overrides", {})
-        ),
-    )
-
-    if growspace.environment_config is None:
-        growspace.environment_config = EnvironmentConfig()
-
-    growspace.environment_config.circulation_fan_config = fan_cfg
-
-    await coordinator.services.save()
-    await coordinator.services.request_refresh()
-
-    fan_coord = coordinator._subsystem_manager.get_circulation_fan_controller(
-        growspace_id
-    )
-    if fan_coord:
-        await fan_coord.async_restart()
-
+    growspace = _get_growspace(coordinator, call)
+    try:
+        patch = circulation_fan_patch(call.data)
+    except EnvironmentPatchError as err:
+        raise ServiceValidationError(str(err)) from err
+    await _commit_or_raise(hass, coordinator, growspace, patch)
     _LOGGER.info("Circulation fan controller configured for '%s'", growspace.name)
 
 
@@ -557,52 +154,15 @@ async def handle_configure_exhaust_fan(
 ) -> None:
     """Handle the configure_exhaust_fan service call.
 
-    Persists the exhaust fan configuration onto the target growspace and
-    restarts the exhaust controller so the new settings take effect. Exhaust
-    demand is always combined (temperature/humidity/VPD), so there is no
-    regulation mode or wind layer.
+    Exhaust demand is always combined (temperature/humidity/VPD), so there is
+    no regulation mode or wind layer.
     """
-    growspace_id = call.data.get("growspace_id")
-
-    if growspace_id not in coordinator.growspaces:
-        error_msg = f"Growspace '{growspace_id}' not found"
-        _LOGGER.error(error_msg)
-        raise ServiceValidationError(error_msg)
-
-    growspace = coordinator.growspaces[growspace_id]
-
-    fan_cfg = ExhaustFanConfig(
-        enabled=bool(call.data.get("enabled", False)),
-        min_speed=int(call.data.get("min_speed", 0)),
-        max_speed=int(call.data.get("max_speed", 100)),
-        temperature_target=float(call.data.get("temperature_target", 25.0)),
-        temperature_tolerance=float(call.data.get("temperature_tolerance", 2.0)),
-        humidity_target=float(call.data.get("humidity_target", 60.0)),
-        humidity_tolerance=float(call.data.get("humidity_tolerance", 5.0)),
-        vpd_target=float(call.data.get("vpd_target", 1.0)),
-        vpd_tolerance=float(call.data.get("vpd_tolerance", 0.2)),
-        stage_vpd_enabled=bool(call.data.get("stage_vpd_enabled", False)),
-        stage_vpd_overrides=_validate_stage_vpd_overrides(
-            call.data.get("stage_vpd_overrides", {})
-        ),
-        critical_temp_low=call.data.get("critical_temp_low"),
-        critical_temp_high=call.data.get("critical_temp_high"),
-        critical_temp_hysteresis=float(call.data.get("critical_temp_hysteresis", 1.0)),
-    )
-
-    growspace.environment_config.exhaust_fan_config = fan_cfg
-
-    await coordinator.services.save()
-    await coordinator.services.request_refresh()
-
-    fan_coord = coordinator._subsystem_manager.get_exhaust_fan_controller(growspace_id)
-    if fan_coord:
-        await fan_coord.async_restart()
-
-    # Re-evaluate the exhaust-migration repair (ADR-0019): enabling the new
-    # controller here should clear the repair without waiting for a reload.
-    evaluate_exhaust_migration_issues(hass, coordinator)
-
+    growspace = _get_growspace(coordinator, call)
+    try:
+        patch = exhaust_fan_patch(call.data)
+    except EnvironmentPatchError as err:
+        raise ServiceValidationError(str(err)) from err
+    await _commit_or_raise(hass, coordinator, growspace, patch)
     _LOGGER.info("Exhaust fan controller configured for '%s'", growspace.name)
 
 

--- a/custom_components/growspace_manager/services/environment_patch_commit.py
+++ b/custom_components/growspace_manager/services/environment_patch_commit.py
@@ -1,0 +1,77 @@
+"""Effect shell for the Environment Patch write seam (ADR-0026).
+
+The one place the assign → save → refresh → targeted controller restarts →
+exhaust-repair re-evaluation ordering lives. Every runtime writer of
+EnvironmentConfig commits through here; the pure merge law stays in
+``domain/environment_patch.py``. A caller that bypasses this shell (the
+storage-manager migration, deliberately) re-assumes responsibility for
+effects.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ..domain.environment_patch import (
+    EnvironmentPatch,
+    EnvironmentPatchVerdict,
+    apply_environment_patch,
+)
+from ..exhaust_migration import evaluate_exhaust_migration_issues
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from ..coordinator import GrowspaceCoordinator
+    from ..models import Growspace
+
+_LOGGER = logging.getLogger(__name__)
+
+_CONTROLLER_ACCESSORS = {
+    "circulation_fan": "get_circulation_fan_controller",
+    "exhaust_fan": "get_exhaust_fan_controller",
+    "growlight": "get_growlight_controller",
+}
+
+
+async def async_commit_environment_patch(
+    hass: HomeAssistant,
+    coordinator: GrowspaceCoordinator,
+    growspace: Growspace,
+    patch: EnvironmentPatch,
+) -> EnvironmentPatchVerdict:
+    """Apply an Environment Patch to the growspace and perform every effect.
+
+    Order: assign the merged config → save → request refresh → restart each
+    sub-controller named in the verdict (only controllers whose fields
+    actually changed) → re-evaluate the exhaust-migration repair (ADR-0019)
+    when a trigger field changed. Returns the verdict so callers can emit
+    logbook text.
+    """
+    verdict = apply_environment_patch(growspace.environment_config, patch)
+    for warning in verdict.warnings:
+        _LOGGER.warning(
+            "Environment patch for '%s' dropped %s: %s",
+            growspace.name,
+            warning.field,
+            warning.message,
+        )
+
+    growspace.environment_config = verdict.config
+    await coordinator.services.save()
+    await coordinator.services.request_refresh()
+
+    for controller in sorted(verdict.controllers_to_restart):
+        accessor = getattr(
+            coordinator._subsystem_manager,
+            _CONTROLLER_ACCESSORS[controller],
+        )
+        if sub_coordinator := accessor(growspace.id):
+            await sub_coordinator.async_restart()
+
+    if verdict.exhaust_repair_relevant:
+        evaluate_exhaust_migration_issues(hass, coordinator)
+
+    _LOGGER.info("Environment updated for '%s': %s", growspace.name, verdict.summary)
+    return verdict

--- a/custom_components/growspace_manager/storage_manager.py
+++ b/custom_components/growspace_manager/storage_manager.py
@@ -19,6 +19,11 @@ from .const import (
     STORAGE_KEY_PLANTS,
     STORAGE_VERSION,
 )
+from .domain.environment_patch import (
+    EnvironmentPatchError,
+    apply_environment_patch,
+    patch_from_flow_options,
+)
 from .models import (
     ECRampCurve,
     EnvironmentConfig,
@@ -40,28 +45,6 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-def _preserve_tank_runtime_state(
-    previous: EnvironmentConfig | None, new: EnvironmentConfig
-) -> None:
-    """Carry tank runtime-accumulated state from ``previous`` into ``new``.
-
-    Tanks in the options snapshot only describe configuration; the runtime
-    water tracking (``water_history``, ``last_recorded_level``, ``peak_level``)
-    is accumulated on the persisted growspace and must survive the options
-    merge. Tanks are matched by ``sensor_entity``.
-    """
-    if previous is None:
-        return
-    previous_by_entity = {t.sensor_entity: t for t in previous.irrigation_tanks}
-    for tank in new.irrigation_tanks:
-        existing = previous_by_entity.get(tank.sensor_entity)
-        if existing is None:
-            continue
-        tank.water_history = existing.water_history
-        tank.last_recorded_level = existing.last_recorded_level
-        tank.peak_level = existing.peak_level
-
-
 def _migrate_preset_items(
     presets: dict[str, NutrientPreset],
     inventory: NutrientInventory,
@@ -74,8 +57,7 @@ def _migrate_preset_items(
     string as the nutrient_id value (orphan — frontend surfaces a warning).
     """
     name_to_id: dict[str, str] = {
-        stock.name.lower(): stock.nutrient_id
-        for stock in inventory.stocks.values()
+        stock.name.lower(): stock.nutrient_id for stock in inventory.stocks.values()
     }
 
     for preset in presets.values():
@@ -86,7 +68,9 @@ def _migrate_preset_items(
             else:
                 name: str = item.get("name", "")
                 nutrient_id = name_to_id.get(name.lower(), name)
-                migrated.append({"nutrient_id": nutrient_id, "dose_ml_l": item["dose_ml_l"]})
+                migrated.append(
+                    {"nutrient_id": nutrient_id, "dose_ml_l": item["dose_ml_l"]}
+                )
         preset.items = migrated
 
     return presets
@@ -151,8 +135,12 @@ class StorageManager:
             "growspaces": {
                 gs.id: asdict(gs) for gs in self.repository.get_all_growspaces()
             },
-            "notifications_sent": self.notification_state.sent if self.notification_state else {},
-            "notifications_enabled": self.notification_state.enabled if self.notification_state else {},
+            "notifications_sent": self.notification_state.sent
+            if self.notification_state
+            else {},
+            "notifications_enabled": self.notification_state.enabled
+            if self.notification_state
+            else {},
         }
         # Merge nutrient data (presets and inventory)
         config.update(nutrient_data)
@@ -265,7 +253,7 @@ class StorageManager:
                 key,
                 backup_path,
             )
-        except (OSError, TypeError, ValueError):
+        except OSError, TypeError, ValueError:
             _LOGGER.exception("Failed to backup corrupt %s data", key)
 
     def _load_plants(self, data: dict[str, Any]) -> None:
@@ -292,7 +280,7 @@ class StorageManager:
                             pid,
                             type(pdata),
                         )
-                except (ValueError, KeyError, TypeError):
+                except ValueError, KeyError, TypeError:
                     _LOGGER.exception(
                         "Failed to load plant %s due to data structure mismatch", pid
                     )
@@ -301,7 +289,7 @@ class StorageManager:
 
             self.repository.load_plants(plants)
             _LOGGER.info("Loaded %d plants", len(plants))
-        except (ValueError, KeyError, TypeError):
+        except ValueError, KeyError, TypeError:
             _LOGGER.exception("Critical data structure error loading plants")
             self._backup_corrupt_data("plants", data)
             self.repository.load_plants({})
@@ -336,7 +324,7 @@ class StorageManager:
                             gid,
                             type(gdata),
                         )
-                except (ValueError, KeyError, TypeError):
+                except ValueError, KeyError, TypeError:
                     _LOGGER.exception(
                         "Failed to load growspace %s due to data structure mismatch",
                         gid,
@@ -348,7 +336,7 @@ class StorageManager:
             _LOGGER.info("Loaded %d growspaces", len(growspaces))
 
             self._apply_options_to_growspaces(options)
-        except (ValueError, KeyError, TypeError):
+        except ValueError, KeyError, TypeError:
             _LOGGER.exception("Critical data structure error loading growspaces")
             self._backup_corrupt_data("growspaces", data)
             self.repository.load_growspaces({})
@@ -358,28 +346,40 @@ class StorageManager:
             self.repository.load_growspaces({})
 
     def _apply_options_to_growspaces(self, options: dict[str, Any] | None) -> None:
-        """Apply configuration options to loaded growspaces.
+        """One-time migration: adopt legacy per-growspace options blobs (ADR-0026).
 
-        The config entry options are the source of truth for environment
-        *configuration* (sensor entities, thresholds, tank setup), but tanks
-        also carry runtime-accumulated state (water_history, last_recorded_level,
-        peak_level) that lives only in the persisted growspace, not in options.
-        Replacing environment_config wholesale would discard that runtime state
-        on every restart, so it is carried over from the loaded growspace.
+        Nothing writes per-growspace environment blobs into config-entry
+        options anymore — the growspace store is the single source of truth.
+        A blob is adopted only when the store has no environment config for
+        that growspace (all defaults), covering installs that predate the
+        store-first write path; a store with real config always wins.
+        Blob deletion happens in async_setup_entry after load.
         """
         if not options:
             return
 
+        default_config = EnvironmentConfig()
         for growspace in self.repository.get_all_growspaces():
-            if growspace.id in options:
-                opts = options[growspace.id]
-                if isinstance(opts, dict):
-                    previous_config = growspace.environment_config
-                    new_config = EnvironmentConfig.from_dict(opts)
-                    _preserve_tank_runtime_state(previous_config, new_config)
-                    growspace.environment_config = new_config
-                else:
-                    growspace.environment_config = opts
+            opts = options.get(growspace.id)
+            if not isinstance(opts, dict):
+                continue
+            if growspace.environment_config != default_config:
+                continue
+            try:
+                growspace.environment_config = apply_environment_patch(
+                    None, patch_from_flow_options(opts)
+                ).config
+            except EnvironmentPatchError as err:
+                # A malformed legacy blob must not brick startup.
+                _LOGGER.warning(
+                    "Ignoring invalid legacy options environment config for %s: %s",
+                    growspace.id,
+                    err,
+                )
+            else:
+                _LOGGER.info(
+                    "Adopted legacy options environment config for %s", growspace.id
+                )
 
     def _load_nutrient_presets(self, data: dict[str, Any]) -> dict[str, NutrientPreset]:
         """Load nutrient presets from storage data."""

--- a/tests/config/test_config_flow.py
+++ b/tests/config/test_config_flow.py
@@ -57,10 +57,14 @@ def mock_coordinator(hass: HomeAssistant, tmp_path: Path):
     coordinator.services = facade
 
     facade.save = AsyncMock()
+    facade.request_refresh = AsyncMock()
     facade.commit = AsyncMock()
     coordinator.async_commit = facade.commit
     coordinator.async_save = facade.save
     coordinator.async_refresh = AsyncMock()
+    coordinator._subsystem_manager.get_circulation_fan_controller.return_value = None
+    coordinator._subsystem_manager.get_exhaust_fan_controller.return_value = None
+    coordinator._subsystem_manager.get_growlight_controller.return_value = None
 
     # --- growspaces sub-facade ---
     gs_facade = MagicMock()
@@ -77,9 +81,7 @@ def mock_coordinator(hass: HomeAssistant, tmp_path: Path):
 
     # --- plants sub-facade ---
     pl_facade = MagicMock()
-    pl_facade.get_plant = MagicMock(
-        side_effect=lambda pid: coordinator.plants.get(pid)
-    )
+    pl_facade.get_plant = MagicMock(side_effect=lambda pid: coordinator.plants.get(pid))
     pl_facade.add_plant = AsyncMock()
     pl_facade.update_plant = AsyncMock()
     pl_facade.remove_plant = AsyncMock()
@@ -94,7 +96,9 @@ def mock_coordinator(hass: HomeAssistant, tmp_path: Path):
         return_value=str(tmp_path / "export.zip")
     )
     cfg_facade.strain_library.remove_strain = AsyncMock()
-    cfg_facade.strain_library.async_delete_strain = cfg_facade.strain_library.remove_strain
+    cfg_facade.strain_library.async_delete_strain = (
+        cfg_facade.strain_library.remove_strain
+    )
     cfg_facade.strain_library.get_all = MagicMock(return_value={})
     cfg_facade.strain_library.get_all_strains = MagicMock(return_value=[])
     cfg_facade.get_strain_options = MagicMock(return_value=[])
@@ -677,7 +681,9 @@ async def test_options_flow_add_growspace_error(
     config_entry = MockConfigEntry(domain=DOMAIN, data={"name": "Test"})
     config_entry.add_to_hass(hass)
     config_entry.runtime_data = mock_coordinator
-    mock_coordinator.services.growspaces.add_growspace.side_effect = Exception("Test error")
+    mock_coordinator.services.growspaces.add_growspace.side_effect = Exception(
+        "Test error"
+    )
     config_entry.runtime_data = mock_coordinator
     hass.services = Mock()
     hass.services.async_services = Mock(return_value={"notify": {}})
@@ -819,7 +825,9 @@ async def test_options_flow_update_growspace_error(
     mock_growspace.plants_per_row = 4
     mock_growspace.notification_target = None
     mock_coordinator.growspaces = {"gs1": mock_growspace}
-    mock_coordinator.services.growspaces.update_growspace.side_effect = Exception("Test error")
+    mock_coordinator.services.growspaces.update_growspace.side_effect = Exception(
+        "Test error"
+    )
 
     config_entry.runtime_data = mock_coordinator
     hass.services = Mock()
@@ -977,7 +985,9 @@ async def test_options_flow_update_plant_success(
     result = await flow.async_step_update_plant(user_input=user_input)
 
     assert result.get("type") == FlowResultType.CREATE_ENTRY
-    mock_coordinator.services.plants.update_plant.assert_awaited_once_with("p1", **user_input)
+    mock_coordinator.services.plants.update_plant.assert_awaited_once_with(
+        "p1", **user_input
+    )
 
 
 @pytest.mark.asyncio
@@ -1078,7 +1088,10 @@ async def test_get_add_plant_schema_with_strain_options(
 
     handler = PlantConfigHandler(hass, config_entry)
     mock_growspace = Mock(name="Growspace 1", rows=4, plants_per_row=4)
-    mock_coordinator.services.config.get_strain_options.return_value = ["Strain 1", "Strain 2"]
+    mock_coordinator.services.config.get_strain_options.return_value = [
+        "Strain 1",
+        "Strain 2",
+    ]
 
     schema = handler.get_add_plant_schema(
         growspace=mock_growspace, coordinator=mock_coordinator
@@ -1104,7 +1117,10 @@ async def test_get_update_plant_schema_no_growspace(
     mock_plant = Mock(strain="Test Strain", row=1, col=1, growspace_id="gs1")
     mock_growspace = Mock(name="Growspace 1", rows=4, plants_per_row=4)
     mock_coordinator.growspaces = {"gs1": mock_growspace}
-    mock_coordinator.services.config.get_strain_options.return_value = ["Strain 1", "Strain 2"]
+    mock_coordinator.services.config.get_strain_options.return_value = [
+        "Strain 1",
+        "Strain 2",
+    ]
 
     schema = handler.get_update_plant_schema(
         plant=mock_plant, coordinator=mock_coordinator
@@ -1155,7 +1171,10 @@ async def test_get_update_plant_schema_with_strain_options(
     mock_plant = Mock(strain="Test Strain", row=1, col=1, growspace_id="gs1")
     mock_growspace = Mock(name="Growspace 1", rows=4, plants_per_row=4)
     mock_coordinator.growspaces = {"gs1": mock_growspace}
-    mock_coordinator.services.config.get_strain_options.return_value = ["Strain 1", "Strain 2"]
+    mock_coordinator.services.config.get_strain_options.return_value = [
+        "Strain 1",
+        "Strain 2",
+    ]
 
     schema = handler.get_update_plant_schema(
         plant=mock_plant, coordinator=mock_coordinator
@@ -1428,7 +1447,9 @@ async def test_options_flow_manage_timed_notifications_edit(
     )
     config_entry.add_to_hass(hass)
     config_entry.runtime_data = mock_coordinator
-    mock_coordinator.services.notifications.get_timed_notifications.return_value = notifications
+    mock_coordinator.services.notifications.get_timed_notifications.return_value = (
+        notifications
+    )
     config_entry.runtime_data = mock_coordinator
 
     flow = OptionsFlowHandler(config_entry)
@@ -1469,7 +1490,9 @@ async def test_options_flow_edit_timed_notification_success(
     )
     config_entry.add_to_hass(hass)
     config_entry.runtime_data = mock_coordinator
-    mock_coordinator.services.notifications.get_timed_notifications.return_value = notifications
+    mock_coordinator.services.notifications.get_timed_notifications.return_value = (
+        notifications
+    )
     config_entry.runtime_data = mock_coordinator
 
     flow = OptionsFlowHandler(config_entry)
@@ -1521,7 +1544,9 @@ async def test_options_flow_manage_timed_notifications_delete(
     )
     config_entry.add_to_hass(hass)
     config_entry.runtime_data = mock_coordinator
-    mock_coordinator.services.notifications.get_timed_notifications.return_value = notifications
+    mock_coordinator.services.notifications.get_timed_notifications.return_value = (
+        notifications
+    )
     config_entry.runtime_data = mock_coordinator
 
     flow = OptionsFlowHandler(config_entry)
@@ -1538,7 +1563,9 @@ async def test_options_flow_manage_timed_notifications_delete(
     result = await flow.async_step_delete_timed_notification(user_input={})
 
     assert result.get("type") == FlowResultType.CREATE_ENTRY
-    mock_coordinator.services.notifications.remove_timed_notification.assert_called_once_with("123")
+    mock_coordinator.services.notifications.remove_timed_notification.assert_called_once_with(
+        "123"
+    )
 
 
 # ============================================================================
@@ -2579,7 +2606,9 @@ async def test_options_flow_import_strain_library_submit(
 
     config_entry.runtime_data = mock_coordinator
     mock_coordinator.services.config.strain_library.async_load = AsyncMock()
-    mock_coordinator.services.config.strain_library.import_library_from_zip = AsyncMock()
+    mock_coordinator.services.config.strain_library.import_library_from_zip = (
+        AsyncMock()
+    )
 
     flow = OptionsFlowHandler(config_entry)
     flow.hass = hass
@@ -3146,26 +3175,22 @@ async def test_options_flow_import_strain_library_errors(
     flow.hass = hass
 
     # 1. File Not Found
-    mock_coordinator.services.config.strain_library.import_library_from_zip.side_effect = (
-        FileNotFoundError
-    )
+    mock_coordinator.services.config.strain_library.import_library_from_zip.side_effect = FileNotFoundError
     result = await flow.async_step_import_strain_library(
         user_input={"file_path": "bad"}
     )
     assert result["errors"] == {"base": "file_not_found"}
 
     # 2. Invalid Zip
-    mock_coordinator.services.config.strain_library.import_library_from_zip.side_effect = (
-        ValueError
-    )
+    mock_coordinator.services.config.strain_library.import_library_from_zip.side_effect = ValueError
     result = await flow.async_step_import_strain_library(
         user_input={"file_path": "bad.zip"}
     )
     assert result["errors"] == {"base": "invalid_zip"}
 
     # 3. Generic Exception
-    mock_coordinator.services.config.strain_library.import_library_from_zip.side_effect = (
-        Exception("Boom")
+    mock_coordinator.services.config.strain_library.import_library_from_zip.side_effect = Exception(
+        "Boom"
     )
     result = await flow.async_step_import_strain_library(
         user_input={"file_path": "bad.zip"}
@@ -3409,7 +3434,9 @@ async def test_options_flow_manage_growspaces_remove_error(
     flow.growspace_handler.get_growspace_management_schema = Mock(  # type: ignore[method-assign]
         return_value=vol.Schema({})
     )
-    mock_coordinator.services.growspaces.remove_growspace.side_effect = Exception("Del Err")
+    mock_coordinator.services.growspaces.remove_growspace.side_effect = Exception(
+        "Del Err"
+    )
 
     mock_coordinator.growspaces = {"gs1": Mock(name="Growspace 1")}
     # Need to simulate the call from manage_growspaces
@@ -3461,8 +3488,8 @@ async def test_options_flow_export_strain_library_error(
     flow = OptionsFlowHandler(config_entry)
     flow.hass = hass
 
-    mock_coordinator.services.config.strain_library.export_library_to_zip.side_effect = (
-        Exception("Exp Err")
+    mock_coordinator.services.config.strain_library.export_library_to_zip.side_effect = Exception(
+        "Exp Err"
     )
 
     result = await flow.async_step_export_strain_library()
@@ -3495,7 +3522,9 @@ async def test_options_flow_strain_library_delete_success(
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "manage_strain_library"
     assert "errors" not in result or not result["errors"]
-    mock_coordinator.services.config.strain_library.remove_strain.assert_called_once_with("s1")
+    mock_coordinator.services.config.strain_library.remove_strain.assert_called_once_with(
+        "s1"
+    )
 
 
 @pytest.mark.asyncio
@@ -3564,7 +3593,10 @@ async def test_fan_controller_handler_property(
         ("async_step_configure_fan_controller", "async_step_configure_fan_controller"),
         ("async_step_configure_fan_vpd", "async_step_configure_fan_vpd"),
         ("async_step_configure_fan_humidity", "async_step_configure_fan_humidity"),
-        ("async_step_configure_fan_temperature", "async_step_configure_fan_temperature"),
+        (
+            "async_step_configure_fan_temperature",
+            "async_step_configure_fan_temperature",
+        ),
         ("async_step_configure_fan_wind", "async_step_configure_fan_wind"),
     ],
 )
@@ -3695,4 +3727,3 @@ async def test_async_step_save_and_finish_success(
     mock_save_and_finish.assert_called_once_with(
         growspace, {"temp_sensor": "sensor.temp"}
     )
-

--- a/tests/config/test_dehumidifier_config_flow.py
+++ b/tests/config/test_dehumidifier_config_flow.py
@@ -50,8 +50,13 @@ async def test_configure_dehumidifier_thresholds(
     ]
     mock_coordinator.services.growspaces.get_growspace.return_value = mock_growspace
     mock_coordinator.services.save = AsyncMock()
+    mock_coordinator.services.request_refresh = AsyncMock()
     mock_coordinator.async_refresh = AsyncMock()
-
+    mock_coordinator._subsystem_manager.get_circulation_fan_controller.return_value = (
+        None
+    )
+    mock_coordinator._subsystem_manager.get_exhaust_fan_controller.return_value = None
+    mock_coordinator._subsystem_manager.get_growlight_controller.return_value = None
 
     entry.runtime_data = mock_coordinator
     entry.add_to_hass(hass)

--- a/tests/config/test_fan_controller_config_flow.py
+++ b/tests/config/test_fan_controller_config_flow.py
@@ -45,7 +45,13 @@ def _make_entry_with_growspace(
     ]
     mock_coordinator.services.growspaces.get_growspace.return_value = mock_growspace
     mock_coordinator.services.save = AsyncMock()
+    mock_coordinator.services.request_refresh = AsyncMock()
     mock_coordinator.async_refresh = AsyncMock()
+    mock_coordinator._subsystem_manager.get_circulation_fan_controller.return_value = (
+        None
+    )
+    mock_coordinator._subsystem_manager.get_exhaust_fan_controller.return_value = None
+    mock_coordinator._subsystem_manager.get_growlight_controller.return_value = None
 
     entry.runtime_data = mock_coordinator
     entry.add_to_hass(hass)
@@ -53,9 +59,7 @@ def _make_entry_with_growspace(
     return entry, mock_coordinator, mock_growspace
 
 
-async def _navigate_to_env_step1(
-    hass: HomeAssistant, entry: MockConfigEntry
-) -> dict:
+async def _navigate_to_env_step1(hass: HomeAssistant, entry: MockConfigEntry) -> dict:
     """Navigate through options flow to the configure_environment step."""
     mock_component(hass, "recorder")
 

--- a/tests/config_handlers/test_environment_sensors_handler.py
+++ b/tests/config_handlers/test_environment_sensors_handler.py
@@ -45,7 +45,11 @@ def _make_flow(
         ("gs1", "Test Tent")
     ]
     coordinator.services.save = AsyncMock()
+    coordinator.services.request_refresh = AsyncMock()
     coordinator.async_refresh = AsyncMock()
+    coordinator._subsystem_manager.get_circulation_fan_controller.return_value = None
+    coordinator._subsystem_manager.get_exhaust_fan_controller.return_value = None
+    coordinator._subsystem_manager.get_growlight_controller.return_value = None
 
     config_entry = MagicMock()
     config_entry.runtime_data = coordinator
@@ -401,56 +405,29 @@ def test_process_irrigation_tanks_uses_friendly_name_from_state() -> None:
     assert result["irrigation_tanks"][0]["name"] == "Main Reservoir"
 
 
-def test_process_irrigation_tanks_preserves_existing_dataclass_tank_data() -> None:
-    """Existing IrrigationTank dataclass → water_history, levels are preserved."""
+def test_process_irrigation_tanks_emits_no_runtime_keys() -> None:
+    """The form conversion carries no runtime state (ADR-0026).
+
+    Tank runtime carry-over (water_history, levels) is owned by the Environment
+    Patch merge, matched per item by sensor_entity — the flow's tank dicts stay
+    pure form data so they can never clobber it.
+    """
     flow = _make_flow()
     flow.hass.states.get.return_value = None
     handler = EnvironmentSensorsHandler(flow)
 
-    existing_tank = IrrigationTank(
-        sensor_entity="sensor.tank1",
-        name="Old Tank",
-        last_recorded_level=55.0,
-        peak_level=90.0,
-    )
     result = handler._process_irrigation_tanks(
         {
             CONF_IRRIGATION_TANK_SENSORS: ["sensor.tank1"],
             CONF_IRRIGATION_TANK_WARNING_LEVEL: 30.0,
-        },
-        existing_tanks=[existing_tank],
+        }
     )
 
     tank = result["irrigation_tanks"][0]
-    assert tank["last_recorded_level"] == 55.0
-    assert tank["peak_level"] == 90.0
-
-
-def test_process_irrigation_tanks_preserves_existing_dict_tank_data() -> None:
-    """Existing tank as a plain dict → water_history, levels are preserved."""
-    flow = _make_flow()
-    flow.hass.states.get.return_value = None
-    handler = EnvironmentSensorsHandler(flow)
-
-    existing_tank_dict: dict = {
-        "sensor_entity": "sensor.tank1",
-        "name": "Dict Tank",
-        "last_recorded_level": 42.5,
-        "peak_level": 80.0,
-        "water_history": {"some": "data"},
-    }
-    result = handler._process_irrigation_tanks(
-        {
-            CONF_IRRIGATION_TANK_SENSORS: ["sensor.tank1"],
-            CONF_IRRIGATION_TANK_WARNING_LEVEL: 30.0,
-        },
-        existing_tanks=[existing_tank_dict],  # type: ignore[list-item]
-    )
-
-    tank = result["irrigation_tanks"][0]
-    assert tank["last_recorded_level"] == 42.5
-    assert tank["peak_level"] == 80.0
-    assert tank["water_history"] == {"some": "data"}
+    assert tank["warning_level"] == 30.0
+    assert "water_history" not in tank
+    assert "last_recorded_level" not in tank
+    assert "peak_level" not in tank
 
 
 # ---------------------------------------------------------------------------
@@ -475,7 +452,7 @@ async def test_async_save_and_finish_saves_env_config_and_returns_entry() -> Non
     assert result["type"] == "create_entry"
     assert growspace.environment_config is not None
     flow.config_entry.runtime_data.services.save.assert_awaited_once()
-    flow.config_entry.runtime_data.async_refresh.assert_awaited_once()
+    flow.config_entry.runtime_data.services.request_refresh.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -56,8 +56,12 @@ def mock_coordinator():
     coordinator._growspace_manager.async_update_growspace = AsyncMock()
     coordinator._growspace_manager.async_remove_growspace = AsyncMock()
     coordinator._growspace_manager.async_update_environment_config = AsyncMock()
-    coordinator._growspace_manager.ensure_special_growspace = MagicMock(return_value="special_gs")
-    coordinator._growspace_manager.get_sorted_growspace_options = MagicMock(return_value=[])
+    coordinator._growspace_manager.ensure_special_growspace = MagicMock(
+        return_value="special_gs"
+    )
+    coordinator._growspace_manager.get_sorted_growspace_options = MagicMock(
+        return_value=[]
+    )
 
     # Clone manager methods
     coordinator.clone_manager.async_take_clones = AsyncMock(return_value=["clone_1"])
@@ -100,6 +104,11 @@ def mock_coordinator():
     _growlight_coord_mock.async_restart = AsyncMock()
     coordinator._subsystem_manager.get_growlight_controller = MagicMock(
         return_value=_growlight_coord_mock
+    )
+    _exhaust_coord_mock = MagicMock()
+    _exhaust_coord_mock.async_restart = AsyncMock()
+    coordinator._subsystem_manager.get_exhaust_fan_controller = MagicMock(
+        return_value=_exhaust_coord_mock
     )
 
     # Initialize ServiceFacade AFTER all async mocks are set so the facade's

--- a/tests/core/test_services_environment.py
+++ b/tests/core/test_services_environment.py
@@ -53,7 +53,7 @@ def mock_call():
 def mock_exhaust_migration():
     """Patch the migration repair helper (it needs a real issue registry)."""
     with patch(
-        "custom_components.growspace_manager.services.environment"
+        "custom_components.growspace_manager.services.environment_patch_commit"
         ".evaluate_exhaust_migration_issues"
     ) as mock_eval:
         yield mock_eval
@@ -121,7 +121,9 @@ async def test_handle_configure_environment_preserves_exhaust_fan_config(
     preserved = mock_gs.environment_config.exhaust_fan_config
     assert preserved.enabled is True
     assert preserved.max_speed == 70
-    mock_exhaust_migration.assert_called_once_with(mock_hass, mock_coordinator)
+    # No exhaust-relevant field changed, so the repair re-evaluation is skipped
+    # (change-driven under ADR-0026, no longer unconditional).
+    mock_exhaust_migration.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -188,7 +190,10 @@ async def test_handle_configure_environment_restarts_growlight_controller(
     mock_coordinator._subsystem_manager.get_growlight_controller.return_value = (
         growlight_coord
     )
-    mock_call.data = {"growspace_id": "gs1", CONF_TEMP_SENSOR: "sensor.temp"}
+    # veg_day_hours moves the photoperiod window the grow light derives its
+    # schedule from — a growlight-relevant change under ADR-0026's
+    # change-driven restarts.
+    mock_call.data = {"growspace_id": "gs1", "veg_day_hours": 20}
 
     await handle_configure_environment(mock_hass, mock_coordinator, mock_call)
 

--- a/tests/core/test_storage_tank_water_persist.py
+++ b/tests/core/test_storage_tank_water_persist.py
@@ -1,4 +1,12 @@
-"""Regression test: tank water_history must survive restart (options merge)."""
+"""Regression tests: the growspace store owns environment_config (ADR-0026).
+
+Historically ``_apply_options_to_growspaces`` replaced the store's
+environment_config with the per-growspace options blob on every restart,
+wiping runtime-accumulated tank state (the restart-reset bug) and silently
+reverting service-made edits. Nothing writes those blobs anymore: on load a
+blob is adopted only when the store has no environment config, and otherwise
+ignored.
+"""
 
 from dataclasses import asdict
 from unittest.mock import MagicMock
@@ -60,16 +68,15 @@ def _tank_with_events(events: int) -> IrrigationTank:
     )
 
 
-def test_runtime_water_history_survives_options_merge(
+def test_stale_options_blob_is_ignored_on_load(
     storage: StorageManager, repository_mock: MagicMock
 ) -> None:
-    """Storage holds fresh runtime events; options holds a stale snapshot.
+    """A store with real environment config wins over a stale options blob.
 
-    On load the options snapshot must not clobber the runtime-accumulated
-    tank water_history (the restart-reset bug).
+    The store carries runtime events and the freshest config edits (which may
+    have been made via services and never reached options); re-applying the
+    blob would revert both.
     """
-    # Storage growspace: 10 runtime consumption events accumulated since the
-    # last config-flow save, with a stale warning_level config value.
     storage_tank = _tank_with_events(10)
     storage_tank.warning_level = 10.0
     storage_gs = Growspace(
@@ -81,9 +88,7 @@ def test_runtime_water_history_survives_options_merge(
     )
     data = {"growspaces": {"gs1": asdict(storage_gs)}}
 
-    # Config-entry options: the environment_config as last written by the config
-    # flow — same tank but NO accumulated runtime events and updated config
-    # values (warning_level, stress_threshold).
+    # A stale snapshot from the era when the config flow wrote options blobs.
     options_tank = IrrigationTank(
         sensor_entity="sensor.tank_1", volume_liters=200.0, warning_level=25.0
     )
@@ -97,10 +102,50 @@ def test_runtime_water_history_survives_options_merge(
 
     loaded = repository_mock.growspaces["gs1"]
     tank = loaded.environment_config.irrigation_tanks[0]
-    # Runtime-accumulated state survives the options merge.
     assert len(tank.water_history.events) == 10, "runtime events were wiped on load"
     assert tank.last_recorded_level == 42.0
     assert tank.peak_level == 80.0
-    # Configuration from options still wins over the persisted snapshot.
-    assert tank.warning_level == 25.0
+    assert tank.warning_level == 10.0, "stale blob reverted a store config value"
+    assert loaded.environment_config.stress_threshold == 0.5
+
+
+def test_legacy_blob_adopted_when_store_has_no_env_config(
+    storage: StorageManager, repository_mock: MagicMock
+) -> None:
+    """An install predating the store-first write path adopts its blob once.
+
+    The blob's own serialized runtime values come along — there is nothing in
+    the store to carry over.
+    """
+    storage_gs = Growspace(id="gs1", name="Tent")
+    data = {"growspaces": {"gs1": asdict(storage_gs)}}
+
+    blob_tank = _tank_with_events(3)
+    blob_tank.warning_level = 25.0
+    options = {
+        "gs1": asdict(
+            EnvironmentConfig(irrigation_tanks=[blob_tank], stress_threshold=0.9)
+        ),
+    }
+
+    storage._load_growspaces(data, options)
+
+    loaded = repository_mock.growspaces["gs1"]
+    tank = loaded.environment_config.irrigation_tanks[0]
     assert loaded.environment_config.stress_threshold == 0.9
+    assert tank.warning_level == 25.0
+    assert len(tank.water_history.events) == 3
+    assert tank.last_recorded_level == 42.0
+
+
+def test_non_dict_blob_is_ignored(
+    storage: StorageManager, repository_mock: MagicMock
+) -> None:
+    """A malformed legacy blob must not brick startup or touch the store."""
+    storage_gs = Growspace(id="gs1", name="Tent")
+    data = {"growspaces": {"gs1": asdict(storage_gs)}}
+
+    storage._load_growspaces(data, {"gs1": "not-a-dict"})
+
+    loaded = repository_mock.growspaces["gs1"]
+    assert loaded.environment_config == EnvironmentConfig()

--- a/tests/domain/test_environment_patch.py
+++ b/tests/domain/test_environment_patch.py
@@ -693,9 +693,15 @@ def test_sub_config_instance_passes_through() -> None:
     assert patch.values["growlight_config"] is cfg
 
 
-def test_sub_config_null_resets_to_defaults() -> None:
-    """Null sub-config is a deliberate reset to dataclass defaults."""
+def test_sub_config_null_means_keep() -> None:
+    """Null sub-config keeps the existing one (historic service contract)."""
     patch = patch_from_service_call({"vision_checkup_config": None})
+    assert "vision_checkup_config" not in patch.values
+
+
+def test_sub_config_empty_dict_resets_to_defaults() -> None:
+    """The explicit reset is an empty dict, replacing whole with defaults."""
+    patch = patch_from_service_call({"vision_checkup_config": {}})
     assert patch.values["vision_checkup_config"] == VisionCheckupConfig()
 
 

--- a/tests/integration/test_circulation_fan_coordinator.py
+++ b/tests/integration/test_circulation_fan_coordinator.py
@@ -1366,14 +1366,14 @@ def test_stage_vpd_overrides_validation(
     bad_overrides: dict,
     match: str,
 ) -> None:
-    """_validate_stage_vpd_overrides rejects out-of-range values, unknown keys, and incomplete entries."""
-    from custom_components.growspace_manager.services.environment import (
-        _validate_stage_vpd_overrides,
+    """validate_stage_vpd_overrides rejects out-of-range values, unknown keys, and incomplete entries."""
+    from custom_components.growspace_manager.domain.environment_patch import (
+        EnvironmentPatchError,
+        validate_stage_vpd_overrides,
     )
-    from homeassistant.exceptions import ServiceValidationError
 
-    with pytest.raises(ServiceValidationError, match=match):
-        _validate_stage_vpd_overrides(bad_overrides)
+    with pytest.raises(EnvironmentPatchError, match=match):
+        validate_stage_vpd_overrides(bad_overrides)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_config_handlers_environment_coverage.py
+++ b/tests/integration/test_config_handlers_environment_coverage.py
@@ -1,6 +1,5 @@
 """Coverage-focused tests for EnvironmentConfigHandler."""
 
-from dataclasses import asdict
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -21,7 +20,6 @@ from custom_components.growspace_manager.models import (
     EnvironmentConfig,
     Growspace,
     IrrigationTank,
-    TankWaterHistory,
 )
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.data_entry_flow import FlowResultType
@@ -68,7 +66,11 @@ def handler():
 
     coordinator.services = MagicMock()
     coordinator.services.save = AsyncMock()
+    coordinator.services.request_refresh = AsyncMock()
     coordinator.services.growspaces = gs_facade
+    coordinator._subsystem_manager.get_circulation_fan_controller.return_value = None
+    coordinator._subsystem_manager.get_exhaust_fan_controller.return_value = None
+    coordinator._subsystem_manager.get_growlight_controller.return_value = None
 
     handler.config_entry = MagicMock()
     handler.config_entry.runtime_data = coordinator
@@ -769,30 +771,6 @@ def test_process_irrigation_tanks_comprehensive(
         side_effect=lambda entity: mock_state if entity == "sensor.tank_1" else None
     )
 
-    # Mock existing tanks - one object (IrrigationTank) and one dict to cover lines 251-258 and 281-296
-    history_obj = TankWaterHistory(
-        snapshots=[{"timestamp": "2026-05-19", "level_pct": 50.0}], events=[]
-    )
-    tank_obj = IrrigationTank(
-        sensor_entity="sensor.tank_1",
-        warning_level=20.0,
-        volume_liters=100.0,
-    )
-    tank_obj.water_history = history_obj
-    tank_obj.last_recorded_level = 50.0
-    tank_obj.peak_level = 95.0
-
-    tank_dict = {
-        "sensor_entity": "sensor.tank_2",
-        "warning_level": 25.0,
-        "volume_liters": 150.0,
-        "water_history": "raw_history_string_or_dict",
-        "last_recorded_level": 40.0,
-        "peak_level": 85.0,
-    }
-
-    existing_tanks = [tank_obj, tank_dict]
-
     # Call _process_irrigation_tanks
     env_config = {
         "irrigation_tank_sensors": ["sensor.tank_1", "sensor.tank_2", "sensor.tank_3"],
@@ -800,9 +778,7 @@ def test_process_irrigation_tanks_comprehensive(
         "irrigation_tank_volume": 120.0,
     }
 
-    result = handler._process_irrigation_tanks(
-        env_config, existing_tanks=existing_tanks
-    )
+    result = handler._process_irrigation_tanks(env_config)
 
     # Validate output
     assert "irrigation_tank_sensors" not in result
@@ -812,25 +788,26 @@ def test_process_irrigation_tanks_comprehensive(
     tanks = result["irrigation_tanks"]
     assert len(tanks) == 3
 
-    # Tank 1 (state object exists, friendly name lookup used, existing was object)
+    # Tank 1 (state object exists, friendly name lookup used)
     t1 = tanks[0]
     assert t1["sensor_entity"] == "sensor.tank_1"
     assert t1["name"] == "My Custom Tank"
     assert t1["warning_level"] == 35.0
     assert t1["volume_liters"] == 120.0
-    assert t1["water_history"] == asdict(history_obj)
-    assert t1["last_recorded_level"] == 50.0
-    assert t1["peak_level"] == 95.0
+    # Runtime carry-over is the Environment Patch merge's job (ADR-0026)
+    assert "water_history" not in t1
+    assert "last_recorded_level" not in t1
+    assert "peak_level" not in t1
 
-    # Tank 2 (no state object, friendly name fallback used, existing was dict)
+    # Tank 2 (no state object, friendly name fallback used)
     t2 = tanks[1]
     assert t2["sensor_entity"] == "sensor.tank_2"
     assert t2["name"] == "Tank 2"
     assert t2["warning_level"] == 35.0
     assert t2["volume_liters"] == 120.0
-    assert t2["water_history"] == "raw_history_string_or_dict"
-    assert t2["last_recorded_level"] == 40.0
-    assert t2["peak_level"] == 85.0
+    assert "water_history" not in t2
+    assert "last_recorded_level" not in t2
+    assert "peak_level" not in t2
 
     # Tank 3 (new tank, no existing runtime data)
     t3 = tanks[2]
@@ -894,8 +871,6 @@ def test_lst_offset_default_for_dry_and_cure_stages(
             break
     assert lst_key is not None
     assert lst_key.default() == -2.0
-
-
 
 
 @pytest.mark.asyncio
@@ -994,28 +969,13 @@ async def test_process_irrigation_tanks_edge_cases(
     """Test _process_irrigation_tanks logic with missing/None fields. Covers lines 262->256, 302->307, 307->309, 309->311."""
     handler.hass.states.get = MagicMock(return_value=None)
 
-    # tank_invalid triggers line 262->256 branch (missing sensor_entity key/attr)
-    tank_invalid = {"warning_level": 25.0}
-
-    # tank_none_fields triggers lines 302->307, 307->309, 309->311 branches (None fields)
-    tank_none_fields = {
-        "sensor_entity": "sensor.tank_none",
-        "water_history": None,
-        "last_recorded_level": None,
-        "peak_level": None,
-    }
-
-    existing_tanks = [tank_invalid, tank_none_fields]
-
     env_config = {
         "irrigation_tank_sensors": ["sensor.tank_none"],
         "irrigation_tank_warning_level": 35.0,
         "irrigation_tank_volume": 120.0,
     }
 
-    result = handler._process_irrigation_tanks(
-        env_config, existing_tanks=existing_tanks
-    )
+    result = handler._process_irrigation_tanks(env_config)
 
     tanks = result["irrigation_tanks"]
     assert len(tanks) == 1
@@ -1052,7 +1012,9 @@ async def test_configure_humidifier_branch(handler: EnvironmentConfigHandler) ->
 
 
 @pytest.mark.asyncio
-async def test_configure_humidifier_show_form(handler: EnvironmentConfigHandler) -> None:
+async def test_configure_humidifier_show_form(
+    handler: EnvironmentConfigHandler,
+) -> None:
     """Test async_step_configure_humidifier shows form when user_input is None."""
     gs = Growspace(id="gs1", name="GS1")
     handler.config_entry.runtime_data.growspaces = {"gs1": gs}
@@ -1079,7 +1041,9 @@ async def test_configure_humidifier_abort_growspace_not_found(
     handler: EnvironmentConfigHandler,
 ) -> None:
     """Test async_step_configure_humidifier aborts when growspace is missing."""
-    handler.config_entry.runtime_data.services.growspaces.get_growspace.return_value = None
+    handler.config_entry.runtime_data.services.growspaces.get_growspace.return_value = (
+        None
+    )
     handler.flow.selected_growspace_id = "missing"
 
     result = await handler.async_step_configure_humidifier()

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -77,7 +77,6 @@ async def test_handle_configure_environment_success(
         substrate_temperature_sensors=[],
         camera_entities=[],
         energy_sensors=[],
-        electricity_cost_per_kwh=None,
     )
     mock_coordinator.services.save.assert_awaited_once()
     mock_coordinator.services.request_refresh.assert_awaited_once()

--- a/tests/integration/test_storage_manager_coverage.py
+++ b/tests/integration/test_storage_manager_coverage.py
@@ -49,9 +49,21 @@ def genetics_manager_mock():
 
 
 @pytest.fixture
-def storage(hass: HomeAssistant, repository_mock, nutrient_manager_mock, genetics_manager_mock, notification_state):
+def storage(
+    hass: HomeAssistant,
+    repository_mock,
+    nutrient_manager_mock,
+    genetics_manager_mock,
+    notification_state,
+):
     """Provide a StorageManager instance."""
-    return StorageManager(hass, repository_mock, nutrient_manager_mock, genetics_manager_mock, notification_state)
+    return StorageManager(
+        hass,
+        repository_mock,
+        nutrient_manager_mock,
+        genetics_manager_mock,
+        notification_state,
+    )
 
 
 @pytest.mark.asyncio
@@ -74,8 +86,12 @@ async def test_storage_async_force_save(storage) -> None:
     with (
         patch.object(storage, "_get_config_data", return_value={}),
         patch.object(storage, "_get_plants_data", return_value={}),
-        patch.object(storage.config_store, "async_save", new_callable=AsyncMock) as mock_config_save,
-        patch.object(storage.plants_store, "async_save", new_callable=AsyncMock) as mock_plants_save,
+        patch.object(
+            storage.config_store, "async_save", new_callable=AsyncMock
+        ) as mock_config_save,
+        patch.object(
+            storage.plants_store, "async_save", new_callable=AsyncMock
+        ) as mock_plants_save,
     ):
         await storage.async_force_save()
         mock_config_save.assert_awaited_once()
@@ -125,7 +141,7 @@ async def test_storage_backup_corrupt_data_success(
 async def test_storage_apply_options_object(
     hass: HomeAssistant, repository_mock, nutrient_manager_mock, storage
 ) -> None:
-    """Test applying options when they are already an object."""
+    """A non-dict legacy blob is ignored — options are JSON, objects are bugs."""
     env_config = EnvironmentConfig(temperature_sensor="sensor.temp")
     options = {"gs1": env_config}
     gs = Growspace(id="gs1", name="Test")
@@ -133,7 +149,7 @@ async def test_storage_apply_options_object(
 
     storage._apply_options_to_growspaces(options)
 
-    assert gs.environment_config == env_config
+    assert gs.environment_config == EnvironmentConfig()
 
 
 @pytest.mark.asyncio
@@ -456,7 +472,9 @@ def test_get_genetics_data_returns_empty_when_no_manager(
     hass: HomeAssistant, repository_mock, nutrient_manager_mock
 ) -> None:
     """Test _get_genetics_data returns {} when genetics_manager is None (storage_manager.py:124)."""
-    storage = StorageManager(hass, repository_mock, nutrient_manager_mock, genetics_manager=None)
+    storage = StorageManager(
+        hass, repository_mock, nutrient_manager_mock, genetics_manager=None
+    )
     result = storage._get_genetics_data()
     assert result == {}
 
@@ -465,7 +483,9 @@ def test_load_genetics_early_return_when_no_manager(
     hass: HomeAssistant, repository_mock, nutrient_manager_mock
 ) -> None:
     """Test _load_genetics returns early when genetics_manager is None (storage_manager.py:358)."""
-    storage = StorageManager(hass, repository_mock, nutrient_manager_mock, genetics_manager=None)
+    storage = StorageManager(
+        hass, repository_mock, nutrient_manager_mock, genetics_manager=None
+    )
     # Should not raise - early return when genetics_manager is None
     storage._load_genetics({"seed_batches": {}, "pollination_events": {}})
 
@@ -477,7 +497,9 @@ def test_load_genetics_exception_is_caught(
     genetics_manager_mock,
 ) -> None:
     """Test _load_genetics catches exceptions and logs them (storage_manager.py:374-375)."""
-    storage = StorageManager(hass, repository_mock, nutrient_manager_mock, genetics_manager_mock)
+    storage = StorageManager(
+        hass, repository_mock, nutrient_manager_mock, genetics_manager_mock
+    )
     genetics_manager_mock.load_data.side_effect = Exception("Unexpected error")
     # Should not raise - exception is caught and logged
     storage._load_genetics({"seed_batches": {}, "pollination_events": {}})

--- a/tests/services/test_environment_config.py
+++ b/tests/services/test_environment_config.py
@@ -51,7 +51,7 @@ def mock_call():
 def mock_exhaust_migration():
     """Patch the migration repair helper (it needs a real issue registry)."""
     with patch(
-        "custom_components.growspace_manager.services.environment"
+        "custom_components.growspace_manager.services.environment_patch_commit"
         ".evaluate_exhaust_migration_issues"
     ) as mock_eval:
         yield mock_eval

--- a/tests/services/test_vpd_optimal_overrides_validation.py
+++ b/tests/services/test_vpd_optimal_overrides_validation.py
@@ -1,11 +1,11 @@
-"""Tests for _validate_vpd_optimal_overrides in the environment service."""
+"""Tests for validate_vpd_optimal_overrides in the Environment Patch module."""
 
 import pytest
 
-from custom_components.growspace_manager.services.environment import (
-    _validate_vpd_optimal_overrides,
+from custom_components.growspace_manager.domain.environment_patch import (
+    EnvironmentPatchError,
+    validate_vpd_optimal_overrides,
 )
-from homeassistant.exceptions import ServiceValidationError
 
 
 def _valid_entry() -> dict:
@@ -14,13 +14,13 @@ def _valid_entry() -> dict:
 
 def test_accepts_empty_dict() -> None:
     """Empty override dict is valid and returned as-is."""
-    assert _validate_vpd_optimal_overrides({}) == {}
+    assert validate_vpd_optimal_overrides({}) == {}
 
 
 def test_accepts_valid_sparse_dict() -> None:
     """A dict with a single valid stage entry is accepted and returned."""
     overrides = {"veg": _valid_entry()}
-    assert _validate_vpd_optimal_overrides(overrides) == overrides
+    assert validate_vpd_optimal_overrides(overrides) == overrides
 
 
 def test_accepts_all_nine_valid_stages() -> None:
@@ -39,72 +39,72 @@ def test_accepts_all_nine_valid_stages() -> None:
             "cure",
         )
     }
-    result = _validate_vpd_optimal_overrides(overrides)
+    result = validate_vpd_optimal_overrides(overrides)
     assert result == overrides
 
 
 def test_rejects_unknown_stage_key() -> None:
-    """An unrecognised stage key raises ServiceValidationError."""
-    with pytest.raises(ServiceValidationError, match="Unknown stage key"):
-        _validate_vpd_optimal_overrides({"typo_stage": _valid_entry()})
+    """An unrecognised stage key raises EnvironmentPatchError."""
+    with pytest.raises(EnvironmentPatchError, match="Unknown stage key"):
+        validate_vpd_optimal_overrides({"typo_stage": _valid_entry()})
 
 
 def test_rejects_missing_day_key() -> None:
-    """An entry missing the 'day' key raises ServiceValidationError."""
+    """An entry missing the 'day' key raises EnvironmentPatchError."""
     bad = {"night": {"low": 0.4, "high": 1.0}}
-    with pytest.raises(ServiceValidationError, match="both 'day' and 'night'"):
-        _validate_vpd_optimal_overrides({"veg": bad})
+    with pytest.raises(EnvironmentPatchError, match="both 'day' and 'night'"):
+        validate_vpd_optimal_overrides({"veg": bad})
 
 
 def test_rejects_missing_night_key() -> None:
-    """An entry missing the 'night' key raises ServiceValidationError."""
+    """An entry missing the 'night' key raises EnvironmentPatchError."""
     bad = {"day": {"low": 0.5, "high": 1.2}}
-    with pytest.raises(ServiceValidationError, match="both 'day' and 'night'"):
-        _validate_vpd_optimal_overrides({"veg": bad})
+    with pytest.raises(EnvironmentPatchError, match="both 'day' and 'night'"):
+        validate_vpd_optimal_overrides({"veg": bad})
 
 
 def test_rejects_missing_low_key() -> None:
-    """An entry missing 'low' in the day period raises ServiceValidationError."""
+    """An entry missing 'low' in the day period raises EnvironmentPatchError."""
     bad = {"day": {"high": 1.2}, "night": {"low": 0.4, "high": 1.0}}
-    with pytest.raises(ServiceValidationError, match="'low' and 'high'"):
-        _validate_vpd_optimal_overrides({"veg": bad})
+    with pytest.raises(EnvironmentPatchError, match="'low' and 'high'"):
+        validate_vpd_optimal_overrides({"veg": bad})
 
 
 def test_rejects_missing_high_key() -> None:
-    """An entry missing 'high' in the night period raises ServiceValidationError."""
+    """An entry missing 'high' in the night period raises EnvironmentPatchError."""
     bad = {"day": {"low": 0.5, "high": 1.2}, "night": {"low": 0.4}}
-    with pytest.raises(ServiceValidationError, match="'low' and 'high'"):
-        _validate_vpd_optimal_overrides({"veg": bad})
+    with pytest.raises(EnvironmentPatchError, match="'low' and 'high'"):
+        validate_vpd_optimal_overrides({"veg": bad})
 
 
 def test_rejects_low_greater_than_or_equal_to_high() -> None:
-    """low >= high raises ServiceValidationError."""
+    """low >= high raises EnvironmentPatchError."""
     bad = {"day": {"low": 1.2, "high": 0.5}, "night": {"low": 0.4, "high": 1.0}}
-    with pytest.raises(ServiceValidationError, match="low.*<.*high"):
-        _validate_vpd_optimal_overrides({"veg": bad})
+    with pytest.raises(EnvironmentPatchError, match="low.*<.*high"):
+        validate_vpd_optimal_overrides({"veg": bad})
 
 
 def test_rejects_low_equal_to_high() -> None:
-    """low == high raises ServiceValidationError."""
+    """low == high raises EnvironmentPatchError."""
     bad = {"day": {"low": 1.0, "high": 1.0}, "night": {"low": 0.4, "high": 1.0}}
-    with pytest.raises(ServiceValidationError, match="low.*<.*high"):
-        _validate_vpd_optimal_overrides({"veg": bad})
+    with pytest.raises(EnvironmentPatchError, match="low.*<.*high"):
+        validate_vpd_optimal_overrides({"veg": bad})
 
 
 def test_rejects_value_below_minimum() -> None:
-    """A VPD value below 0.1 kPa raises ServiceValidationError."""
+    """A VPD value below 0.1 kPa raises EnvironmentPatchError."""
     bad = {"day": {"low": 0.05, "high": 1.0}, "night": {"low": 0.4, "high": 1.0}}
-    with pytest.raises(ServiceValidationError, match="out of range"):
-        _validate_vpd_optimal_overrides({"veg": bad})
+    with pytest.raises(EnvironmentPatchError, match="out of range"):
+        validate_vpd_optimal_overrides({"veg": bad})
 
 
 def test_rejects_value_above_maximum() -> None:
-    """A VPD value above 3.0 kPa raises ServiceValidationError."""
+    """A VPD value above 3.0 kPa raises EnvironmentPatchError."""
     bad = {"day": {"low": 0.5, "high": 3.5}, "night": {"low": 0.4, "high": 1.0}}
-    with pytest.raises(ServiceValidationError, match="out of range"):
-        _validate_vpd_optimal_overrides({"veg": bad})
+    with pytest.raises(EnvironmentPatchError, match="out of range"):
+        validate_vpd_optimal_overrides({"veg": bad})
 
 
 def test_none_treated_as_empty_dict() -> None:
     """None input is treated as an empty dict (no overrides)."""
-    assert _validate_vpd_optimal_overrides(None) == {}
+    assert validate_vpd_optimal_overrides(None) == {}


### PR DESCRIPTION
## Summary

`EnvironmentConfig` (~50 fields) had five writers, each with private merge rules — any field a writer didn't name silently reset to defaults. Known casualties: the exhaust-config reset (ADR-0019), the Stage Hysteresis Threshold wipe, the tank water-history clobber, and `electricity_cost_per_kwh` becoming `None`. Separately, `storage_manager` re-applied legacy per-growspace options blobs over the store on **every restart**, even though nothing writes those blobs anymore — silently reverting service-made edits on installs carrying a stale blob.

This PR introduces the **Environment Patch** seam (ADR-0026) and cuts every writer over to it.

## What's in here

**Docs** (`7752b1a`): ADR-0026 + three CONTEXT.md glossary entries ([[Environment Patch]], [[Environment Field Ownership]], [[Environment Patch Verdict]]).

**Pure merge module** (`1a21ede`):
- `ENVIRONMENT_FIELD_OWNERSHIP` beside the model: every field classified (grower-config / runtime-accumulated / sub-config), with singular-shadow aliases and the nested tank-runtime spec (`water_history`/`last_recorded_level`/`peak_level` matched per item by `sensor_entity`). An **import-time completeness check** makes the table total — adding a model field without a row fails every import.
- `domain/environment_patch.py`: writer-specific builders (validation front-loaded) + a total `apply_environment_patch` returning a verdict (fresh config, `changed_fields` by value, `controllers_to_restart`, `exhaust_repair_relevant`, logbook summary). Unknown keys mirror the model's `bayesian_options` catch-all, so advanced Bayesian/trend settings keep working.
- 92 zero-mock tests pinning the regression table; 99% module coverage.

**Cutover + retirement** (`7f18943`):
- `services/environment_patch_commit.py`: one shared effect shell (assign → save → refresh → **targeted** controller restarts → exhaust-repair re-evaluation). All six service handlers and both config-flow environment handlers route through it; the ad-hoc preservation blocks, duplicated validators, and tank runtime-copying are deleted (`services/environment.py`: 641 → 200 lines).
- `storage_manager`: `_apply_options_to_growspaces` is now a one-time adopt-if-missing migration — the growspace store is the single source of truth; a store with real env config always wins. `_preserve_tank_runtime_state` deleted.
- `__init__.py`: legacy options blobs are stripped during setup, before the update listener is registered (no reload loop).

## Behaviour changes

1. **`configure_environment` is now patch semantics**: an omitted field keeps its current value; an explicitly sent empty value clears it. Omission previously wiped config — that was always a bug, never an intent. `services.yaml` updated. Automations relying on omission-to-clear must send explicit empties.
2. **Restarts and the ADR-0019 repair re-evaluation are change-driven**: a save that changes nothing restarts nothing. Config-flow saves now restart affected controllers (they previously never did).
3. **Explicit `null` sub-config means keep** (the historic contract — callers could never distinguish null from absent); the explicit reset is an empty dict. `null` on a non-nullable scalar is dropped with a warning instead of writing a type-invalid `None`.
4. **Restart no longer reverts environment edits**: the options-blob apply is retired; blobs are adopted once only when the store has no env config (pre-store-era installs), then deleted.

## Testing

- Full suite: **4,861 passed**, 46 snapshots, 0 failures.
- New: `tests/domain/test_environment_patch.py` (110 tests incl. edge branches), rewritten storage regression tests (store-wins + adopt-once + malformed-blob), updated flow/handler tests for the change-driven contract.
- Follow-up (plan step 5): audit the Lovelace card's three env-draft seeders for omit-to-clear assumptions — expected clean since the card round-trips full payloads.

ADR: `docs/adr/0026-environment-patch-single-write-seam.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)