### PR TITLE
WS Command Lifecycle: payload-returning handlers + typed error codes (ADR-0027)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -211,6 +211,17 @@ All external callers (sensors, websocket handlers, config flow handlers, service
 
 Infrastructure methods (`save`, `request_refresh`, `fire_event`, `add_timeline_note`) live on the container itself.
 
+## WebSocket API
+
+**WS Command Lifecycle**
+The one owner of everything between a WebSocket message arriving and a result or error leaving: coordinator resolution → handler execution → `send_result` → error mapping, implemented by the registration wrapper in `websocket/_common.py` (ADR-0027). A handler is a payload-returning function `(hass, coordinator, msg) → payload | None` — it never sees the connection, so its return value is its test surface (no mock connections). Each module declares its commands as [[WSCommand]] rows; the registrar loop in `websocket/__init__.py` wraps every row identically. Inline `connection.send_error` calls are forbidden in handlers — an error is a raised typed exception, mapped once by the shared error table.
+
+**WSCommand**
+The declarative row a websocket module contributes: `(type, handler, schema, resolve, sync)`. `resolve="targeted"` resolves the coordinator from ids in the message via `get_for_service_call`; `resolve="any"` uses `get_any` (global commands: strain library, genetics, nutrients, lineage). `sync=True` registers a `@callback` wrapper for cheap reads. Adding a WS command = one handler + one row; the lifecycle is inherited. (The WS command count is asserted in `test_core_init`.)
+
+**Typed Error Codes**
+The five-code wire vocabulary shared with the card (ADR-0005, completed backend-side by ADR-0027): `coordinator_not_ready`, `entity_not_found`, `validation_failed`, `internal_error`, `rate_limited`. Produced by the [[WS Command Lifecycle]] error table from typed exceptions — `EntityNotFoundError`, `CoordinatorNotReadyError`, `RateLimitedError` (subclasses of the existing hierarchy, so service-call paths behave as before) plus the validation family → `validation_failed` and everything else → `internal_error` (with traceback). The card's `errors.ts` types exactly this set and coerces anything else to `internal_error` — so ad-hoc codes are self-defeating and deliberately retired.
+
 ## Sensor Entities
 
 Each computed drying metric is a distinct HA sensor entity:

--- a/custom_components/growspace_manager/exceptions.py
+++ b/custom_components/growspace_manager/exceptions.py
@@ -1,17 +1,40 @@
 """Custom exceptions for the Growspace Manager integration."""
 
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 
 class GrowspaceError(HomeAssistantError):
     """Base error for Growspace Manager."""
 
 
-class PlantNotFoundError(GrowspaceError):
+class EntityNotFoundError(GrowspaceError):
+    """A referenced growspace/plant/record does not exist.
+
+    Maps to the ``entity_not_found`` wire code in the WS Command Lifecycle
+    (ADR-0027); service-call paths treat it as any other GrowspaceError.
+    """
+
+
+class CoordinatorNotReadyError(ServiceValidationError):
+    """No Growspace Manager instance is loaded yet.
+
+    Maps to the ``coordinator_not_ready`` wire code (ADR-0027). Subclasses
+    ServiceValidationError so direct service-call raises keep today's type.
+    """
+
+
+class RateLimitedError(GrowspaceError):
+    """An upstream dependency asked us to back off.
+
+    Maps to the ``rate_limited`` wire code (ADR-0027).
+    """
+
+
+class PlantNotFoundError(EntityNotFoundError):
     """Raised when a plant is not found."""
 
 
-class GrowspaceNotFoundError(GrowspaceError):
+class GrowspaceNotFoundError(EntityNotFoundError):
     """Raised when a growspace is not found."""
 
 

--- a/custom_components/growspace_manager/service_coordinator_locator.py
+++ b/custom_components/growspace_manager/service_coordinator_locator.py
@@ -19,6 +19,7 @@ from .const import (
     ATTR_TARGET_GROWSPACE_ID,
     DOMAIN,
 )
+from .exceptions import CoordinatorNotReadyError
 
 if TYPE_CHECKING:
     from .coordinator import GrowspaceCoordinator
@@ -72,7 +73,12 @@ class ServiceCoordinatorLocator:
         if len(coordinators) == 1:
             return coordinators[0]
 
-        # Unable to determine which coordinator to use
+        if not coordinators:
+            raise CoordinatorNotReadyError(
+                "No Growspace Manager instance is currently loaded."
+            )
+
+        # Multiple instances and no id matched — the caller must disambiguate.
         raise ServiceValidationError(
             "Could not determine which Growspace Manager instance to use. "
             "Please specify a valid growspace_id or plant_id."
@@ -93,7 +99,7 @@ class ServiceCoordinatorLocator:
         """
         coordinators = ServiceCoordinatorLocator._get_loaded_coordinators(hass)
         if not coordinators:
-            raise ServiceValidationError(
+            raise CoordinatorNotReadyError(
                 "No Growspace Manager instance is currently loaded."
             )
         return coordinators[0]

--- a/custom_components/growspace_manager/services/report.py
+++ b/custom_components/growspace_manager/services/report.py
@@ -13,7 +13,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from custom_components.growspace_manager.const import DOMAIN, GrowspaceService
-from custom_components.growspace_manager.exceptions import GrowspaceError
+from custom_components.growspace_manager.exceptions import (
+    GrowspaceError,
+    PlantNotFoundError,
+)
 from custom_components.growspace_manager.models import Plant
 from custom_components.growspace_manager.schemas import EXPORT_GROW_REPORT_SCHEMA
 from homeassistant.components.persistent_notification import (
@@ -107,7 +110,13 @@ async def handle_export_grow_report(
             title="Grow Report Export",
         )
 
-    except (AttributeError, KeyError, ValueError, ServiceValidationError, GrowspaceError) as err:
+    except (
+        AttributeError,
+        KeyError,
+        ValueError,
+        ServiceValidationError,
+        GrowspaceError,
+    ) as err:
         _LOGGER.exception("Failed to export grow report")
         create_notification(
             hass,
@@ -205,7 +214,13 @@ async def _get_plant_timeline_events(
 
     except HomeAssistantError:
         raise
-    except (AttributeError, KeyError, ValueError, ServiceValidationError, GrowspaceError) as err:
+    except (
+        AttributeError,
+        KeyError,
+        ValueError,
+        ServiceValidationError,
+        GrowspaceError,
+    ) as err:
         _LOGGER.warning("Could not fetch logbook events for report: %s", err)
         return []
 
@@ -282,7 +297,13 @@ async def _get_plant_environmental_stats(
 
     except HomeAssistantError:
         raise
-    except (AttributeError, KeyError, ValueError, ServiceValidationError, GrowspaceError) as err:
+    except (
+        AttributeError,
+        KeyError,
+        ValueError,
+        ServiceValidationError,
+        GrowspaceError,
+    ) as err:
         _LOGGER.warning("Could not fetch statistics for the report: %s", err)
 
     return averages
@@ -394,7 +415,13 @@ async def _aggregate_growspace_data(
                             data["environment"]["vpd_avg"] = round(
                                 sum(pts) / len(pts), 2
                             )
-            except (AttributeError, KeyError, ValueError, ServiceValidationError, GrowspaceError) as err:
+            except (
+                AttributeError,
+                KeyError,
+                ValueError,
+                ServiceValidationError,
+                GrowspaceError,
+            ) as err:
                 _LOGGER.warning(
                     "Could not fetch env stats for growspace report: %s", err
                 )
@@ -404,43 +431,21 @@ async def _aggregate_growspace_data(
 
 async def async_websocket_get_grow_report(
     hass: HomeAssistant,
-    connection: Any,
+    coordinator: Any,
     msg: dict[str, Any],
-) -> None:
-    """Handle WebSocket grow report request."""
+) -> dict[str, Any]:
+    """Build the grow report payload (WS Command Lifecycle handler, ADR-0027)."""
+    plant_id = msg.get("plant_id")
+    growspace_id = msg.get("growspace_id")
 
-    from custom_components.growspace_manager.coordinator import (  # noqa: PLC0415
-        GrowspaceCoordinator,
-    )
-
-    try:
-        coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
-        plant_id = msg.get("plant_id")
-        growspace_id = msg.get("growspace_id")
-
-        if plant_id:
-            plant = coordinator._data_repository.get_plant(plant_id)
-            if not plant:
-                connection.send_error(
-                    msg["id"], "not_found", f"Plant {plant_id} not found"
-                )
-                return
-            report_data = await _aggregate_plant_data(hass, coordinator, plant)
-        elif growspace_id:
-            report_data = await _aggregate_growspace_data(
-                hass, coordinator, growspace_id
-            )
-        else:
-            connection.send_error(
-                msg["id"], "invalid_request", "No plant_id or growspace_id"
-            )
-            return
-
-        connection.send_result(msg["id"], report_data)
-
-    except (AttributeError, KeyError, ValueError, ServiceValidationError, GrowspaceError) as err:
-        _LOGGER.exception("Error generating grow report for WebSocket")
-        connection.send_error(msg["id"], "unknown_error", str(err))
+    if plant_id:
+        plant = coordinator._data_repository.get_plant(plant_id)
+        if not plant:
+            raise PlantNotFoundError(f"Plant {plant_id} not found")
+        return await _aggregate_plant_data(hass, coordinator, plant)
+    if growspace_id:
+        return await _aggregate_growspace_data(hass, coordinator, growspace_id)
+    raise ServiceValidationError("No plant_id or growspace_id")
 
 
 def _export_as_json(data: dict[str, Any], file_path: str) -> None:
@@ -455,6 +460,7 @@ def _export_as_pdf(data: dict[str, Any], file_path: str) -> None:
         from fpdf import FPDF  # noqa: PLC0415
     except ImportError as err:
         from homeassistant.exceptions import HomeAssistantError  # noqa: PLC0415
+
         raise HomeAssistantError(
             "PDF export requires the 'fpdf2' package. Install it with: pip install fpdf2>=2.7.9"
         ) from err

--- a/custom_components/growspace_manager/services/utils.py
+++ b/custom_components/growspace_manager/services/utils.py
@@ -22,6 +22,7 @@ WS_ERR_COORDINATOR_NOT_READY = "coordinator_not_ready"
 WS_ERR_ENTITY_NOT_FOUND = "entity_not_found"
 WS_ERR_VALIDATION_FAILED = "validation_failed"
 WS_ERR_INTERNAL_ERROR = "internal_error"
+WS_ERR_RATE_LIMITED = "rate_limited"
 
 
 def get_validated_coordinator(config_entry: ConfigEntry) -> GrowspaceCoordinator:
@@ -89,13 +90,15 @@ def invalidates_cache(growspace_id_kwarg: str = "growspace_id") -> Callable[...,
         async def wrapper(*args: Any, **kwargs: Any) -> Any:
             result = await func(*args, **kwargs)
             growspace_id: str | None = kwargs.get(growspace_id_kwarg) or (
-                args[1].get(growspace_id_kwarg) if len(args) > 1 and isinstance(args[1], dict) else None
+                args[1].get(growspace_id_kwarg)
+                if len(args) > 1 and isinstance(args[1], dict)
+                else None
             )
             if growspace_id:
                 try:
                     coordinator: GrowspaceCoordinator = args[0]
                     coordinator.cache.pop(growspace_id, None)
-                except (AttributeError, IndexError):
+                except AttributeError, IndexError:
                     pass
             return result
 

--- a/custom_components/growspace_manager/websocket/__init__.py
+++ b/custom_components/growspace_manager/websocket/__init__.py
@@ -6,7 +6,6 @@ import logging
 
 from custom_components.growspace_manager.const import ATTR_NOTES, ATTR_PLANT_ID
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
-from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 
 from . import (
@@ -25,7 +24,12 @@ from . import (
     timeline,
     vision,
 )
-from ._common import _EPOCH_SENTINEL, _extract_ts, _merge_logbook_event
+from ._common import (
+    _EPOCH_SENTINEL,
+    _extract_ts,
+    _merge_logbook_event,
+    register_ws_command,
+)
 from .ai_assistant import (
     SCHEMA_WS_SEND_MESSAGE,
     SCHEMA_WS_START_CONVERSATION,
@@ -196,9 +200,8 @@ def async_register_websocket_api(hass: HomeAssistant) -> None:
     _LOGGER.debug("Registering WebSocket API for growspace_manager")
 
     for module in _MODULES:
-        for ws_type, handler, schema, is_sync in module.COMMANDS:
-            registered = handler if is_sync else websocket_api.async_response(handler)
-            websocket_api.async_register_command(hass, ws_type, registered, schema)
+        for command in module.COMMANDS:
+            register_ws_command(hass, command)
 
 
 __all__ = [
@@ -327,4 +330,3 @@ __all__ = [
     "websocket_update_vision_checkup_config",
     "websocket_upload_strain_image",
 ]
-

--- a/custom_components/growspace_manager/websocket/_common.py
+++ b/custom_components/growspace_manager/websocket/_common.py
@@ -3,15 +3,29 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import datetime
 from functools import wraps
 import logging
 from typing import Any
 
 from custom_components.growspace_manager.const import MERGE_ALERT_GAP_SECONDS
-from custom_components.growspace_manager.exceptions import GrowspaceError
+from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
+from custom_components.growspace_manager.exceptions import (
+    CoordinatorNotReadyError,
+    EntityNotFoundError,
+    GrowspaceError,
+    RateLimitedError,
+)
+from custom_components.growspace_manager.services.utils import (
+    WS_ERR_COORDINATOR_NOT_READY,
+    WS_ERR_ENTITY_NOT_FOUND,
+    WS_ERR_INTERNAL_ERROR,
+    WS_ERR_RATE_LIMITED,
+    WS_ERR_VALIDATION_FAILED,
+)
 from homeassistant.components import websocket_api
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 import homeassistant.util.dt as dt_util
 
@@ -23,7 +37,19 @@ _EPOCH_SENTINEL: datetime = datetime.min.replace(tzinfo=dt_util.UTC)
 _WSHandler = Callable[
     [HomeAssistant, websocket_api.ActiveConnection, dict[str, Any]], Awaitable[None]
 ]
-_WSHandlerSync = Callable[[HomeAssistant, websocket_api.ActiveConnection, dict[str, Any]], None]
+_WSHandlerSync = Callable[
+    [HomeAssistant, websocket_api.ActiveConnection, dict[str, Any]], None
+]
+
+# Payload-returning handlers (ADR-0027): the WS Command Lifecycle owns the
+# connection; a handler computes a payload (or None) and raises typed
+# exceptions for errors.
+WSPayloadHandler = Callable[
+    [HomeAssistant, GrowspaceCoordinator, dict[str, Any]], Awaitable[Any]
+]
+WSPayloadHandlerSync = Callable[
+    [HomeAssistant, GrowspaceCoordinator, dict[str, Any]], Any
+]
 
 # (exception types to match, error code to send, whether to log a traceback,
 # optional fixed message overriding str(err))
@@ -31,12 +57,20 @@ WSErrorMap = tuple[
     tuple[type[Exception] | tuple[type[Exception], ...], str, bool, str | None], ...
 ]
 
-# Covers the common pattern: validation-shaped errors are reported as
-# "validation_failed" without a traceback, everything else is logged and
-# reported as "unknown_error".
+# The Typed Error Codes vocabulary shared with the card (ADR-0005, completed
+# by ADR-0027). The card's errors.ts types exactly this set and coerces any
+# other code to internal_error, so ad-hoc codes are self-defeating.
 DEFAULT_WS_ERROR_MAP: WSErrorMap = (
-    ((ServiceValidationError, GrowspaceError, ValueError), "validation_failed", False, None),
-    (Exception, "unknown_error", True, None),
+    (EntityNotFoundError, WS_ERR_ENTITY_NOT_FOUND, False, None),
+    (CoordinatorNotReadyError, WS_ERR_COORDINATOR_NOT_READY, False, None),
+    (RateLimitedError, WS_ERR_RATE_LIMITED, False, None),
+    (
+        (ServiceValidationError, GrowspaceError, ValueError),
+        WS_ERR_VALIDATION_FAILED,
+        False,
+        None,
+    ),
+    (Exception, WS_ERR_INTERNAL_ERROR, True, None),
 )
 
 
@@ -52,59 +86,90 @@ def _send_ws_error(
         if isinstance(err, exc_types):
             if should_log:
                 _LOGGER.exception("Error handling %s", func_name)
-            connection.send_error(msg["id"], code, message if message is not None else str(err))
+            connection.send_error(
+                msg["id"], code, message if message is not None else str(err)
+            )
             return
     raise err
 
 
-def handle_ws_errors(error_map: WSErrorMap = DEFAULT_WS_ERROR_MAP) -> Callable[[_WSHandler], _WSHandler]:
-    """Decorate an async WebSocket handler with standardized error reporting.
+@dataclass(frozen=True, slots=True)
+class WSCommand:
+    """One declarative WS command row (ADR-0027, [[WSCommand]]).
 
-    On success the handler is responsible for calling
-    ``connection.send_result``. On a raised exception, ``error_map`` is
-    checked in order for the first matching exception type and the
-    corresponding error code is sent via ``connection.send_error``.
-
-    Mirrors ``services.utils.handle_service_errors`` for the WebSocket layer.
+    ``resolve="targeted"`` locates the coordinator from ids in the message via
+    ``get_for_service_call``; ``"any"`` uses ``get_any`` (global commands).
+    ``sync=True`` registers a ``@callback`` wrapper for cheap reads.
+    ``error_map`` overrides the default Typed Error Codes table for modules
+    with a genuinely different message policy.
     """
 
-    def decorator(func: _WSHandler) -> _WSHandler:
-        @wraps(func)
-        async def wrapper(
+    type: str
+    handler: Any
+    schema: Any
+    resolve: str = "targeted"
+    sync: bool = False
+    error_map: WSErrorMap | None = None
+
+
+def _resolve_coordinator(
+    hass: HomeAssistant, msg: dict[str, Any], mode: str
+) -> GrowspaceCoordinator:
+    """Locate the coordinator for a command per its declared resolve mode."""
+    if mode == "any":
+        return GrowspaceCoordinator.get_any(hass)
+    return GrowspaceCoordinator.get_for_service_call(hass, msg)
+
+
+def register_ws_command(hass: HomeAssistant, command: WSCommand) -> None:
+    """Register one command behind the WS Command Lifecycle (ADR-0027).
+
+    The wrapper owns resolve → execute → ``send_result`` → error mapping;
+    the handler is a payload-returning function that never sees the
+    connection. Its return value is sent as the result payload (``None``
+    for mutations).
+    """
+    error_map = command.error_map or DEFAULT_WS_ERROR_MAP
+
+    if command.sync:
+
+        @callback
+        @wraps(command.handler)
+        def sync_wrapper(
             hass: HomeAssistant,
             connection: websocket_api.ActiveConnection,
             msg: dict[str, Any],
         ) -> None:
             try:
-                await func(hass, connection, msg)
+                coordinator = _resolve_coordinator(hass, msg, command.resolve)
+                payload = command.handler(hass, coordinator, msg)
+                connection.send_result(msg["id"], payload)
             except Exception as err:  # noqa: BLE001
-                _send_ws_error(connection, msg, func.__name__, err, error_map)
+                _send_ws_error(
+                    connection, msg, command.handler.__name__, err, error_map
+                )
 
-        return wrapper
+        websocket_api.async_register_command(
+            hass, command.type, sync_wrapper, command.schema
+        )
+        return
 
-    return decorator
+    @wraps(command.handler)
+    async def async_wrapper(
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict[str, Any],
+    ) -> None:
+        try:
+            coordinator = _resolve_coordinator(hass, msg, command.resolve)
+            payload = await command.handler(hass, coordinator, msg)
+            connection.send_result(msg["id"], payload)
+        except Exception as err:  # noqa: BLE001
+            _send_ws_error(connection, msg, command.handler.__name__, err, error_map)
 
-
-def handle_ws_errors_sync(
-    error_map: WSErrorMap = DEFAULT_WS_ERROR_MAP,
-) -> Callable[[_WSHandlerSync], _WSHandlerSync]:
-    """Sync-callback variant of :func:`handle_ws_errors`."""
-
-    def decorator(func: _WSHandlerSync) -> _WSHandlerSync:
-        @wraps(func)
-        def wrapper(
-            hass: HomeAssistant,
-            connection: websocket_api.ActiveConnection,
-            msg: dict[str, Any],
-        ) -> None:
-            try:
-                func(hass, connection, msg)
-            except Exception as err:  # noqa: BLE001
-                _send_ws_error(connection, msg, func.__name__, err, error_map)
-
-        return wrapper
-
-    return decorator
+    websocket_api.async_register_command(
+        hass, command.type, websocket_api.async_response(async_wrapper), command.schema
+    )
 
 
 def _extract_ts(state_obj: Any) -> datetime:
@@ -165,6 +230,6 @@ def _merge_logbook_event(
                         )
                         last_evt["reasons"] = comb[:5]
                     return True  # type: ignore[no-any-return]
-        except (ValueError, TypeError, KeyError):
+        except ValueError, TypeError, KeyError:
             pass
     return False

--- a/custom_components/growspace_manager/websocket/ai_assistant.py
+++ b/custom_components/growspace_manager/websocket/ai_assistant.py
@@ -27,6 +27,12 @@ import voluptuous as vol
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
+from custom_components.growspace_manager.exceptions import (
+    CoordinatorNotReadyError,
+    EntityNotFoundError,
+    GrowspaceError,
+    RateLimitedError,
+)
 from custom_components.growspace_manager.models import GrowspaceType
 from custom_components.growspace_manager.utils import (
     calculate_days_since,
@@ -37,6 +43,8 @@ from homeassistant.components import conversation, websocket_api
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 
+from ._common import WSCommand
+
 _LOGGER = logging.getLogger(__name__)
 
 # Matches [ACTION]...[/ACTION] — non-greedy, allows multi-line content
@@ -44,7 +52,12 @@ _ACTION_RE = re.compile(r"\[ACTION\](.*?)\[/ACTION\]", re.DOTALL)
 
 _VALID_IMAGE_DOMAINS = {"camera", "image"}
 
-_RATE_LIMIT_MARKERS = ("429", "Too Many Requests", "RESOURCE_EXHAUSTED", "resource_exhausted")
+_RATE_LIMIT_MARKERS = (
+    "429",
+    "Too Many Requests",
+    "RESOURCE_EXHAUSTED",
+    "resource_exhausted",
+)
 _RATE_LIMIT_MESSAGE = "rate_limited"
 
 WS_TYPE_START_CONVERSATION = f"{DOMAIN}/start_conversation"
@@ -70,25 +83,14 @@ SCHEMA_WS_SEND_MESSAGE = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 )
 
 
-def _validate_image_entities(
-    image_entities: list[str],
-    connection: websocket_api.ActiveConnection,
-    msg_id: int,
-) -> bool:
-    """Validate that all image entity IDs belong to camera or image domains.
-
-    Returns True if valid, False and sends an error to the connection if not.
-    """
+def _validate_image_entities(image_entities: list[str]) -> None:
+    """Validate that all image entity IDs belong to camera or image domains."""
     for entity_id in image_entities:
         domain = entity_id.split(".", 1)[0]
         if domain not in _VALID_IMAGE_DOMAINS:
-            connection.send_error(
-                msg_id,
-                "invalid_entity",
-                f"Entity '{entity_id}' is not in the camera or image domain",
+            raise ServiceValidationError(
+                f"Entity '{entity_id}' is not in the camera or image domain"
             )
-            return False
-    return True
 
 
 def _extract_action(text: str) -> tuple[str, dict[str, Any] | None]:
@@ -104,7 +106,7 @@ def _extract_action(text: str) -> tuple[str, dict[str, Any] | None]:
     raw_json = strip_markdown_fence(match.group(1).strip())
     try:
         action = json.loads(raw_json)
-    except (json.JSONDecodeError, ValueError):
+    except json.JSONDecodeError, ValueError:
         # Malformed block — return the full text without modification
         return text, None
         return text, None
@@ -163,8 +165,16 @@ def _build_context_message(
 
     # Collect sensor readings — first valid entity per type wins
     sensor_specs: list[tuple[str, list[str | None]]] = [
-        ("Temperature", env.temperature_sensors or ([env.temperature_sensor] if env.temperature_sensor else [])),
-        ("Humidity", env.humidity_sensors or ([env.humidity_sensor] if env.humidity_sensor else [])),
+        (
+            "Temperature",
+            env.temperature_sensors
+            or ([env.temperature_sensor] if env.temperature_sensor else []),
+        ),
+        (
+            "Humidity",
+            env.humidity_sensors
+            or ([env.humidity_sensor] if env.humidity_sensor else []),
+        ),
         ("VPD", env.vpd_sensors or ([env.vpd_sensor] if env.vpd_sensor else [])),
         ("CO2", [env.co2_sensor] if env.co2_sensor else []),
         ("Substrate temp", env.substrate_temperature_sensors),
@@ -191,7 +201,11 @@ def _build_context_message(
         plants = coordinator.services.growspaces.get_growspace_plants(growspace_id)
         if plants:
             max_flower = max(
-                (calculate_days_since(p.flower_start) for p in plants if p.flower_start),
+                (
+                    calculate_days_since(p.flower_start)
+                    for p in plants
+                    if p.flower_start
+                ),
                 default=-1,
             )
             max_veg = max(
@@ -199,7 +213,11 @@ def _build_context_message(
                 default=-1,
             )
             max_seedling = max(
-                (calculate_days_since(p.seedling_start) for p in plants if p.seedling_start),
+                (
+                    calculate_days_since(p.seedling_start)
+                    for p in plants
+                    if p.seedling_start
+                ),
                 default=-1,
             )
             max_clone = max(
@@ -209,13 +227,19 @@ def _build_context_message(
             if max_flower >= 0:
                 stage_line = f"Stage: flower | Day {max_flower} | Week {days_to_week(max_flower)}"
             elif max_veg >= 0:
-                stage_line = f"Stage: veg | Day {max_veg} | Week {days_to_week(max_veg)}"
+                stage_line = (
+                    f"Stage: veg | Day {max_veg} | Week {days_to_week(max_veg)}"
+                )
             elif max_seedling >= 0:
                 stage_line = f"Stage: seedling | Day {max_seedling} | Week {days_to_week(max_seedling)}"
             elif max_clone >= 0:
-                stage_line = f"Stage: clone | Day {max_clone} | Week {days_to_week(max_clone)}"
+                stage_line = (
+                    f"Stage: clone | Day {max_clone} | Week {days_to_week(max_clone)}"
+                )
 
-    lines: list[str] = [f"[Growspace: {growspace.name} | Type: {growspace.growspace_type.value}]"]
+    lines: list[str] = [
+        f"[Growspace: {growspace.name} | Type: {growspace.growspace_type.value}]"
+    ]
     if stage_line:
         lines.append(stage_line)
     if sensor_parts:
@@ -241,11 +265,37 @@ async def _run_conversation(
     )
 
 
-async def websocket_start_conversation(
+async def _converse_or_raise(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    message: str,
+    agent_id: str | None,
+    conversation_id: str | None,
+) -> tuple[str, str]:
+    """Run a conversation turn, raising typed errors for the lifecycle map.
+
+    Returns ``(speech, conversation_id)``.
+    """
+    try:
+        result = await _run_conversation(hass, message, agent_id, conversation_id)
+    except Exception as err:
+        _LOGGER.error("AI conversation failed: %s", err)
+        if _is_rate_limited_error(err):
+            raise RateLimitedError(_RATE_LIMIT_MESSAGE) from err
+        raise GrowspaceError(str(err)) from err
+
+    if _is_rate_limited_result(result):
+        _LOGGER.warning("AI rate limit reached")
+        raise RateLimitedError(_RATE_LIMIT_MESSAGE)
+
+    speech = _extract_speech(result)
+    if speech is None:
+        raise GrowspaceError("AI assistant returned an empty response")
+    return speech, result.conversation_id
+
+
+async def websocket_start_conversation(
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Handle the start_conversation WebSocket command.
 
     Begins a brand-new AI conversation (conversation_id=None) and returns
@@ -254,45 +304,15 @@ async def websocket_start_conversation(
     growspace_id: str = msg["growspace_id"]
     message: str = msg["message"]
     agent_id: str | None = msg.get("agent_id")
-    coordinator = _get_coordinator(hass, connection)
-    if agent_id is None and coordinator is not None:
+    if agent_id is None:
         agent_id = coordinator.options.get("ai_settings", {}).get("assistant_id")
-    image_entities: list[str] = msg.get("image_entities") or []
 
-    if not _validate_image_entities(image_entities, connection, msg["id"]):
-        return
+    _validate_image_entities(msg.get("image_entities") or [])
+    message = _build_context_message(hass, coordinator, growspace_id, message)
 
-    if coordinator is not None:
-        message = _build_context_message(hass, coordinator, growspace_id, message)
-
-    try:
-        result = await _run_conversation(hass, message, agent_id, conversation_id=None)
-    except ServiceValidationError as err:
-        _LOGGER.error("Error in start_conversation: %s", err)
-        if _is_rate_limited_error(err):
-            connection.send_error(msg["id"], "rate_limited", _RATE_LIMIT_MESSAGE)
-        else:
-            connection.send_error(msg["id"], "ai_error", str(err))
-        return
-    except Exception as err:  # noqa: BLE001
-        _LOGGER.error("Unexpected error in start_conversation: %s", err)
-        if _is_rate_limited_error(err):
-            connection.send_error(msg["id"], "rate_limited", _RATE_LIMIT_MESSAGE)
-        else:
-            connection.send_error(msg["id"], "ai_error", str(err))
-        return
-
-    if _is_rate_limited_result(result):
-        _LOGGER.warning("AI rate limit reached in start_conversation")
-        connection.send_error(msg["id"], "rate_limited", _RATE_LIMIT_MESSAGE)
-        return
-
-    speech = _extract_speech(result)
-    if speech is None:
-        connection.send_error(
-            msg["id"], "ai_error", "AI assistant returned an empty response"
-        )
-        return
+    speech, thread_id = await _converse_or_raise(
+        hass, message, agent_id, conversation_id=None
+    )
 
     display_text, action = _extract_action(speech)
     ai_message: dict[str, Any] = {
@@ -303,18 +323,16 @@ async def websocket_start_conversation(
     if action is not None:
         ai_message["suggestedAction"] = action
 
-    connection.send_result(msg["id"], {
-        "thread_id": result.conversation_id,
+    return {
+        "thread_id": thread_id,
         "growspace_id": growspace_id,
         "messages": [ai_message],
-    })
+    }
 
 
 async def websocket_send_message(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Handle the send_message WebSocket command.
 
     Continues an existing AI conversation identified by *conversation_id*.
@@ -322,47 +340,15 @@ async def websocket_send_message(
     conversation_id: str = msg["conversation_id"]
     growspace_id: str = msg["growspace_id"]
     message: str = msg["message"]
-    image_entities: list[str] = msg.get("image_entities") or []
 
-    if not _validate_image_entities(image_entities, connection, msg["id"]):
-        return
+    _validate_image_entities(msg.get("image_entities") or [])
 
-    coordinator = _get_coordinator(hass, connection)
-    agent_id: str | None = None
-    if coordinator is not None:
-        agent_id = coordinator.options.get("ai_settings", {}).get("assistant_id")
-        message = _build_context_message(hass, coordinator, growspace_id, message)
+    agent_id = coordinator.options.get("ai_settings", {}).get("assistant_id")
+    message = _build_context_message(hass, coordinator, growspace_id, message)
 
-    try:
-        result = await _run_conversation(
-            hass, message, agent_id=agent_id, conversation_id=conversation_id
-        )
-    except ServiceValidationError as err:
-        _LOGGER.error("Error in send_message: %s", err)
-        if _is_rate_limited_error(err):
-            connection.send_error(msg["id"], "rate_limited", _RATE_LIMIT_MESSAGE)
-        else:
-            connection.send_error(msg["id"], "ai_error", str(err))
-        return
-    except Exception as err:  # noqa: BLE001
-        _LOGGER.error("Unexpected error in send_message: %s", err)
-        if _is_rate_limited_error(err):
-            connection.send_error(msg["id"], "rate_limited", _RATE_LIMIT_MESSAGE)
-        else:
-            connection.send_error(msg["id"], "ai_error", str(err))
-        return
-
-    if _is_rate_limited_result(result):
-        _LOGGER.warning("AI rate limit reached in send_message")
-        connection.send_error(msg["id"], "rate_limited", _RATE_LIMIT_MESSAGE)
-        return
-
-    speech = _extract_speech(result)
-    if speech is None:
-        connection.send_error(
-            msg["id"], "ai_error", "AI assistant returned an empty response"
-        )
-        return
+    speech, _ = await _converse_or_raise(
+        hass, message, agent_id=agent_id, conversation_id=conversation_id
+    )
 
     display_text, action = _extract_action(speech)
     ai_message: dict[str, Any] = {
@@ -373,26 +359,11 @@ async def websocket_send_message(
     if action is not None:
         ai_message["suggestedAction"] = action
 
-    connection.send_result(msg["id"], {
+    return {
         "thread_id": conversation_id,
         "growspace_id": growspace_id,
         "messages": [ai_message],
-    })
-
-
-def _get_coordinator(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-) -> GrowspaceCoordinator | None:
-    """Return the first loaded GrowspaceCoordinator, or *None*.
-
-    Returns ``None`` (rather than raising) so callers can send a typed
-    WebSocket error response.
-    """
-    try:
-        return GrowspaceCoordinator.get_for_service_call(hass, {})
-    except (ServiceValidationError, Exception):  # noqa: BLE001
-        return None
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -410,28 +381,18 @@ SCHEMA_WS_GET_AI_ALERTS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 
 
 async def websocket_get_ai_alerts(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Return AI alert records, optionally filtered by growspace or type.
 
     WebSocket message fields:
     - ``growspace_id`` *(optional)*: filter to a specific growspace
     - ``alert_type`` *(optional)*: ``"stress"`` or ``"mold"``
     """
-    coordinator = _get_coordinator(hass, connection)
-    if coordinator is None:
-        connection.send_error(
-            msg["id"], "not_found", "Growspace Manager integration not loaded"
-        )
-        return
-
-    alerts = coordinator.services.notifications.get_alerts(
+    return coordinator.services.notifications.get_alerts(
         growspace_id=msg.get("growspace_id"),
         alert_type=msg.get("alert_type"),
     )
-    connection.send_result(msg["id"], alerts)
 
 
 # ---------------------------------------------------------------------------
@@ -449,34 +410,24 @@ SCHEMA_WS_RESOLVE_AI_ALERT = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 
 
 async def websocket_resolve_ai_alert(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Mark an AI alert as resolved.
 
     WebSocket message fields:
     - ``alert_id`` *(required)*: UUID of the alert to resolve
     - ``resolution_note`` *(optional)*: resolution notes to attach
     """
-    coordinator = _get_coordinator(hass, connection)
-    if coordinator is None:
-        connection.send_error(
-            msg["id"], "not_found", "Growspace Manager integration not loaded"
-        )
-        return
-
     alert_id: str = msg["alert_id"]
     notes: str | None = msg.get("resolution_note")
-    resolved = await coordinator.services.notifications.resolve_alert(alert_id, notes=notes)
+    resolved = await coordinator.services.notifications.resolve_alert(
+        alert_id, notes=notes
+    )
 
     if not resolved:
-        connection.send_error(
-            msg["id"], "not_found", f"Alert '{alert_id}' not found"
-        )
-        return
+        raise EntityNotFoundError(f"Alert '{alert_id}' not found")
 
-    connection.send_result(msg["id"], {"success": True, "alert_id": alert_id})
+    return {"success": True, "alert_id": alert_id}
 
 
 # ---------------------------------------------------------------------------
@@ -494,10 +445,8 @@ SCHEMA_WS_GET_BRIEFING = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 
 
 async def websocket_get_briefing(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Return the latest AI briefing, optionally regenerating it.
 
     WebSocket message fields:
@@ -505,23 +454,12 @@ async def websocket_get_briefing(
     - ``force_refresh`` *(optional, default False)*: when ``True`` bypass the
       cache and generate a fresh briefing immediately.
     """
-    coordinator = _get_coordinator(hass, connection)
-    if coordinator is None:
-        connection.send_error(
-            msg["id"], "not_found", "Growspace Manager integration not loaded"
-        )
-        return
-
     briefing_scheduler = getattr(coordinator, "briefing_scheduler", None)
     if briefing_scheduler is None:
-        connection.send_error(
-            msg["id"], "not_found", "Briefing scheduler not available"
-        )
-        return
+        raise CoordinatorNotReadyError("Briefing scheduler not available")
 
     force_refresh: bool = msg.get("force_refresh", False)
-    briefing = await briefing_scheduler.async_get_briefing(force_refresh=force_refresh)
-    connection.send_result(msg["id"], briefing)
+    return await briefing_scheduler.async_get_briefing(force_refresh=force_refresh)
 
 
 # ---------------------------------------------------------------------------
@@ -535,23 +473,16 @@ SCHEMA_WS_GET_AI_STATUS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 
 
 async def websocket_get_ai_status(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Return the component-level AI enabled flag.
 
     Response: ``{ "ai_enabled": bool }``
     """
-    coordinator = _get_coordinator(hass, connection)
-    if coordinator is None:
-        connection.send_error(
-            msg["id"], "not_found", "Growspace Manager integration not loaded"
-        )
-        return
-
-    ai_enabled: bool = coordinator.options.get("ai_settings", {}).get("ai_enabled", False)
-    connection.send_result(msg["id"], {"ai_enabled": bool(ai_enabled)})
+    ai_enabled: bool = coordinator.options.get("ai_settings", {}).get(
+        "ai_enabled", False
+    )
+    return {"ai_enabled": bool(ai_enabled)}
 
 
 # ---------------------------------------------------------------------------
@@ -565,23 +496,14 @@ SCHEMA_WS_GET_AI_SETTINGS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 
 
 async def websocket_get_ai_settings(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Return the full ai_settings dict from the config entry options.
 
     Response: the ``ai_settings`` dict, or ``{}`` when not yet configured.
     """
-    coordinator = _get_coordinator(hass, connection)
-    if coordinator is None:
-        connection.send_error(
-            msg["id"], "not_found", "Growspace Manager integration not loaded"
-        )
-        return
-
     ai_settings: dict[str, Any] = coordinator.options.get("ai_settings", {})
-    connection.send_result(msg["id"], dict(ai_settings))
+    return dict(ai_settings)
 
 
 # ---------------------------------------------------------------------------
@@ -598,10 +520,8 @@ SCHEMA_WS_SAVE_AI_AGENT = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 
 
 async def websocket_save_ai_agent(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Persist a conversation agent selection and enable AI features.
 
     WebSocket message fields:
@@ -610,13 +530,6 @@ async def websocket_save_ai_agent(
     Sets ``ai_settings.assistant_id`` and ``ai_settings.ai_enabled = True`` in
     the config entry options so the change survives restarts.
     """
-    coordinator = _get_coordinator(hass, connection)
-    if coordinator is None:
-        connection.send_error(
-            msg["id"], "not_found", "Growspace Manager integration not loaded"
-        )
-        return
-
     agent_id: str = msg["agent_id"]
     new_options = coordinator.config_entry.options.copy()
     ai_settings: dict[str, Any] = dict(new_options.get("ai_settings", {}))
@@ -627,10 +540,12 @@ async def websocket_save_ai_agent(
     if hasattr(coordinator, "options"):
         coordinator.options = new_options
 
-    hass.config_entries.async_update_entry(coordinator.config_entry, options=new_options)
+    hass.config_entries.async_update_entry(
+        coordinator.config_entry, options=new_options
+    )
     await coordinator.async_commit()
 
-    connection.send_result(msg["id"], {"success": True, "agent_id": agent_id})
+    return {"success": True, "agent_id": agent_id}
 
 
 # ---------------------------------------------------------------------------
@@ -667,37 +582,30 @@ SCHEMA_WS_SAVE_AI_SETTINGS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 
 
 async def websocket_save_ai_settings(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Persist all user-facing AI settings from the Growmaster Settings Panel.
 
     Accepts the nine user-facing ``ai_settings`` fields (all except
     ``vision_debug_enabled``) and writes them atomically to the config entry.
     """
-    coordinator = _get_coordinator(hass, connection)
-    if coordinator is None:
-        connection.send_error(
-            msg["id"], "not_found", "Growspace Manager integration not loaded"
-        )
-        return
-
     new_options = coordinator.config_entry.options.copy()
     existing_settings = dict(new_options.get("ai_settings", {}))
     ai_settings: dict[str, Any] = {
         **existing_settings,
-        **{k: msg[k] for k in _AI_SETTINGS_KEYS if k in msg}
+        **{k: msg[k] for k in _AI_SETTINGS_KEYS if k in msg},
     }
     new_options["ai_settings"] = ai_settings
 
     if hasattr(coordinator, "options"):
         coordinator.options = new_options
 
-    hass.config_entries.async_update_entry(coordinator.config_entry, options=new_options)
+    hass.config_entries.async_update_entry(
+        coordinator.config_entry, options=new_options
+    )
     await coordinator.async_commit()
 
-    connection.send_result(msg["id"], {"success": True})
+    return {"success": True}
 
 
 # ---------------------------------------------------------------------------
@@ -714,10 +622,8 @@ SCHEMA_WS_GET_CONVERSATION_THREADS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.e
 
 
 async def websocket_get_conversation_threads(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Return persisted conversation threads for a growspace.
 
     WebSocket message fields:
@@ -725,15 +631,7 @@ async def websocket_get_conversation_threads(
 
     Response: list of thread objects (may be empty).
     """
-    coordinator = _get_coordinator(hass, connection)
-    if coordinator is None:
-        connection.send_error(
-            msg["id"], "not_found", "Growspace Manager integration not loaded"
-        )
-        return
-
-    threads = coordinator.conversation_store.get_threads(msg["growspace_id"])
-    connection.send_result(msg["id"], threads)
+    return coordinator.conversation_store.get_threads(msg["growspace_id"])
 
 
 # ---------------------------------------------------------------------------
@@ -751,10 +649,8 @@ SCHEMA_WS_SAVE_CONVERSATION_THREADS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.
 
 
 async def websocket_save_conversation_threads(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Persist the frontend-managed conversation thread list for a growspace.
 
     The frontend enforces MAX_PINNED_THREADS / MAX_RECENT_THREADS eviction
@@ -766,29 +662,77 @@ async def websocket_save_conversation_threads(
 
     Response: ``{ "success": True }``
     """
-    coordinator = _get_coordinator(hass, connection)
-    if coordinator is None:
-        connection.send_error(
-            msg["id"], "not_found", "Growspace Manager integration not loaded"
-        )
-        return
-
     await coordinator.conversation_store.save_threads(
         msg["growspace_id"], msg["threads"]
     )
-    connection.send_result(msg["id"], {"success": True})
+    return {"success": True}
 
 
-COMMANDS: list[tuple[str, Any, Any, bool]] = [
-    (WS_TYPE_START_CONVERSATION, websocket_start_conversation, SCHEMA_WS_START_CONVERSATION, False),
-    (WS_TYPE_SEND_MESSAGE, websocket_send_message, SCHEMA_WS_SEND_MESSAGE, False),
-    (WS_TYPE_GET_AI_ALERTS, websocket_get_ai_alerts, SCHEMA_WS_GET_AI_ALERTS, False),
-    (WS_TYPE_RESOLVE_AI_ALERT, websocket_resolve_ai_alert, SCHEMA_WS_RESOLVE_AI_ALERT, False),
-    (WS_TYPE_GET_BRIEFING, websocket_get_briefing, SCHEMA_WS_GET_BRIEFING, False),
-    (WS_TYPE_GET_AI_STATUS, websocket_get_ai_status, SCHEMA_WS_GET_AI_STATUS, False),
-    (WS_TYPE_GET_AI_SETTINGS, websocket_get_ai_settings, SCHEMA_WS_GET_AI_SETTINGS, False),
-    (WS_TYPE_SAVE_AI_AGENT, websocket_save_ai_agent, SCHEMA_WS_SAVE_AI_AGENT, False),
-    (WS_TYPE_SAVE_AI_SETTINGS, websocket_save_ai_settings, SCHEMA_WS_SAVE_AI_SETTINGS, False),
-    (WS_TYPE_GET_CONVERSATION_THREADS, websocket_get_conversation_threads, SCHEMA_WS_GET_CONVERSATION_THREADS, False),
-    (WS_TYPE_SAVE_CONVERSATION_THREADS, websocket_save_conversation_threads, SCHEMA_WS_SAVE_CONVERSATION_THREADS, False),
+COMMANDS: list[WSCommand] = [
+    WSCommand(
+        WS_TYPE_START_CONVERSATION,
+        websocket_start_conversation,
+        SCHEMA_WS_START_CONVERSATION,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_SEND_MESSAGE,
+        websocket_send_message,
+        SCHEMA_WS_SEND_MESSAGE,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_GET_AI_ALERTS,
+        websocket_get_ai_alerts,
+        SCHEMA_WS_GET_AI_ALERTS,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_RESOLVE_AI_ALERT,
+        websocket_resolve_ai_alert,
+        SCHEMA_WS_RESOLVE_AI_ALERT,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_GET_BRIEFING,
+        websocket_get_briefing,
+        SCHEMA_WS_GET_BRIEFING,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_GET_AI_STATUS,
+        websocket_get_ai_status,
+        SCHEMA_WS_GET_AI_STATUS,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_GET_AI_SETTINGS,
+        websocket_get_ai_settings,
+        SCHEMA_WS_GET_AI_SETTINGS,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_SAVE_AI_AGENT,
+        websocket_save_ai_agent,
+        SCHEMA_WS_SAVE_AI_AGENT,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_SAVE_AI_SETTINGS,
+        websocket_save_ai_settings,
+        SCHEMA_WS_SAVE_AI_SETTINGS,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_GET_CONVERSATION_THREADS,
+        websocket_get_conversation_threads,
+        SCHEMA_WS_GET_CONVERSATION_THREADS,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_SAVE_CONVERSATION_THREADS,
+        websocket_save_conversation_threads,
+        SCHEMA_WS_SAVE_CONVERSATION_THREADS,
+        resolve="any",
+    ),
 ]

--- a/custom_components/growspace_manager/websocket/data.py
+++ b/custom_components/growspace_manager/websocket/data.py
@@ -9,17 +9,13 @@ import voluptuous as vol
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
-from custom_components.growspace_manager.exceptions import GrowspaceError
 from custom_components.growspace_manager.services.report import (
     async_websocket_get_grow_report,
 )
-from custom_components.growspace_manager.services.utils import (
-    WS_ERR_COORDINATOR_NOT_READY,
-    WS_ERR_INTERNAL_ERROR,
-)
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+
+from ._common import WSCommand
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,29 +39,17 @@ SCHEMA_WS_GET_GROW_REPORT = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 
 
 async def websocket_get_growspace_data(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Handle get growspace data command."""
-    growspace_id = msg.get("growspace_id")
-    try:
-        coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
-        data = coordinator.services.growspaces.get_growspace_data(growspace_id)
-        connection.send_result(msg["id"], data)
-    except ServiceValidationError:
-        connection.send_error(
-            msg["id"], WS_ERR_COORDINATOR_NOT_READY, "Growspace Manager integration not loaded"
-        )
-    except (
-        AttributeError,
-        KeyError,
-        ValueError,
-        GrowspaceError,
-        Exception,  # noqa: BLE001
-    ) as e:
-        connection.send_error(msg["id"], WS_ERR_INTERNAL_ERROR, str(e))
+    return coordinator.services.growspaces.get_growspace_data(msg.get("growspace_id"))
 
 
-COMMANDS: list[tuple[str, Any, Any, bool]] = [
-    (WS_TYPE_GET_DATA, websocket_get_growspace_data, SCHEMA_WS_GET_DATA, False),
-    (WS_TYPE_GET_GROW_REPORT, async_websocket_get_grow_report, SCHEMA_WS_GET_GROW_REPORT, False),
+COMMANDS: list[WSCommand] = [
+    WSCommand(WS_TYPE_GET_DATA, websocket_get_growspace_data, SCHEMA_WS_GET_DATA),
+    WSCommand(
+        WS_TYPE_GET_GROW_REPORT,
+        async_websocket_get_grow_report,
+        SCHEMA_WS_GET_GROW_REPORT,
+    ),
 ]

--- a/custom_components/growspace_manager/websocket/environment.py
+++ b/custom_components/growspace_manager/websocket/environment.py
@@ -11,7 +11,10 @@ import voluptuous as vol
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
-from custom_components.growspace_manager.exceptions import GrowspaceError
+from custom_components.growspace_manager.exceptions import (
+    GrowspaceError,
+    GrowspaceNotFoundError,
+)
 from homeassistant.components import websocket_api
 from homeassistant.components.recorder import (
     get_instance,
@@ -22,7 +25,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 import homeassistant.util.dt as dt_util
 
-from ._common import _EPOCH_SENTINEL, _extract_ts
+from ._common import _EPOCH_SENTINEL, WSCommand, _extract_ts
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -263,99 +266,74 @@ async def _get_history_with_binary_search_downsample(
 
 
 async def websocket_get_history_stats(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Handle get history stats command with server-side optimization."""
     entity_ids = msg["entity_ids"]
     start_time_str = msg["start_time"]
     end_time_str = msg.get("end_time")
     interval = msg["interval_minutes"]
 
-    try:
-        start_time = dt_util.parse_datetime(start_time_str)
-        end_time = (
-            dt_util.parse_datetime(end_time_str) if end_time_str else dt_util.utcnow()
-        )
+    start_time = dt_util.parse_datetime(start_time_str)
+    end_time = (
+        dt_util.parse_datetime(end_time_str) if end_time_str else dt_util.utcnow()
+    )
 
-        if not start_time:
-            connection.send_error(msg["id"], "invalid_args", "Invalid start_time")
-            return
+    if not start_time:
+        raise ServiceValidationError("Invalid start_time")
+    if not end_time:
+        raise ServiceValidationError("Invalid end_time")
 
-        if not end_time:
-            connection.send_error(msg["id"], "invalid_args", "Invalid end_time")
-            return
-
-        if interval >= 60:
-            stats_result = await _get_statistics_data(
-                hass, entity_ids, start_time, end_time, interval
-            )
-            if stats_result:
-                connection.send_result(msg["id"], stats_result)
-                return
-
-        result = await _get_history_with_binary_search_downsample(
+    if interval >= 60:
+        stats_result = await _get_statistics_data(
             hass, entity_ids, start_time, end_time, interval
         )
-        connection.send_result(msg["id"], result)
+        if stats_result:
+            return stats_result
 
-    except Exception as err:
-        _LOGGER.exception("Error handling websocket_get_history_stats")
-        connection.send_error(msg["id"], "unknown_error", str(err))
+    return await _get_history_with_binary_search_downsample(
+        hass, entity_ids, start_time, end_time, interval
+    )
 
 
 async def websocket_update_sensor_coordinates(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
 ) -> None:
     """Handle update sensor coordinates command."""
     growspace_id = msg["growspace_id"]
     entity_id = msg["entity_id"]
-    x = msg["x"]
-    y = msg["y"]
-    z = msg["z"]
     rotation = msg.get("rotation")
 
-    try:
-        coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
-        growspace = coordinator.growspaces.get(growspace_id)
+    growspace = coordinator.growspaces.get(growspace_id)
+    if not growspace:
+        raise GrowspaceNotFoundError(f"Growspace {growspace_id} not found")
 
-        if not growspace:
-            connection.send_error(
-                msg["id"], "not_found", f"Growspace {growspace_id} not found"
-            )
-            return
+    if not hasattr(growspace, "environment_config") or not growspace.environment_config:
+        raise ServiceValidationError("Grow space has no environment configuration")
 
-        if (
-            not hasattr(growspace, "environment_config")
-            or not growspace.environment_config
-        ):
-            connection.send_error(
-                msg["id"],
-                "invalid_state",
-                "Grow space has no environment configuration",
-            )
-            return
+    if not growspace.environment_config.sensor_coordinates:
+        growspace.environment_config.sensor_coordinates = {}
 
-        if not growspace.environment_config.sensor_coordinates:
-            growspace.environment_config.sensor_coordinates = {}
+    data = {"x": msg["x"], "y": msg["y"], "z": msg["z"]}
+    if rotation is not None:
+        data["rotation"] = rotation
 
-        data = {"x": x, "y": y, "z": z}
-        if rotation is not None:
-            data["rotation"] = rotation
+    growspace.environment_config.sensor_coordinates[entity_id] = data
 
-        growspace.environment_config.sensor_coordinates[entity_id] = data
-
-        await coordinator.async_commit()
-        await coordinator.async_request_refresh()
-
-        connection.send_result(msg["id"])
-    except ServiceValidationError as err:
-        connection.send_error(msg["id"], "invalid_args", str(err))
-    except Exception as err:
-        _LOGGER.exception("Error handling websocket_update_sensor_coordinates")
-        connection.send_error(msg["id"], "unknown_error", str(err))
+    await coordinator.async_commit()
+    await coordinator.async_request_refresh()
 
 
-COMMANDS: list[tuple[str, Any, Any, bool]] = [
-    (WS_TYPE_GET_HISTORY_STATS, websocket_get_history_stats, SCHEMA_WS_GET_HISTORY_STATS, False),
-    (WS_TYPE_UPDATE_SENSOR_COORDINATES, websocket_update_sensor_coordinates, SCHEMA_WS_UPDATE_SENSOR_COORDINATES, False),
+COMMANDS: list[WSCommand] = [
+    WSCommand(
+        WS_TYPE_GET_HISTORY_STATS,
+        websocket_get_history_stats,
+        SCHEMA_WS_GET_HISTORY_STATS,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_UPDATE_SENSOR_COORDINATES,
+        websocket_update_sensor_coordinates,
+        SCHEMA_WS_UPDATE_SENSOR_COORDINATES,
+    ),
 ]

--- a/custom_components/growspace_manager/websocket/genetics.py
+++ b/custom_components/growspace_manager/websocket/genetics.py
@@ -10,17 +10,9 @@ from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from custom_components.growspace_manager.strain_library import StrainLibrary
 from homeassistant.components import websocket_api
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.core import HomeAssistant
 
-from ._common import WSErrorMap, handle_ws_errors, handle_ws_errors_sync
-
-_GET_ERROR_MAP: WSErrorMap = ((Exception, "unknown_error", True, None),)
-
-_BREEDER_ERROR_MAP: WSErrorMap = (
-    (ServiceValidationError, "not_loaded", False, "Growspace Manager strain library not loaded"),
-    (Exception, "unknown_error", True, None),
-)
+from ._common import WSCommand
 
 WS_TYPE_GET_GENETICS_DATA = f"{DOMAIN}/get_genetics_data"
 SCHEMA_WS_GET_GENETICS_DATA = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
@@ -48,55 +40,54 @@ SCHEMA_WS_DELETE_BREEDER = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 )
 
 
-@callback
-@handle_ws_errors_sync(_GET_ERROR_MAP)
 def websocket_get_genetics_data(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Handle get genetics data command via WebSocket."""
-    coordinator: GrowspaceCoordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
-    connection.send_result(
-        msg["id"],
-        coordinator.services.genetics.get_serialization_data(),
-    )
+    return coordinator.services.genetics.get_serialization_data()
 
 
-@handle_ws_errors(_BREEDER_ERROR_MAP)
 async def websocket_update_breeder(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Handle updating breeder info across all strains."""
-    coordinator = GrowspaceCoordinator.get_any(hass)
     strain_library: StrainLibrary = coordinator.services.config.strain_library
     count = await strain_library.update_breeder(
         original_name=msg["original_name"],
         new_name=msg["new_name"],
         logo=msg.get("logo"),
     )
-    connection.send_result(msg["id"], {"updated": count})
+    return {"updated": count}
 
 
-@handle_ws_errors(_BREEDER_ERROR_MAP)
 async def websocket_delete_breeder(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Handle removing breeder association from all strains."""
-    coordinator = GrowspaceCoordinator.get_any(hass)
     strain_library: StrainLibrary = coordinator.services.config.strain_library
     count = await strain_library.delete_breeder(
         breeder_name=msg["breeder_name"],
     )
-    connection.send_result(msg["id"], {"deleted": count})
+    return {"deleted": count}
 
 
-COMMANDS: list[tuple[str, Any, Any, bool]] = [
-    (WS_TYPE_GET_GENETICS_DATA, websocket_get_genetics_data, SCHEMA_WS_GET_GENETICS_DATA, True),
-    (WS_TYPE_UPDATE_BREEDER, websocket_update_breeder, SCHEMA_WS_UPDATE_BREEDER, False),
-    (WS_TYPE_DELETE_BREEDER, websocket_delete_breeder, SCHEMA_WS_DELETE_BREEDER, False),
+COMMANDS: list[WSCommand] = [
+    WSCommand(
+        WS_TYPE_GET_GENETICS_DATA,
+        websocket_get_genetics_data,
+        SCHEMA_WS_GET_GENETICS_DATA,
+        sync=True,
+    ),
+    WSCommand(
+        WS_TYPE_UPDATE_BREEDER,
+        websocket_update_breeder,
+        SCHEMA_WS_UPDATE_BREEDER,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_DELETE_BREEDER,
+        websocket_delete_breeder,
+        SCHEMA_WS_DELETE_BREEDER,
+        resolve="any",
+    ),
 ]

--- a/custom_components/growspace_manager/websocket/irrigation.py
+++ b/custom_components/growspace_manager/websocket/irrigation.py
@@ -11,13 +11,11 @@ from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from custom_components.growspace_manager.crop_steering_history import (
     CropSteeringHistoryAnalyzer,
 )
+from custom_components.growspace_manager.exceptions import GrowspaceNotFoundError
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
 
-from ._common import WSErrorMap, handle_ws_errors
-
-# Existing handlers report all errors as "unknown_error" without a traceback.
-_ERROR_MAP: WSErrorMap = ((Exception, "unknown_error", False, None),)
+from ._common import WSCommand
 
 WS_TYPE_GET_IRRIGATION_ANALYTICS = f"{DOMAIN}/irrigation_analytics"
 SCHEMA_WS_GET_IRRIGATION_ANALYTICS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
@@ -61,14 +59,10 @@ _RANGE_CONFIG: dict[str, tuple[str, int]] = {
 }
 
 
-@handle_ws_errors(_ERROR_MAP)
 async def websocket_get_irrigation_analytics(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Return water consumption aggregated by growth stage for a growspace."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     growspace_id: str = msg["growspace_id"]
     trackers = coordinator.services.growspaces.get_all_trackers_for_growspace(
         growspace_id
@@ -79,36 +73,24 @@ async def websocket_get_irrigation_analytics(
         for stage, liters in tracker.get_stage_aggregates().items():
             combined[stage] = combined.get(stage, 0.0) + liters
 
-    connection.send_result(
-        msg["id"],
-        {"growspace_id": growspace_id, "stage_aggregates": combined},
-    )
+    return {"growspace_id": growspace_id, "stage_aggregates": combined}
 
 
-@handle_ws_errors(_ERROR_MAP)
 async def websocket_get_tank_water_history(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Return pre-bucketed water consumption for qualifying tanks of a growspace."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     growspace_id: str = msg["growspace_id"]
     range_key: str = msg["range"]
+    empty = {"growspace_id": growspace_id, "range": range_key, "buckets": []}
 
     growspace = coordinator.growspaces.get(growspace_id)
     if growspace is None:
-        connection.send_result(
-            msg["id"], {"growspace_id": growspace_id, "range": range_key, "buckets": []}
-        )
-        return
+        return empty
 
     env = growspace.environment_config
     if env.irrigation_flow_sensors or env.drain_volume_sensors:
-        connection.send_result(
-            msg["id"], {"growspace_id": growspace_id, "range": range_key, "buckets": []}
-        )
-        return
+        return empty
 
     trackers = coordinator.services.growspaces.get_all_trackers_for_growspace(
         growspace_id
@@ -123,87 +105,63 @@ async def websocket_get_tank_water_history(
             raw_histories.append(tracker.get_history_24h()[-bucket_count:])
 
     if not raw_histories:
-        connection.send_result(
-            msg["id"], {"growspace_id": growspace_id, "range": range_key, "buckets": []}
-        )
-        return
+        return empty
 
     buckets: list[dict[str, Any]] = []
     for i, slot in enumerate(raw_histories[0]):
         total = sum(h[i]["liters_consumed"] for h in raw_histories)
         buckets.append({"timestamp": slot["bucket_start"], "liters": round(total, 4)})
 
-    connection.send_result(
-        msg["id"],
-        {"growspace_id": growspace_id, "range": range_key, "buckets": buckets},
-    )
+    return {"growspace_id": growspace_id, "range": range_key, "buckets": buckets}
 
 
-@handle_ws_errors(_ERROR_MAP)
 async def websocket_get_crop_steering_history(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Return bucketed crop steering sensor history for a growspace."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     growspace_id: str = msg["growspace_id"]
 
     growspace = coordinator.growspaces.get(growspace_id)
     if growspace is None:
-        connection.send_error(
-            msg["id"], "not_found", f"Growspace {growspace_id} not found"
-        )
-        return
+        raise GrowspaceNotFoundError(f"Growspace {growspace_id} not found")
 
     analyzer = CropSteeringHistoryAnalyzer(hass)
     history = await analyzer.async_get_history(growspace)
 
-    connection.send_result(msg["id"], {"growspace_id": growspace_id, **history})
+    return {"growspace_id": growspace_id, **history}
 
 
-@handle_ws_errors(_ERROR_MAP)
 async def websocket_apply_steering_mode(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Stamp a Steering Mode's preset values into the strategy (ADR-0012)."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     growspace_id: str = msg["growspace_id"]
     mode = SteeringMode(msg["steering_mode"])
 
     await coordinator.services.growspaces.apply_steering_mode(growspace_id, mode)
 
-    connection.send_result(
-        msg["id"],
-        {"growspace_id": growspace_id, "declared_steering_mode": mode.value},
-    )
+    return {"growspace_id": growspace_id, "declared_steering_mode": mode.value}
 
 
-COMMANDS: list[tuple[str, Any, Any, bool]] = [
-    (
+COMMANDS: list[WSCommand] = [
+    WSCommand(
         WS_TYPE_GET_IRRIGATION_ANALYTICS,
         websocket_get_irrigation_analytics,
         SCHEMA_WS_GET_IRRIGATION_ANALYTICS,
-        False,
     ),
-    (
+    WSCommand(
         WS_TYPE_GET_TANK_WATER_HISTORY,
         websocket_get_tank_water_history,
         SCHEMA_WS_GET_TANK_WATER_HISTORY,
-        False,
     ),
-    (
+    WSCommand(
         WS_TYPE_GET_CROP_STEERING_HISTORY,
         websocket_get_crop_steering_history,
         SCHEMA_WS_GET_CROP_STEERING_HISTORY,
-        False,
     ),
-    (
+    WSCommand(
         WS_TYPE_APPLY_STEERING_MODE,
         websocket_apply_steering_mode,
         SCHEMA_WS_APPLY_STEERING_MODE,
-        False,
     ),
 ]

--- a/custom_components/growspace_manager/websocket/lineage.py
+++ b/custom_components/growspace_manager/websocket/lineage.py
@@ -9,20 +9,13 @@ import voluptuous as vol
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
-from custom_components.growspace_manager.exceptions import GrowspaceError
+from custom_components.growspace_manager.exceptions import PlantNotFoundError
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 
-from ._common import WSErrorMap, handle_ws_errors
+from ._common import WSCommand
 
 _LOGGER = logging.getLogger(__name__)
-
-# Strain library lookups report "not loaded" rather than a generic failure.
-_STRAIN_LIBRARY_ERROR_MAP: WSErrorMap = (
-    (ServiceValidationError, "not_loaded", False, None),
-    (Exception, "unknown_error", False, None),
-)
 
 WS_TYPE_GET_LINEAGE_TREE = f"{DOMAIN}/get_lineage_tree"
 SCHEMA_WS_GET_LINEAGE_TREE = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
@@ -66,89 +59,78 @@ SCHEMA_WS_IMPORT_STRAIN_LINEAGE_TREE = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA
 
 
 async def websocket_get_lineage_tree(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Handle get lineage tree command."""
     plant_id = msg["plant_id"]
-    try:
-        coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
-    except ServiceValidationError as err:
-        connection.send_error(msg["id"], "invalid_args", str(err))
-        return
-    except Exception as e:  # noqa: BLE001
-        connection.send_error(msg["id"], "unknown_error", str(e))
-        return
-
     if plant_id not in coordinator.plants:
-        connection.send_error(msg["id"], "invalid_args", f"Plant {plant_id} not found")
-        return
+        raise PlantNotFoundError(f"Plant {plant_id} not found")
 
-    try:
-        tree = coordinator.services.genetics.get_lineage_tree(plant_id)
+    tree = coordinator.services.genetics.get_lineage_tree(plant_id)
 
-        if not tree.get("parents") and (strain_library := coordinator.services.config.strain_library):
-            plant = coordinator.plants.get(plant_id)
-            strain_name = plant.genetics.strain_name if plant else None
-            if strain_name:
-                strain_tree = strain_library.get_strain_lineage_tree(strain_name)
-                if strain_tree.get("parents"):
-                    tree["parents"] = strain_tree["parents"]
+    if not tree.get("parents") and (
+        strain_library := coordinator.services.config.strain_library
+    ):
+        plant = coordinator.plants.get(plant_id)
+        strain_name = plant.genetics.strain_name if plant else None
+        if strain_name:
+            strain_tree = strain_library.get_strain_lineage_tree(strain_name)
+            if strain_tree.get("parents"):
+                tree["parents"] = strain_tree["parents"]
 
-        connection.send_result(msg["id"], tree)
-    except (
-        AttributeError,
-        KeyError,
-        ValueError,
-        ServiceValidationError,
-        GrowspaceError,
-        Exception,  # noqa: BLE001
-    ) as e:
-        connection.send_error(msg["id"], "unknown_error", str(e))
+    return tree
 
 
-@handle_ws_errors(_STRAIN_LIBRARY_ERROR_MAP)
 async def websocket_get_strain_lineage_tree(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Handle get_strain_lineage_tree command."""
-    strain_name = msg["strain_name"]
-    coordinator = GrowspaceCoordinator.get_any(hass)
     strain_library = coordinator.services.config.strain_library
-    tree = strain_library.get_strain_lineage_tree(strain_name)
-    connection.send_result(msg["id"], tree)
+    return strain_library.get_strain_lineage_tree(msg["strain_name"])
 
 
-@handle_ws_errors(_STRAIN_LIBRARY_ERROR_MAP)
 async def websocket_update_strain_lineage_tree(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Handle update_strain_lineage_tree command."""
-    strain_name = msg["strain_name"]
-    parents = msg["parents"]
-    coordinator = GrowspaceCoordinator.get_any(hass)
     strain_library = coordinator.services.config.strain_library
-    flat_lineage = await strain_library.update_strain_lineage_tree(strain_name, parents)
-    connection.send_result(msg["id"], {"lineage": flat_lineage})
+    flat_lineage = await strain_library.update_strain_lineage_tree(
+        msg["strain_name"], msg["parents"]
+    )
+    return {"lineage": flat_lineage}
 
 
-@handle_ws_errors(_STRAIN_LIBRARY_ERROR_MAP)
 async def websocket_import_strain_lineage_tree(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Import a full seedfinder lineage tree, creating ancestor stubs as needed."""
-    strain_name = msg["strain_name"]
-    tree = msg["tree"]
-    coordinator = GrowspaceCoordinator.get_any(hass)
     strain_library = coordinator.services.config.strain_library
     await strain_library.async_import_seedfinder_lineage_tree(
-        strain_name, tree, scraper=coordinator.seedfinder_scraper
+        msg["strain_name"], msg["tree"], scraper=coordinator.seedfinder_scraper
     )
-    connection.send_result(msg["id"], {"ok": True})
+    return {"ok": True}
 
 
-COMMANDS: list[tuple[str, Any, Any, bool]] = [
-    (WS_TYPE_GET_LINEAGE_TREE, websocket_get_lineage_tree, SCHEMA_WS_GET_LINEAGE_TREE, False),
-    (WS_TYPE_GET_STRAIN_LINEAGE_TREE, websocket_get_strain_lineage_tree, SCHEMA_WS_GET_STRAIN_LINEAGE_TREE, False),
-    (WS_TYPE_UPDATE_STRAIN_LINEAGE_TREE, websocket_update_strain_lineage_tree, SCHEMA_WS_UPDATE_STRAIN_LINEAGE_TREE, False),
-    (WS_TYPE_IMPORT_STRAIN_LINEAGE_TREE, websocket_import_strain_lineage_tree, SCHEMA_WS_IMPORT_STRAIN_LINEAGE_TREE, False),
+COMMANDS: list[WSCommand] = [
+    WSCommand(
+        WS_TYPE_GET_LINEAGE_TREE, websocket_get_lineage_tree, SCHEMA_WS_GET_LINEAGE_TREE
+    ),
+    WSCommand(
+        WS_TYPE_GET_STRAIN_LINEAGE_TREE,
+        websocket_get_strain_lineage_tree,
+        SCHEMA_WS_GET_STRAIN_LINEAGE_TREE,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_UPDATE_STRAIN_LINEAGE_TREE,
+        websocket_update_strain_lineage_tree,
+        SCHEMA_WS_UPDATE_STRAIN_LINEAGE_TREE,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_IMPORT_STRAIN_LINEAGE_TREE,
+        websocket_import_strain_lineage_tree,
+        SCHEMA_WS_IMPORT_STRAIN_LINEAGE_TREE,
+        resolve="any",
+    ),
 ]

--- a/custom_components/growspace_manager/websocket/logbook.py
+++ b/custom_components/growspace_manager/websocket/logbook.py
@@ -15,6 +15,7 @@ from custom_components.growspace_manager.const import (
     EVENT_GROWSPACE_LOG_ENTRY,
     EVENT_LOG_LOOKBACK_DAYS,
 )
+from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from homeassistant.components import websocket_api
 from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.db_schema import EventData, Events, EventTypes
@@ -22,7 +23,7 @@ from homeassistant.components.recorder.util import session_scope
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
-from ._common import _merge_logbook_event
+from ._common import WSCommand, _merge_logbook_event
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -133,110 +134,89 @@ def _query_logbook_events_impl(
                     d["event_id"] = e_row.event_id
                     formatted.append(d)
 
-            except (json.JSONDecodeError, AttributeError):
+            except json.JSONDecodeError, AttributeError:
                 continue
     return formatted
 
 
+async def _query_grouped_events(
+    hass: HomeAssistant,
+    msg: dict[str, Any],
+    lookback_days: int,
+    default_limit: int,
+    exclude_categories: set[str] | None,
+    include_categories: set[str] | None,
+    limit_multiplier: int,
+) -> dict[str, Any]:
+    """Run the recorder query and group results by plant/growspace key."""
+    growspace_id = msg.get("growspace_id")
+    plant_id = msg.get("plant_id")
+    limit = msg.get("limit", default_limit)
+    response_key = plant_id or growspace_id
+
+    try:
+        recorder = get_instance(hass)
+    except (ImportError, KeyError) as err:
+        # Recorder unavailable is a graceful empty result, not an error.
+        _LOGGER.warning("Recorder not available: %s", err)
+        return {response_key: []} if response_key else {}
+
+    end_time = dt_util.utcnow()
+    start_time = end_time - timedelta(days=lookback_days)
+
+    evts = await recorder.async_add_executor_job(
+        _query_logbook_events_impl,
+        hass,
+        start_time,
+        end_time,
+        limit,
+        growspace_id,
+        plant_id,
+        exclude_categories,
+        include_categories,
+        limit_multiplier,
+    )
+    res: dict[str, Any] = {}
+    if response_key:
+        res[response_key] = evts
+    else:
+        for v in evts:
+            gid = v.get("growspace_id", "global")
+            res.setdefault(gid, []).append(v)
+    return res
+
+
 async def websocket_get_event_log(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Handle get event log command via Recorder.
 
     Excludes high-frequency environmental alerts (optimal, stress, mold).
     """
-    growspace_id = msg.get("growspace_id")
-    plant_id = msg.get("plant_id")
-    limit = msg.get("limit", 50)
     spam_cats = {"optimal", "stress", "mold", "alert", "environment"}
-
-    try:
-        recorder = get_instance(hass)
-        end_time = dt_util.utcnow()
-        start_time = end_time - timedelta(days=EVENT_LOG_LOOKBACK_DAYS)
-
-        evts = await recorder.async_add_executor_job(
-            _query_logbook_events_impl,
-            hass,
-            start_time,
-            end_time,
-            limit,
-            growspace_id,
-            plant_id,
-            spam_cats,
-            None,
-            2,
-        )
-        res = {}
-        response_key = plant_id or growspace_id
-        if response_key:
-            res[response_key] = evts
-        else:
-            for v in evts:
-                gid = v.get("growspace_id", "global")
-                res.setdefault(gid, []).append(v)
-
-        connection.send_result(msg["id"], res)
-
-    except (ImportError, KeyError) as err:
-        _LOGGER.warning("Recorder not available: %s", err)
-        response_key = plant_id or growspace_id
-        connection.send_result(msg["id"], {response_key: []} if response_key else {})
-    except Exception as err:
-        _LOGGER.exception("Error handling websocket_get_event_log")
-        connection.send_error(msg["id"], "unknown_error", str(err))
+    return await _query_grouped_events(
+        hass, msg, EVENT_LOG_LOOKBACK_DAYS, 50, spam_cats, None, 2
+    )
 
 
 async def websocket_get_alerts(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Handle get alerts command via Recorder.
 
     ONLY includes high-frequency environmental alerts (optimal, stress, mold).
     """
-    growspace_id = msg.get("growspace_id")
-    plant_id = msg.get("plant_id")
-    limit = msg.get("limit", 200)
     alert_cats = {"optimal", "stress", "mold", "alert", "environment"}
-
-    try:
-        recorder = get_instance(hass)
-        end_time = dt_util.utcnow()
-        start_time = end_time - timedelta(days=ALERT_LOG_LOOKBACK_DAYS)
-
-        evts = await recorder.async_add_executor_job(
-            _query_logbook_events_impl,
-            hass,
-            start_time,
-            end_time,
-            limit,
-            growspace_id,
-            plant_id,
-            None,
-            alert_cats,
-            5,
-        )
-        res = {}
-        response_key = plant_id or growspace_id
-        if response_key:
-            res[response_key] = evts
-        else:
-            for v in evts:
-                gid = v.get("growspace_id", "global")
-                res.setdefault(gid, []).append(v)
-
-        connection.send_result(msg["id"], res)
-
-    except (ImportError, KeyError) as err:
-        _LOGGER.warning("Recorder not available: %s", err)
-        response_key = plant_id or growspace_id
-        connection.send_result(msg["id"], {response_key: []} if response_key else {})
-    except Exception as err:
-        _LOGGER.exception("Error handling websocket_get_alerts")
-        connection.send_error(msg["id"], "unknown_error", str(err))
+    return await _query_grouped_events(
+        hass, msg, ALERT_LOG_LOOKBACK_DAYS, 200, None, alert_cats, 5
+    )
 
 
-COMMANDS: list[tuple[str, Any, Any, bool]] = [
-    (WS_TYPE_GET_LOG, websocket_get_event_log, SCHEMA_WS_GET_LOG, False),
-    (WS_TYPE_GET_ALERTS, websocket_get_alerts, SCHEMA_WS_GET_ALERTS, False),
+COMMANDS: list[WSCommand] = [
+    WSCommand(
+        WS_TYPE_GET_LOG, websocket_get_event_log, SCHEMA_WS_GET_LOG, resolve="any"
+    ),
+    WSCommand(
+        WS_TYPE_GET_ALERTS, websocket_get_alerts, SCHEMA_WS_GET_ALERTS, resolve="any"
+    ),
 ]

--- a/custom_components/growspace_manager/websocket/notifications.py
+++ b/custom_components/growspace_manager/websocket/notifications.py
@@ -11,20 +11,10 @@ from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+
+from ._common import WSCommand
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _get_coordinator(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-) -> GrowspaceCoordinator | None:
-    try:
-        return GrowspaceCoordinator.get_for_service_call(hass, {})
-    except (ServiceValidationError, Exception):  # noqa: BLE001
-        return None
-
 
 WS_TYPE_SAVE_NOTIFICATION_SETTINGS = f"{DOMAIN}/save_notification_settings"
 SCHEMA_WS_SAVE_NOTIFICATION_SETTINGS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
@@ -38,18 +28,9 @@ SCHEMA_WS_SAVE_NOTIFICATION_SETTINGS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA
 
 
 async def websocket_save_notification_settings(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Persist notification timing settings and ai_auto_alerts atomically."""
-    coordinator = _get_coordinator(hass, connection)
-    if coordinator is None:
-        connection.send_error(
-            msg["id"], "not_found", "Growspace Manager integration not loaded"
-        )
-        return
-
     new_options = coordinator.config_entry.options.copy()
     new_options["notification_settings"] = msg["notification_settings"]
 
@@ -65,17 +46,19 @@ async def websocket_save_notification_settings(
     if hasattr(coordinator, "options"):
         coordinator.options = new_options
 
-    hass.config_entries.async_update_entry(coordinator.config_entry, options=new_options)
+    hass.config_entries.async_update_entry(
+        coordinator.config_entry, options=new_options
+    )
     await coordinator.async_commit()
 
-    connection.send_result(msg["id"], {"success": True})
+    return {"success": True}
 
 
-COMMANDS: list[tuple[str, Any, Any, bool]] = [
-    (
+COMMANDS: list[WSCommand] = [
+    WSCommand(
         WS_TYPE_SAVE_NOTIFICATION_SETTINGS,
         websocket_save_notification_settings,
         SCHEMA_WS_SAVE_NOTIFICATION_SETTINGS,
-        False,
+        resolve="any",
     ),
 ]

--- a/custom_components/growspace_manager/websocket/nutrients.py
+++ b/custom_components/growspace_manager/websocket/nutrients.py
@@ -10,15 +10,10 @@ import voluptuous as vol
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from homeassistant.components import websocket_api
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 
-from ._common import WSErrorMap, handle_ws_errors_sync
-
-_ERROR_MAP: WSErrorMap = (
-    (ServiceValidationError, "not_loaded", False, "Growspace Manager integration not loaded"),
-    (Exception, "unknown_error", True, None),
-)
+from ._common import WSCommand
 
 WS_TYPE_GET_NUTRIENT_PRESETS = f"{DOMAIN}/get_nutrient_presets"
 SCHEMA_WS_GET_NUTRIENT_PRESETS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
@@ -77,69 +72,49 @@ SCHEMA_WS_REMOVE_NUTRIENT_STOCK = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.exte
 )
 
 
-@callback
-@handle_ws_errors_sync(_ERROR_MAP)
 def websocket_get_nutrient_presets(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Handle get nutrient presets command via WebSocket."""
-    coordinator: GrowspaceCoordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
-    data = coordinator.services.config.get_nutrient_serialization_data()
-    connection.send_result(msg["id"], data["nutrient_presets"])
+    return coordinator.services.config.get_nutrient_serialization_data()[
+        "nutrient_presets"
+    ]
 
 
-@callback
-@handle_ws_errors_sync(_ERROR_MAP)
 def websocket_get_ipm_presets(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Handle get IPM presets command via WebSocket."""
-    coordinator: GrowspaceCoordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
-    data = coordinator.services.config.get_nutrient_serialization_data()
-    connection.send_result(msg["id"], data["ipm_presets"])
+    return coordinator.services.config.get_nutrient_serialization_data()["ipm_presets"]
 
 
-@callback
-@handle_ws_errors_sync(_ERROR_MAP)
 def websocket_get_ec_ramp_curves(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Handle get EC ramp curves command via WebSocket."""
-    coordinator: GrowspaceCoordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
-    data = coordinator.services.config.get_nutrient_serialization_data()
-    connection.send_result(msg["id"], data.get("ec_ramp_curves", []))
+    return coordinator.services.config.get_nutrient_serialization_data().get(
+        "ec_ramp_curves", []
+    )
 
 
-@callback
-@handle_ws_errors_sync(_ERROR_MAP)
 def websocket_get_nutrient_inventory(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Handle get nutrient inventory command."""
-    coordinator: GrowspaceCoordinator = GrowspaceCoordinator.get_any(hass)
     inventory = coordinator.services.config.get_inventory()
     if inventory is not None:
-        connection.send_result(msg["id"], asdict(inventory))
-    else:
-        connection.send_result(msg["id"], {"stocks": {}})
+        return asdict(inventory)
+    return {"stocks": {}}
 
 
-@callback
-@handle_ws_errors_sync(_ERROR_MAP)
 def websocket_update_nutrient_stock(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
 ) -> None:
     """Handle update nutrient stock command."""
-    coordinator: GrowspaceCoordinator = GrowspaceCoordinator.get_any(hass)
     current_ml = float(msg["current_ml"])
     initial_ml = float(msg["initial_ml"])
     if current_ml > initial_ml:
-        connection.send_error(
-            msg["id"],
-            "invalid_input",
-            "current_ml cannot exceed initial_ml",
-        )
-        return
+        raise ServiceValidationError("current_ml cannot exceed initial_ml")
     coordinator.services.config.update_stock(
         nutrient_id=msg["nutrient_id"],
         name=msg["name"],
@@ -154,28 +129,56 @@ def websocket_update_nutrient_stock(
     coordinator.config_entry.async_create_background_task(
         hass, coordinator.async_commit(), "save_coordinator_data"
     )
-    connection.send_result(msg["id"])
 
 
-@callback
-@handle_ws_errors_sync(_ERROR_MAP)
 def websocket_remove_nutrient_stock(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
 ) -> None:
     """Handle remove nutrient stock command."""
-    coordinator: GrowspaceCoordinator = GrowspaceCoordinator.get_any(hass)
     coordinator.services.config.remove_stock(msg["nutrient_id"])
     coordinator.config_entry.async_create_background_task(
         hass, coordinator.async_commit(), "save_coordinator_data"
     )
-    connection.send_result(msg["id"])
 
 
-COMMANDS: list[tuple[str, Any, Any, bool]] = [
-    (WS_TYPE_GET_NUTRIENT_PRESETS, websocket_get_nutrient_presets, SCHEMA_WS_GET_NUTRIENT_PRESETS, True),
-    (WS_TYPE_GET_IPM_PRESETS, websocket_get_ipm_presets, SCHEMA_WS_GET_IPM_PRESETS, True),
-    (WS_TYPE_GET_EC_RAMP_CURVES, websocket_get_ec_ramp_curves, SCHEMA_WS_GET_EC_RAMP_CURVES, True),
-    (WS_TYPE_GET_NUTRIENT_INVENTORY, websocket_get_nutrient_inventory, SCHEMA_WS_GET_NUTRIENT_INVENTORY, True),
-    (WS_TYPE_UPDATE_NUTRIENT_STOCK, websocket_update_nutrient_stock, SCHEMA_WS_UPDATE_NUTRIENT_STOCK, True),
-    (WS_TYPE_REMOVE_NUTRIENT_STOCK, websocket_remove_nutrient_stock, SCHEMA_WS_REMOVE_NUTRIENT_STOCK, True),
+COMMANDS: list[WSCommand] = [
+    WSCommand(
+        WS_TYPE_GET_NUTRIENT_PRESETS,
+        websocket_get_nutrient_presets,
+        SCHEMA_WS_GET_NUTRIENT_PRESETS,
+        sync=True,
+    ),
+    WSCommand(
+        WS_TYPE_GET_IPM_PRESETS,
+        websocket_get_ipm_presets,
+        SCHEMA_WS_GET_IPM_PRESETS,
+        sync=True,
+    ),
+    WSCommand(
+        WS_TYPE_GET_EC_RAMP_CURVES,
+        websocket_get_ec_ramp_curves,
+        SCHEMA_WS_GET_EC_RAMP_CURVES,
+        sync=True,
+    ),
+    WSCommand(
+        WS_TYPE_GET_NUTRIENT_INVENTORY,
+        websocket_get_nutrient_inventory,
+        SCHEMA_WS_GET_NUTRIENT_INVENTORY,
+        resolve="any",
+        sync=True,
+    ),
+    WSCommand(
+        WS_TYPE_UPDATE_NUTRIENT_STOCK,
+        websocket_update_nutrient_stock,
+        SCHEMA_WS_UPDATE_NUTRIENT_STOCK,
+        resolve="any",
+        sync=True,
+    ),
+    WSCommand(
+        WS_TYPE_REMOVE_NUTRIENT_STOCK,
+        websocket_remove_nutrient_stock,
+        SCHEMA_WS_REMOVE_NUTRIENT_STOCK,
+        resolve="any",
+        sync=True,
+    ),
 ]

--- a/custom_components/growspace_manager/websocket/plant.py
+++ b/custom_components/growspace_manager/websocket/plant.py
@@ -46,14 +46,18 @@ from custom_components.growspace_manager.const import (
     DOMAIN,
 )
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
-from custom_components.growspace_manager.exceptions import GrowspaceError
+from custom_components.growspace_manager.exceptions import (
+    GrowspaceError,
+    GrowspaceNotFoundError,
+    PlantNotFoundError,
+)
 from custom_components.growspace_manager.utils import parse_date_field
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util import dt as dt_util
 
-from ._common import handle_ws_errors
+from ._common import WSCommand
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -274,35 +278,30 @@ def _parse_date_kwargs(msg: dict[str, Any]) -> dict[str, Any]:
     return {f: parse_date_field(msg[f]) for f in add_date_fields if f in msg}
 
 
-@handle_ws_errors()
 async def websocket_water_plant(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Water a plant."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     await coordinator.services.plants.water_plant(
         plant_id=msg[ATTR_PLANT_ID],
         amount=msg[ATTR_AMOUNT],
         nutrients=msg.get(ATTR_NUTRIENTS),
         preset_id=msg.get(ATTR_PRESET_ID),
     )
-    connection.send_result(msg["id"])
 
 
-@handle_ws_errors()
 async def websocket_add_plant(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Add a single plant to a growspace."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     growspace_id: str = msg[ATTR_GROWSPACE_ID]
 
     if growspace_id not in coordinator.growspaces:
-        raise ServiceValidationError(f"Growspace '{growspace_id}' not found")
+        raise GrowspaceNotFoundError(f"Growspace '{growspace_id}' not found")
 
     parsed_dates = _parse_date_kwargs(msg)
     if growspace_id == CANONICAL_ID_MOTHER and not parsed_dates.get("mother_start"):
@@ -326,23 +325,19 @@ async def websocket_add_plant(
         **parsed_dates,
     )
 
-    connection.send_result(msg["id"])
 
-
-@handle_ws_errors()
 async def websocket_add_plants(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Batch-add plants to a growspace."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     growspace_id: str = msg[ATTR_GROWSPACE_ID]
     strain: str = msg[ATTR_STRAIN]
     amount: int = msg[ATTR_AMOUNT]
 
     if growspace_id not in coordinator.growspaces:
-        raise ServiceValidationError(f"Growspace '{growspace_id}' not found")
+        raise GrowspaceNotFoundError(f"Growspace '{growspace_id}' not found")
 
     free_row, free_col = coordinator.validator.find_first_available_position(
         growspace_id
@@ -396,17 +391,15 @@ async def websocket_add_plants(
             _LOGGER.error("Batch add stopped at plant %d: %s", i + 1, err)
             break
 
-    connection.send_result(msg["id"], {"plants_added": plants_added})
+    return {"plants_added": plants_added}
 
 
-@handle_ws_errors()
 async def websocket_update_plant(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Update attributes on a plant."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     plant_id: str = msg[ATTR_PLANT_ID]
     coordinator.validator.validate_plant_exists(plant_id)
 
@@ -425,38 +418,31 @@ async def websocket_update_plant(
     if update_data:
         await coordinator.services.plants.update_plant(plant_id, **update_data)
 
-    connection.send_result(msg["id"])
 
-
-@handle_ws_errors()
 async def websocket_remove_plant(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Remove a plant from its growspace."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     plant_id: str = msg[ATTR_PLANT_ID]
 
     if plant_id not in coordinator.plants:
-        raise ServiceValidationError(f"Plant '{plant_id}' not found")
+        raise PlantNotFoundError(f"Plant '{plant_id}' not found")
 
     await coordinator.services.plants.remove_plant(plant_id)
-    connection.send_result(msg["id"])
 
 
-@handle_ws_errors()
 async def websocket_harvest_plant(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Harvest a plant, optionally with yield metrics."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     plant_id: str = msg[ATTR_PLANT_ID]
 
     if plant_id not in coordinator.plants:
-        raise ServiceValidationError(f"Plant '{plant_id}' not found")
+        raise PlantNotFoundError(f"Plant '{plant_id}' not found")
 
     transition_date_str: str | None = msg.get(ATTR_TRANSITION_DATE)
     transition_date: str | None = None
@@ -481,22 +467,19 @@ async def websocket_harvest_plant(
         cbd_percentage=msg.get(ATTR_CBD_PERCENTAGE),
         terpene_profile=msg.get(ATTR_TERPENE_PROFILE),
     )
-    connection.send_result(msg["id"])
 
 
-@handle_ws_errors()
 async def websocket_move_plant(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Transplant a non-clone plant to a different growspace."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     plant_id: str = msg[ATTR_PLANT_ID]
     target_growspace_id: str = msg[ATTR_TARGET_GROWSPACE_ID]
 
     if plant_id not in coordinator.plants:
-        raise ServiceValidationError(f"Plant '{plant_id}' not found")
+        raise PlantNotFoundError(f"Plant '{plant_id}' not found")
 
     transition_date_str: str | None = msg.get(ATTR_TRANSITION_DATE)
     transition_date: str | None = None
@@ -511,17 +494,14 @@ async def websocket_move_plant(
         target_growspace_name=None,
         transition_date=transition_date,
     )
-    connection.send_result(msg["id"])
 
 
-@handle_ws_errors()
 async def websocket_move_clone(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Promote a clone to the next growth stage in a target growspace."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     plant_id: str = msg[ATTR_PLANT_ID]
     target_growspace_id: str = msg[ATTR_TARGET_GROWSPACE_ID]
 
@@ -539,41 +519,35 @@ async def websocket_move_clone(
         target_growspace_id=target_growspace_id,
         transition_date=transition_date,
     )
-    connection.send_result(msg["id"])
 
 
-@handle_ws_errors()
 async def websocket_switch_plants(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Swap the grid positions of two plants."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     plant1_id: str = msg[ATTR_PLANT1_ID]
     plant2_id: str = msg[ATTR_PLANT2_ID]
 
     if plant1_id not in coordinator.plants:
-        raise ServiceValidationError(f"Plant '{plant1_id}' not found")
+        raise PlantNotFoundError(f"Plant '{plant1_id}' not found")
     if plant2_id not in coordinator.plants:
-        raise ServiceValidationError(f"Plant '{plant2_id}' not found")
+        raise PlantNotFoundError(f"Plant '{plant2_id}' not found")
 
     await coordinator.services.plants.switch_plants(plant1_id, plant2_id)
-    connection.send_result(msg["id"])
 
 
-@handle_ws_errors()
 async def websocket_take_clone(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Take clones from a mother plant."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     mother_plant_id: str = msg[ATTR_MOTHER_PLANT_ID]
 
     if mother_plant_id not in coordinator.plants:
-        raise ServiceValidationError(f"Mother plant '{mother_plant_id}' not found")
+        raise PlantNotFoundError(f"Mother plant '{mother_plant_id}' not found")
 
     transition_date_str: str | None = msg.get(ATTR_TRANSITION_DATE)
     # Keep the full datetime (no .date() truncation): the manager's Lifecycle
@@ -591,21 +565,17 @@ async def websocket_take_clone(
         transition_date=transition_date,
     )
 
-    connection.send_result(msg["id"])
 
-
-@handle_ws_errors()
 async def websocket_score_plant(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Score phenotype traits on a plant."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     plant_id: str = msg[ATTR_PLANT_ID]
 
     if plant_id not in coordinator.plants:
-        raise ServiceValidationError(f"Plant '{plant_id}' not found")
+        raise PlantNotFoundError(f"Plant '{plant_id}' not found")
 
     await coordinator.services.plants.score_plant(
         plant_id=plant_id,
@@ -621,64 +591,52 @@ async def websocket_score_plant(
         keeper=msg.get(ATTR_KEEPER),
         notes=msg.get("notes"),
     )
-    connection.send_result(msg["id"])
 
 
-@handle_ws_errors()
 async def websocket_log_drying_weight(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Log a drying weight reading for a plant."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     await coordinator.services.plants.log_drying_weight(
         plant_id=msg[ATTR_PLANT_ID],
         weight_grams=msg["weight_grams"],
         date=msg.get("date"),
     )
-    connection.send_result(msg["id"])
 
 
-@handle_ws_errors()
 async def websocket_log_moisture_reading(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Log a substrate moisture reading for a plant."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     await coordinator.services.plants.log_moisture_reading(
         plant_id=msg[ATTR_PLANT_ID],
         moisture_percent=msg["moisture_percent"],
         date=msg.get("date"),
     )
-    connection.send_result(msg["id"])
 
 
-@handle_ws_errors()
 async def websocket_set_visual_tag(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Attach or clear a visual tag on a plant."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     await coordinator.services.plants.set_visual_tag(
         plant_id=msg[ATTR_PLANT_ID],
         visual_tag=msg["visual_tag"],
     )
-    connection.send_result(msg["id"])
 
 
-@handle_ws_errors()
 async def websocket_update_harvest_metrics(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Persist harvest yield metrics on a plant."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     await coordinator.services.plants.update_harvest_metrics(
         plant_id=msg[ATTR_PLANT_ID],
         wet_weight=msg.get(ATTR_WET_WEIGHT),
@@ -688,52 +646,50 @@ async def websocket_update_harvest_metrics(
         cbd_percentage=msg.get(ATTR_CBD_PERCENTAGE),
         terpene_profile=msg.get(ATTR_TERPENE_PROFILE),
     )
-    connection.send_result(msg["id"])
 
 
-@handle_ws_errors()
 async def websocket_print_label(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
+    coordinator: GrowspaceCoordinator,
     msg: dict[str, Any],
-) -> None:
+) -> Any:
     """Print a label for a plant or strain via the Niimbot service."""
     skip_keys = {"id", "type"}
     service_data = {k: v for k, v in msg.items() if k not in skip_keys}
     await hass.services.async_call(DOMAIN, "print_label", service_data, blocking=True)
-    connection.send_result(msg["id"])
 
 
-COMMANDS: list[tuple[str, Any, Any, bool]] = [
-    (WS_TYPE_WATER_PLANT, websocket_water_plant, SCHEMA_WS_WATER_PLANT, False),
-    (WS_TYPE_ADD_PLANT, websocket_add_plant, SCHEMA_WS_ADD_PLANT, False),
-    (WS_TYPE_ADD_PLANTS, websocket_add_plants, SCHEMA_WS_ADD_PLANTS, False),
-    (WS_TYPE_UPDATE_PLANT, websocket_update_plant, SCHEMA_WS_UPDATE_PLANT, False),
-    (WS_TYPE_REMOVE_PLANT, websocket_remove_plant, SCHEMA_WS_REMOVE_PLANT, False),
-    (WS_TYPE_HARVEST_PLANT, websocket_harvest_plant, SCHEMA_WS_HARVEST_PLANT, False),
-    (WS_TYPE_MOVE_PLANT, websocket_move_plant, SCHEMA_WS_MOVE_PLANT, False),
-    (WS_TYPE_MOVE_CLONE, websocket_move_clone, SCHEMA_WS_MOVE_CLONE, False),
-    (WS_TYPE_SWITCH_PLANTS, websocket_switch_plants, SCHEMA_WS_SWITCH_PLANTS, False),
-    (WS_TYPE_TAKE_CLONE, websocket_take_clone, SCHEMA_WS_TAKE_CLONE, False),
-    (WS_TYPE_SCORE_PLANT, websocket_score_plant, SCHEMA_WS_SCORE_PLANT, False),
-    (
+COMMANDS: list[WSCommand] = [
+    WSCommand(WS_TYPE_WATER_PLANT, websocket_water_plant, SCHEMA_WS_WATER_PLANT),
+    WSCommand(WS_TYPE_ADD_PLANT, websocket_add_plant, SCHEMA_WS_ADD_PLANT),
+    WSCommand(WS_TYPE_ADD_PLANTS, websocket_add_plants, SCHEMA_WS_ADD_PLANTS),
+    WSCommand(WS_TYPE_UPDATE_PLANT, websocket_update_plant, SCHEMA_WS_UPDATE_PLANT),
+    WSCommand(WS_TYPE_REMOVE_PLANT, websocket_remove_plant, SCHEMA_WS_REMOVE_PLANT),
+    WSCommand(WS_TYPE_HARVEST_PLANT, websocket_harvest_plant, SCHEMA_WS_HARVEST_PLANT),
+    WSCommand(WS_TYPE_MOVE_PLANT, websocket_move_plant, SCHEMA_WS_MOVE_PLANT),
+    WSCommand(WS_TYPE_MOVE_CLONE, websocket_move_clone, SCHEMA_WS_MOVE_CLONE),
+    WSCommand(WS_TYPE_SWITCH_PLANTS, websocket_switch_plants, SCHEMA_WS_SWITCH_PLANTS),
+    WSCommand(WS_TYPE_TAKE_CLONE, websocket_take_clone, SCHEMA_WS_TAKE_CLONE),
+    WSCommand(WS_TYPE_SCORE_PLANT, websocket_score_plant, SCHEMA_WS_SCORE_PLANT),
+    WSCommand(
         WS_TYPE_LOG_DRYING_WEIGHT,
         websocket_log_drying_weight,
         SCHEMA_WS_LOG_DRYING_WEIGHT,
-        False,
     ),
-    (
+    WSCommand(
         WS_TYPE_LOG_MOISTURE_READING,
         websocket_log_moisture_reading,
         SCHEMA_WS_LOG_MOISTURE_READING,
-        False,
     ),
-    (WS_TYPE_SET_VISUAL_TAG, websocket_set_visual_tag, SCHEMA_WS_SET_VISUAL_TAG, False),
-    (
+    WSCommand(
+        WS_TYPE_SET_VISUAL_TAG, websocket_set_visual_tag, SCHEMA_WS_SET_VISUAL_TAG
+    ),
+    WSCommand(
         WS_TYPE_UPDATE_HARVEST_METRICS,
         websocket_update_harvest_metrics,
         SCHEMA_WS_UPDATE_HARVEST_METRICS,
-        False,
     ),
-    (WS_TYPE_PRINT_LABEL, websocket_print_label, SCHEMA_WS_PRINT_LABEL, False),
+    WSCommand(
+        WS_TYPE_PRINT_LABEL, websocket_print_label, SCHEMA_WS_PRINT_LABEL, resolve="any"
+    ),
 ]

--- a/custom_components/growspace_manager/websocket/strain.py
+++ b/custom_components/growspace_manager/websocket/strain.py
@@ -10,26 +10,16 @@ import voluptuous as vol
 
 from custom_components.growspace_manager.const import CONF_BLACKLIST_BREEDERS, DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
+from custom_components.growspace_manager.exceptions import GrowspaceError
 from custom_components.growspace_manager.strain_library import StrainLibrary
 from homeassistant.components import websocket_api
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import slugify
 
-from ._common import WSErrorMap, handle_ws_errors, handle_ws_errors_sync
+from ._common import WSCommand
 
 _LOGGER = logging.getLogger(__name__)
-
-_LIBRARY_ERROR_MAP: WSErrorMap = (
-    (ServiceValidationError, "not_loaded", False, "Growspace Manager strain library not loaded"),
-    (Exception, "unknown_error", True, None),
-)
-
-_IMAGE_ERROR_MAP: WSErrorMap = (
-    (ServiceValidationError, "not_loaded", False, "Strain library not loaded"),
-    (Exception, "unknown_error", False, None),
-)
 
 WS_TYPE_GET_STRAIN_LIBRARY = f"{DOMAIN}/get_strain_library"
 SCHEMA_WS_GET_STRAIN_LIBRARY = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
@@ -79,50 +69,37 @@ SCHEMA_WS_DOWNLOAD_STRAIN_IMAGE = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.exte
 )
 
 
-@callback
-@handle_ws_errors_sync(_LIBRARY_ERROR_MAP)
 def websocket_get_strain_library(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Handle get strain library command via WebSocket."""
-    coordinator = GrowspaceCoordinator.get_any(hass)
     strain_library: StrainLibrary = coordinator.services.config.strain_library
     all_strains = strain_library.get_all()
-    response = {
+    return {
         "strains": all_strains,
         "strain_list": list(all_strains.keys()),
     }
-    connection.send_result(msg["id"], response)
 
 
-@handle_ws_errors(_IMAGE_ERROR_MAP)
 async def websocket_upload_strain_image(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Upload a strain image to disk and return its local path."""
-    coordinator = GrowspaceCoordinator.get_any(hass)
     image_manager = coordinator.services.config.strain_library.image_manager
     abs_path = await image_manager.save_strain_image(
         slugify(msg["strain"]), slugify(msg["phenotype"]), msg["image_base64"]
     )
     filename = Path(abs_path).name
-    local_path = f"/local/growspace_manager/strains/{filename}"
-    connection.send_result(msg["id"], {"path": local_path})
+    return {"path": f"/local/growspace_manager/strains/{filename}"}
 
 
-@handle_ws_errors(_IMAGE_ERROR_MAP)
 async def websocket_download_strain_image(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Download a remote image URL and save it as a local strain image."""
     import base64 as _base64  # noqa: PLC0415
 
     url = msg["url"]
-    coordinator = GrowspaceCoordinator.get_any(hass)
     image_manager = coordinator.services.config.strain_library.image_manager
 
     session = async_get_clientsession(hass)
@@ -131,10 +108,11 @@ async def websocket_download_strain_image(
         "Accept": "image/webp,image/png,image/jpeg,*/*",
         "Referer": "https://en.seedfinder.eu/",
     }
-    async with session.get(url, timeout=15, headers=headers, allow_redirects=True, max_redirects=20) as response:
+    async with session.get(
+        url, timeout=15, headers=headers, allow_redirects=True, max_redirects=20
+    ) as response:
         if response.status != 200:
-            connection.send_error(msg["id"], "fetch_failed", f"HTTP {response.status}")
-            return
+            raise GrowspaceError(f"Image download failed: HTTP {response.status}")
         raw = await response.read()
 
     mime_type = response.headers.get("Content-Type", "image/jpeg")
@@ -143,55 +121,35 @@ async def websocket_download_strain_image(
         slugify(msg["strain"]), slugify(msg["phenotype"]), image_base64
     )
     filename = Path(abs_path).name
-    local_path = f"/local/growspace_manager/strains/{filename}"
-    connection.send_result(msg["id"], {"path": local_path})
+    return {"path": f"/local/growspace_manager/strains/{filename}"}
 
 
 async def websocket_query_external_strain(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> Any:
     """Query external strain database."""
-    query = msg["query"]
-    coordinator = GrowspaceCoordinator.get_any(hass)
     scraper = coordinator.seedfinder_scraper
 
     blacklist = []
     try:
-        coordinator = GrowspaceCoordinator.get_any(hass)
         blacklist = coordinator.config_entry.options.get(CONF_BLACKLIST_BREEDERS, [])
-    except (AttributeError, KeyError, RuntimeError):
-        _LOGGER.debug("Could not retrieve coordinator for blacklist, using empty list")
+    except AttributeError, KeyError, RuntimeError:
+        _LOGGER.debug("Could not retrieve blacklist, using empty list")
 
-    try:
-        results = await scraper.async_search_strains(query, blacklist=blacklist)
-    except ServiceValidationError as err:
-        connection.send_error(msg["id"], "seedfinder_unavailable", str(err))
-        return
-    connection.send_result(msg["id"], results)
+    return await scraper.async_search_strains(msg["query"], blacklist=blacklist)
 
 
 async def websocket_get_external_strain_details(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any] | None:
     """Get details for an external strain."""
     import re  # noqa: PLC0415
 
-    url = msg["url"]
-    coordinator = GrowspaceCoordinator.get_any(hass)
     scraper = coordinator.seedfinder_scraper
 
-    try:
-        raw = await scraper.async_get_strain_details(url)
-    except ServiceValidationError as err:
-        connection.send_error(msg["id"], "seedfinder_unavailable", str(err))
-        return
+    raw = await scraper.async_get_strain_details(msg["url"])
     if raw is None:
-        connection.send_result(msg["id"], None)
-        return
+        return None
 
     flowering_days: int | None = None
     ft = raw.get("flowering_time") or ""
@@ -201,36 +159,59 @@ async def websocket_get_external_strain_details(
         hi = int(ft_match.group(2)) if ft_match.group(2) else lo
         flowering_days = round((lo + hi) / 2)
 
-    connection.send_result(
-        msg["id"],
-        {
-            "name": raw.get("name"),
-            "breeder": raw.get("breeder"),
-            "type": raw.get("type"),
-            "indica_percentage": (raw.get("composition") or {}).get("indica"),
-            "sativa_percentage": (raw.get("composition") or {}).get("sativa"),
-            "flowering_days": flowering_days,
-            "description": raw.get("description"),
-            "images": raw.get("images", []),
-            "yield_potential": raw.get("yield_potential"),
-            "height": raw.get("height"),
-            "thc": raw.get("thc"),
-            "cbd": raw.get("cbd"),
-            "cbg": raw.get("cbg"),
-            "awards": raw.get("awards"),
-            "parents": raw.get("lineage_tree") or None,
-            "lineage_str": raw.get("lineage_str"),
-            "effects": raw.get("effects"),
-            "aroma": raw.get("aroma"),
-            "taste": raw.get("taste"),
-        },
-    )
+    return {
+        "name": raw.get("name"),
+        "breeder": raw.get("breeder"),
+        "type": raw.get("type"),
+        "indica_percentage": (raw.get("composition") or {}).get("indica"),
+        "sativa_percentage": (raw.get("composition") or {}).get("sativa"),
+        "flowering_days": flowering_days,
+        "description": raw.get("description"),
+        "images": raw.get("images", []),
+        "yield_potential": raw.get("yield_potential"),
+        "height": raw.get("height"),
+        "thc": raw.get("thc"),
+        "cbd": raw.get("cbd"),
+        "cbg": raw.get("cbg"),
+        "awards": raw.get("awards"),
+        "parents": raw.get("lineage_tree") or None,
+        "lineage_str": raw.get("lineage_str"),
+        "effects": raw.get("effects"),
+        "aroma": raw.get("aroma"),
+        "taste": raw.get("taste"),
+    }
 
 
-COMMANDS: list[tuple[str, Any, Any, bool]] = [
-    (WS_TYPE_GET_STRAIN_LIBRARY, websocket_get_strain_library, SCHEMA_WS_GET_STRAIN_LIBRARY, True),
-    (WS_TYPE_UPLOAD_STRAIN_IMAGE, websocket_upload_strain_image, SCHEMA_WS_UPLOAD_STRAIN_IMAGE, False),
-    (WS_TYPE_DOWNLOAD_STRAIN_IMAGE, websocket_download_strain_image, SCHEMA_WS_DOWNLOAD_STRAIN_IMAGE, False),
-    (WS_TYPE_QUERY_EXTERNAL_STRAIN, websocket_query_external_strain, SCHEMA_WS_QUERY_EXTERNAL_STRAIN, False),
-    (WS_TYPE_GET_EXTERNAL_STRAIN_DETAILS, websocket_get_external_strain_details, SCHEMA_WS_GET_EXTERNAL_STRAIN_DETAILS, False),
+COMMANDS: list[WSCommand] = [
+    WSCommand(
+        WS_TYPE_GET_STRAIN_LIBRARY,
+        websocket_get_strain_library,
+        SCHEMA_WS_GET_STRAIN_LIBRARY,
+        resolve="any",
+        sync=True,
+    ),
+    WSCommand(
+        WS_TYPE_UPLOAD_STRAIN_IMAGE,
+        websocket_upload_strain_image,
+        SCHEMA_WS_UPLOAD_STRAIN_IMAGE,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_DOWNLOAD_STRAIN_IMAGE,
+        websocket_download_strain_image,
+        SCHEMA_WS_DOWNLOAD_STRAIN_IMAGE,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_QUERY_EXTERNAL_STRAIN,
+        websocket_query_external_strain,
+        SCHEMA_WS_QUERY_EXTERNAL_STRAIN,
+        resolve="any",
+    ),
+    WSCommand(
+        WS_TYPE_GET_EXTERNAL_STRAIN_DETAILS,
+        websocket_get_external_strain_details,
+        SCHEMA_WS_GET_EXTERNAL_STRAIN_DETAILS,
+        resolve="any",
+    ),
 ]

--- a/custom_components/growspace_manager/websocket/subareas.py
+++ b/custom_components/growspace_manager/websocket/subareas.py
@@ -11,14 +11,8 @@ from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 
-from ._common import WSErrorMap, handle_ws_errors
-
-_ERROR_MAP: WSErrorMap = (
-    (ServiceValidationError, "invalid_args", False, None),
-    (Exception, "unknown_error", False, None),
-)
+from ._common import WSCommand
 
 WS_TYPE_GET_SUBAREAS = f"{DOMAIN}/get_subareas"
 SCHEMA_WS_GET_SUBAREAS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
@@ -54,51 +48,51 @@ SCHEMA_WS_REMOVE_SUBAREA = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 )
 
 
-@handle_ws_errors(_ERROR_MAP)
 async def websocket_get_subareas(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> list[dict[str, Any]]:
     """Return all subareas for a growspace."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     subareas = coordinator.services.growspaces.get_subareas(msg["growspace_id"])
-    connection.send_result(msg["id"], [asdict(s) for s in subareas])
+    return [asdict(s) for s in subareas]
 
 
-@handle_ws_errors(_ERROR_MAP)
 async def websocket_add_subarea(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Add a subarea to a growspace."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
-    subarea = await coordinator.services.growspaces.add_subarea(msg["growspace_id"], msg["name"])
-    connection.send_result(msg["id"], asdict(subarea))
+    subarea = await coordinator.services.growspaces.add_subarea(
+        msg["growspace_id"], msg["name"]
+    )
+    return asdict(subarea)
 
 
-@handle_ws_errors(_ERROR_MAP)
 async def websocket_update_subarea(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Update a subarea's environment config."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
     subarea = await coordinator.services.growspaces.update_subarea(
         msg["growspace_id"], msg["subarea_id"], msg["environment_config"]
     )
-    connection.send_result(msg["id"], asdict(subarea))
+    return asdict(subarea)
 
 
-@handle_ws_errors(_ERROR_MAP)
 async def websocket_remove_subarea(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Remove a subarea from a growspace."""
-    coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
-    await coordinator.services.growspaces.remove_subarea(msg["growspace_id"], msg["subarea_id"])
-    connection.send_result(msg["id"], {"success": True})
+    await coordinator.services.growspaces.remove_subarea(
+        msg["growspace_id"], msg["subarea_id"]
+    )
+    return {"success": True}
 
 
-COMMANDS: list[tuple[str, Any, Any, bool]] = [
-    (WS_TYPE_GET_SUBAREAS, websocket_get_subareas, SCHEMA_WS_GET_SUBAREAS, False),
-    (WS_TYPE_ADD_SUBAREA, websocket_add_subarea, SCHEMA_WS_ADD_SUBAREA, False),
-    (WS_TYPE_UPDATE_SUBAREA, websocket_update_subarea, SCHEMA_WS_UPDATE_SUBAREA, False),
-    (WS_TYPE_REMOVE_SUBAREA, websocket_remove_subarea, SCHEMA_WS_REMOVE_SUBAREA, False),
+COMMANDS: list[WSCommand] = [
+    WSCommand(WS_TYPE_GET_SUBAREAS, websocket_get_subareas, SCHEMA_WS_GET_SUBAREAS),
+    WSCommand(WS_TYPE_ADD_SUBAREA, websocket_add_subarea, SCHEMA_WS_ADD_SUBAREA),
+    WSCommand(
+        WS_TYPE_UPDATE_SUBAREA, websocket_update_subarea, SCHEMA_WS_UPDATE_SUBAREA
+    ),
+    WSCommand(
+        WS_TYPE_REMOVE_SUBAREA, websocket_remove_subarea, SCHEMA_WS_REMOVE_SUBAREA
+    ),
 ]

--- a/custom_components/growspace_manager/websocket/timeline.py
+++ b/custom_components/growspace_manager/websocket/timeline.py
@@ -26,7 +26,8 @@ from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.db_schema import Events
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+
+from ._common import WSCommand
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,91 +67,65 @@ SCHEMA_WS_REMOVE_TIMELINE_EVENT = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.exte
 
 
 async def websocket_add_timeline_note(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
 ) -> None:
     """Handle add timeline note command via WebSocket."""
-    try:
-        coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
-
-        await coordinator.services.add_timeline_note(
-            plant_id=msg[ATTR_PLANT_ID],
-            notes=msg[ATTR_NOTES],
-            timestamp=msg.get(ATTR_TRANSITION_DATE),
-            images_base64=msg.get(ATTR_IMAGES),
-            tags=msg.get(ATTR_TAGS),
-            ph=msg.get(ATTR_PH),
-            ec=msg.get(ATTR_EC),
-            amount_ml=msg.get(ATTR_AMOUNT_ML),
-            external_metadata=msg.get(ATTR_METADATA),
-        )
-        connection.send_result(msg["id"])
-    except ServiceValidationError as err:
-        connection.send_error(msg["id"], "invalid_args", str(err))
-    except Exception as err:
-        _LOGGER.exception("Error handling websocket_add_timeline_note")
-        connection.send_error(msg["id"], "unknown_error", str(err))
+    await coordinator.services.add_timeline_note(
+        plant_id=msg[ATTR_PLANT_ID],
+        notes=msg[ATTR_NOTES],
+        timestamp=msg.get(ATTR_TRANSITION_DATE),
+        images_base64=msg.get(ATTR_IMAGES),
+        tags=msg.get(ATTR_TAGS),
+        ph=msg.get(ATTR_PH),
+        ec=msg.get(ATTR_EC),
+        amount_ml=msg.get(ATTR_AMOUNT_ML),
+        external_metadata=msg.get(ATTR_METADATA),
+    )
 
 
 async def websocket_add_growspace_note(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
 ) -> None:
     """Handle add growspace note command via WebSocket."""
-    try:
-        coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
-
-        await coordinator.services.growspaces.add_growspace_note(
-            hass=hass,
-            growspace_id=msg[ATTR_GROWSPACE_ID],
-            notes=msg[ATTR_NOTES],
-            images_base64=msg.get(ATTR_IMAGES),
-        )
-        connection.send_result(msg["id"])
-    except ServiceValidationError as err:
-        connection.send_error(msg["id"], "invalid_args", str(err))
-    except Exception as err:
-        _LOGGER.exception("Error handling websocket_add_growspace_note")
-        connection.send_error(msg["id"], "unknown_error", str(err))
+    await coordinator.services.growspaces.add_growspace_note(
+        hass=hass,
+        growspace_id=msg[ATTR_GROWSPACE_ID],
+        notes=msg[ATTR_NOTES],
+        images_base64=msg.get(ATTR_IMAGES),
+    )
 
 
 async def websocket_remove_timeline_event(
-    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
 ) -> None:
     """Handle remove timeline event command via WebSocket."""
     event_id = msg["event_id"]
-    try:
-        recorder = get_instance(hass)
+    recorder = get_instance(hass)
 
-        def _delete_event() -> None:
-            with session_scope(hass=hass) as session:
-                session.query(Events).filter(Events.event_id == event_id).delete(
-                    synchronize_session=False
-                )
+    def _delete_event() -> None:
+        with session_scope(hass=hass) as session:
+            session.query(Events).filter(Events.event_id == event_id).delete(
+                synchronize_session=False
+            )
 
-        await recorder.async_add_executor_job(_delete_event)
-        connection.send_result(msg["id"])
-
-    except Exception as err:
-        _LOGGER.exception("Error handling websocket_remove_timeline_event")
-        connection.send_error(msg["id"], "unknown_error", str(err))
+    await recorder.async_add_executor_job(_delete_event)
 
 
-COMMANDS: list[tuple[str, Any, Any, bool]] = [
-    (
+COMMANDS: list[WSCommand] = [
+    WSCommand(
         WS_TYPE_ADD_TIMELINE_NOTE,
         websocket_add_timeline_note,
         SCHEMA_WS_ADD_TIMELINE_NOTE,
-        False,
     ),
-    (
+    WSCommand(
         WS_TYPE_ADD_GROWSPACE_NOTE,
         websocket_add_growspace_note,
         SCHEMA_WS_ADD_GROWSPACE_NOTE,
-        False,
     ),
-    (
+    WSCommand(
         WS_TYPE_REMOVE_TIMELINE_EVENT,
         websocket_remove_timeline_event,
         SCHEMA_WS_REMOVE_TIMELINE_EVENT,
-        False,
+        resolve="any",
     ),
 ]

--- a/custom_components/growspace_manager/websocket/vision.py
+++ b/custom_components/growspace_manager/websocket/vision.py
@@ -10,10 +10,13 @@ import voluptuous as vol
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
+from custom_components.growspace_manager.exceptions import GrowspaceNotFoundError
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 import homeassistant.util.dt as dt_util
+
+from ._common import WSCommand
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,35 +62,26 @@ SCHEMA_WS_GET_SNAPSHOTS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 )
 
 
-async def websocket_capture_snapshot(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
-    """Handle manual snapshot capture for a growspace."""
-    growspace_id: str = msg["growspace_id"]
-
-    try:
-        coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
-    except ServiceValidationError as err:
-        connection.send_error(msg["id"], "not_loaded", str(err))
-        return
-
+def _get_growspace(coordinator: GrowspaceCoordinator, growspace_id: str) -> Any:
+    """Resolve a growspace or raise the typed not-found error."""
     growspace = coordinator.growspaces.get(growspace_id)
     if not growspace:
-        connection.send_error(
-            msg["id"], "not_found", f"Growspace '{growspace_id}' not found"
-        )
-        return
+        raise GrowspaceNotFoundError(f"Growspace '{growspace_id}' not found")
+    return growspace
+
+
+async def websocket_capture_snapshot(
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
+    """Handle manual snapshot capture for a growspace."""
+    growspace_id: str = msg["growspace_id"]
+    growspace = _get_growspace(coordinator, growspace_id)
 
     camera_entities = growspace.environment_config.camera_entities
     if not camera_entities:
-        connection.send_error(
-            msg["id"],
-            "no_cameras",
-            f"No cameras configured for growspace '{growspace_id}'",
+        raise ServiceValidationError(
+            f"No cameras configured for growspace '{growspace_id}'"
         )
-        return
 
     snapshot_dir = (
         Path(hass.config.path("www")) / "growspace_manager" / "snapshots" / growspace_id
@@ -113,26 +107,21 @@ async def websocket_capture_snapshot(
                 f"/local/growspace_manager/snapshots/{growspace_id}/{filename}"
             )
             captured_paths.append(public_path)
-        except (AttributeError, KeyError, ValueError, HomeAssistantError, Exception):
+        except AttributeError, KeyError, ValueError, HomeAssistantError, Exception:
             _LOGGER.exception(
                 "Failed to capture snapshot from camera %s", camera_entity_id
             )
 
-    connection.send_result(
-        msg["id"],
-        {
-            "growspace_id": growspace_id,
-            "timestamp": timestamp,
-            "snapshots": captured_paths,
-        },
-    )
+    return {
+        "growspace_id": growspace_id,
+        "timestamp": timestamp,
+        "snapshots": captured_paths,
+    }
 
 
 async def websocket_get_snapshots(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Handle listing snapshots for a growspace."""
     growspace_id: str = msg["growspace_id"]
     limit: int = msg.get("limit", 50)
@@ -142,58 +131,35 @@ async def websocket_get_snapshots(
         Path(hass.config.path("www")) / "growspace_manager" / "snapshots" / growspace_id
     )
 
-    try:
-        if not snapshot_dir.exists():
-            connection.send_result(msg["id"], {"snapshots": [], "total": 0})
-            return
+    if not snapshot_dir.exists():
+        return {"snapshots": [], "total": 0}
 
-        all_files = sorted(
-            snapshot_dir.glob("*.jpg"),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        )
-        total = len(all_files)
-        paged_files = all_files[offset : offset + limit]
+    all_files = sorted(
+        snapshot_dir.glob("*.jpg"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    total = len(all_files)
+    paged_files = all_files[offset : offset + limit]
 
-        snapshots = [
-            {
-                "path": f"/local/growspace_manager/snapshots/{growspace_id}/{f.name}",
-                "filename": f.name,
-                "timestamp": f.name[:15],
-            }
-            for f in paged_files
-        ]
+    snapshots = [
+        {
+            "path": f"/local/growspace_manager/snapshots/{growspace_id}/{f.name}",
+            "filename": f.name,
+            "timestamp": f.name[:15],
+        }
+        for f in paged_files
+    ]
 
-        connection.send_result(
-            msg["id"],
-            {"growspace_id": growspace_id, "snapshots": snapshots, "total": total},
-        )
-    except Exception as err:
-        _LOGGER.exception("Error listing snapshots for %s", growspace_id)
-        connection.send_error(msg["id"], "unknown_error", str(err))
+    return {"growspace_id": growspace_id, "snapshots": snapshots, "total": total}
 
 
 async def websocket_get_vision_history(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Return vision checkup history for a growspace."""
-    growspace_id: str = msg["growspace_id"]
+    growspace = _get_growspace(coordinator, msg["growspace_id"])
     limit: int = msg.get("limit", 10)
-
-    try:
-        coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
-    except ServiceValidationError as err:
-        connection.send_error(msg["id"], "not_loaded", str(err))
-        return
-
-    growspace = coordinator.growspaces.get(growspace_id)
-    if not growspace:
-        connection.send_error(
-            msg["id"], "not_found", f"Growspace {growspace_id} not found"
-        )
-        return
 
     history = [
         {
@@ -208,40 +174,19 @@ async def websocket_get_vision_history(
         for r in growspace.vision_checkup_history[:limit]
     ]
 
-    connection.send_result(
-        msg["id"],
-        {"history": history, "total": len(growspace.vision_checkup_history)},
-    )
+    return {"history": history, "total": len(growspace.vision_checkup_history)}
 
 
 async def websocket_update_vision_checkup_config(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
+    hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
+) -> dict[str, Any]:
     """Update vision checkup configuration for a growspace."""
-    growspace_id: str = msg["growspace_id"]
-
-    try:
-        coordinator = GrowspaceCoordinator.get_for_service_call(hass, msg)
-    except ServiceValidationError as err:
-        connection.send_error(msg["id"], "not_loaded", str(err))
-        return
-
-    growspace = coordinator.growspaces.get(growspace_id)
-    if not growspace:
-        connection.send_error(
-            msg["id"], "not_found", f"Growspace {growspace_id!r} not found"
-        )
-        return
+    growspace = _get_growspace(coordinator, msg["growspace_id"])
 
     if not growspace.environment_config:
-        connection.send_error(
-            msg["id"],
-            "no_environment",
-            f"No environment config for growspace {growspace_id!r}",
+        raise ServiceValidationError(
+            f"No environment config for growspace {msg['growspace_id']!r}"
         )
-        return
 
     vision_config = growspace.environment_config.vision_checkup_config
     if "enabled" in msg:
@@ -256,12 +201,22 @@ async def websocket_update_vision_checkup_config(
     await coordinator.async_commit()
     coordinator.vision_scheduler.schedule_all_growspaces()
 
-    connection.send_result(msg["id"], {"success": True})
+    return {"success": True}
 
 
-COMMANDS: list[tuple[str, Any, Any, bool]] = [
-    (WS_TYPE_CAPTURE_SNAPSHOT, websocket_capture_snapshot, SCHEMA_WS_CAPTURE_SNAPSHOT, False),
-    (WS_TYPE_GET_SNAPSHOTS, websocket_get_snapshots, SCHEMA_WS_GET_SNAPSHOTS, False),
-    (WS_TYPE_GET_VISION_HISTORY, websocket_get_vision_history, SCHEMA_WS_GET_VISION_HISTORY, False),
-    (WS_TYPE_UPDATE_VISION_CHECKUP_CONFIG, websocket_update_vision_checkup_config, SCHEMA_WS_UPDATE_VISION_CHECKUP_CONFIG, False),
+COMMANDS: list[WSCommand] = [
+    WSCommand(
+        WS_TYPE_CAPTURE_SNAPSHOT, websocket_capture_snapshot, SCHEMA_WS_CAPTURE_SNAPSHOT
+    ),
+    WSCommand(WS_TYPE_GET_SNAPSHOTS, websocket_get_snapshots, SCHEMA_WS_GET_SNAPSHOTS),
+    WSCommand(
+        WS_TYPE_GET_VISION_HISTORY,
+        websocket_get_vision_history,
+        SCHEMA_WS_GET_VISION_HISTORY,
+    ),
+    WSCommand(
+        WS_TYPE_UPDATE_VISION_CHECKUP_CONFIG,
+        websocket_update_vision_checkup_config,
+        SCHEMA_WS_UPDATE_VISION_CHECKUP_CONFIG,
+    ),
 ]

--- a/docs/adr/0027-ws-command-lifecycle-and-typed-error-codes.md
+++ b/docs/adr/0027-ws-command-lifecycle-and-typed-error-codes.md
@@ -1,0 +1,67 @@
+# 27. WS Command Lifecycle and typed error-code completion
+
+Date: 2026-07-06
+
+## Status
+
+Accepted
+
+## Context
+
+The WebSocket package was already half-deep: registration is table-driven
+(each module exposes a `COMMANDS` tuple consumed by one loop), every handler
+is wrapped by `handle_ws_errors`, and coordinator resolution is one call
+(`GrowspaceCoordinator.get_for_service_call`). What remained shallow:
+
+- Every one of the 66 handlers carried the `(hass, connection, msg)` plumbing
+  and its own `connection.send_result(msg["id"], payload)` — so every handler
+  test needed a mock connection and asserted on `send_result` calls. The
+  connection mechanics were part of every handler's interface without ever
+  varying.
+- ADR-0005's typed error-code contract was implemented on the card
+  (`errors.ts` types `coordinator_not_ready` / `entity_not_found` /
+  `validation_failed` / `internal_error` / `rate_limited` and coerces unknown
+  codes to `internal_error`) but only half on the backend: it sent
+  `unknown_error` instead of `internal_error`, never sent `entity_not_found`
+  or `coordinator_not_ready`, and grew five ad-hoc codes (`invalid_args`,
+  `not_loaded`, `ai_error`, `seedfinder_unavailable`, `fetch_failed`) —
+  mostly inline `connection.send_error` calls bypassing the decorator — which
+  the card silently flattens to `internal_error`. Not-found and retry-later
+  UX distinctions died on the wire.
+
+## Decision
+
+1. **Payload-returning handlers.** A WS handler is
+   `(hass, coordinator, msg) → payload | None`. The registration wrapper in
+   `websocket/_common.py` owns the whole lifecycle: resolve coordinator →
+   execute → `send_result` → error map. Handlers never see the connection
+   (verified: no handler uses it beyond send_result/send_error today). The
+   handler's return value is the test surface.
+2. **Declarative command table.** `COMMANDS` entries become `WSCommand`
+   records: `(type, handler, schema, resolve="targeted"|"any", sync=False)`.
+   `targeted` resolves via `get_for_service_call(hass, msg)`; `any` via
+   `get_any(hass)` (global commands: strain library, genetics, nutrients,
+   lineage). Sync reads keep a `@callback` wrapper path.
+3. **Backend adopts ADR-0005's error vocabulary** (the card moves zero lines):
+   `unknown_error` → `internal_error`; new typed exceptions produce the
+   missing codes — `EntityNotFoundError` → `entity_not_found`,
+   `CoordinatorNotReadyError` → `coordinator_not_ready`, `RateLimitedError` →
+   `rate_limited`. The ad-hoc codes are retired: inline `send_error` calls
+   become raises mapped by the shared table.
+4. **Typed exceptions subclass the existing hierarchy**
+   (`EntityNotFoundError(ServiceValidationError)` etc. in `exceptions.py`),
+   so the service-call path keeps today's behaviour unchanged — only the WS
+   error map distinguishes the subclasses.
+
+## Consequences
+
+- Handler tests assert on returned payloads / raised exceptions; no mock
+  connections. The lifecycle wrapper is tested once.
+- Adding a WS command = one handler function + one `WSCommand` row; the
+  lifecycle, error semantics, and resolution mode are inherited, not
+  re-implemented.
+- The card's not-found / retry-later narrowing becomes reachable; nothing on
+  the wire changes shape except error `code` strings, which the card already
+  types or coerces.
+- The `test_core_init` hardcoded command count (67) is unaffected — no
+  commands are added or removed.

--- a/tests/core/test_core_init.py
+++ b/tests/core/test_core_init.py
@@ -644,20 +644,20 @@ async def test_websocket_get_event_log(hass: HomeAssistant, mock_coordinator) ->
             "type": f"{DOMAIN}/get_log",
             "growspace_id": "gs1",
         }
-        await websocket_get_event_log(hass, mock_connection, msg)
+        result = await websocket_get_event_log(hass, mock_coordinator, msg)
 
         expected_data = mock_event.data.copy()
         expected_data["event_id"] = 12345
-        mock_connection.send_result.assert_called_with(1, {"gs1": [expected_data]})
+        assert result == {"gs1": [expected_data]}
 
         # Case B: Global (Aggregate)
         msg_global = {
             "id": 2,
             "type": f"{DOMAIN}/get_log",
         }
-        await websocket_get_event_log(hass, mock_connection, msg_global)
+        result = await websocket_get_event_log(hass, mock_coordinator, msg_global)
 
-        mock_connection.send_result.assert_called_with(2, {"gs1": [expected_data]})
+        assert result == {"gs1": [expected_data]}
 
         # Case C: Filtering out unrelated ID - returns empty because query returns gs1 data
         msg_other = {
@@ -665,8 +665,8 @@ async def test_websocket_get_event_log(hass: HomeAssistant, mock_coordinator) ->
             "type": f"{DOMAIN}/get_log",
             "growspace_id": "gs2",
         }
-        await websocket_get_event_log(hass, mock_connection, msg_other)
-        mock_connection.send_result.assert_called_with(3, {"gs2": []})
+        result = await websocket_get_event_log(hass, mock_coordinator, msg_other)
+        assert result == {"gs2": []}
 
 
 @pytest.mark.asyncio
@@ -679,51 +679,20 @@ async def test_websocket_get_growspace_data(
     mock_connection.send_result = MagicMock()
     mock_connection.send_error = MagicMock()
 
-    # 1. Success
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        return_value=mock_coordinator,
-    ):
-        # FIX: Add .services here to match the updated websocket.py logic
-        mock_coordinator.services.growspaces.get_growspace_data.return_value = {
-            "name": "Test space"
-        }
+    # Resolution failures are mapped by the WS Command Lifecycle and are
+    # covered in test_ws_command_lifecycle.py; the handler is a pure payload
+    # function.
+    mock_coordinator.services.growspaces.get_growspace_data.return_value = {
+        "name": "Test space"
+    }
 
-        msg = {
-            "id": 1,
-            "type": f"{DOMAIN}/get_data",
-            "growspace_id": "gs1",
-        }
-        await websocket_get_growspace_data(hass, mock_connection, msg)
-        mock_connection.send_result.assert_called_with(1, {"name": "Test space"})
-
-    # 2. Error (ServiceValidationError)
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        side_effect=ServiceValidationError("Invalid ID"),
-    ):
-        msg = {
-            "id": 2,
-            "type": f"{DOMAIN}/get_data",
-            "growspace_id": "invalid",
-        }
-        await websocket_get_growspace_data(hass, mock_connection, msg)
-        mock_connection.send_error.assert_called_with(
-            2, "coordinator_not_ready", "Growspace Manager integration not loaded"
-        )
-
-    # 3. Unknown Error
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        side_effect=Exception("Boom"),
-    ):
-        msg = {
-            "id": 3,
-            "type": f"{DOMAIN}/get_data",
-            "growspace_id": "gs1",
-        }
-        await websocket_get_growspace_data(hass, mock_connection, msg)
-        mock_connection.send_error.assert_called_with(3, "internal_error", "Boom")
+    msg = {
+        "id": 1,
+        "type": f"{DOMAIN}/get_data",
+        "growspace_id": "gs1",
+    }
+    result = await websocket_get_growspace_data(hass, mock_coordinator, msg)
+    assert result == {"name": "Test space"}
 
 
 @pytest.mark.asyncio
@@ -921,11 +890,9 @@ async def test_websocket_get_event_log_unknown_error(hass: HomeAssistant) -> Non
             "type": f"{DOMAIN}/get_log",
             "growspace_id": "gs_unknown",
         }
-        await websocket_get_event_log(hass, mock_connection, msg)
-
-        mock_connection.send_error.assert_called_with(
-            99, "unknown_error", "Unexpected Error"
-        )
+        # The lifecycle maps this to internal_error; the handler just raises.
+        with pytest.raises(RuntimeError, match="Unexpected Error"):
+            await websocket_get_event_log(hass, MagicMock(), msg)
 
 
 @pytest.mark.asyncio
@@ -1018,10 +985,8 @@ async def test_websocket_get_history_stats(
             "significant_changes_only": True,
         }
 
-        await websocket_get_history_stats(hass, mock_connection, msg)
+        result = await websocket_get_history_stats(hass, MagicMock(), msg)
 
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
         assert "sensor.test" in result
         stats = result["sensor.test"]
         # Expected: T+0, T+15, T+30 -> 3 points
@@ -1037,10 +1002,8 @@ async def test_websocket_get_history_stats(
         "interval_minutes": 5,
         "significant_changes_only": True,
     }
-    await websocket_get_history_stats(hass, mock_connection, msg_inv)
-    mock_connection.send_error.assert_called_with(
-        2, "invalid_args", "Invalid start_time"
-    )
+    with pytest.raises(ServiceValidationError, match="Invalid start_time"):
+        await websocket_get_history_stats(hass, MagicMock(), msg_inv)
 
     # 3. Exception Handling
     with (
@@ -1061,14 +1024,14 @@ async def test_websocket_get_history_stats(
             "interval_minutes": 5,
             "significant_changes_only": True,
         }
-        await websocket_get_history_stats(hass, mock_connection, msg_err)
-        mock_connection.send_error.assert_called_with(3, "unknown_error", "DB Error")
+        with pytest.raises(Exception, match="DB Error"):
+            await websocket_get_history_stats(hass, MagicMock(), msg_err)
 
 
 @pytest.mark.asyncio
 async def test_websocket_history_empty_and_unavailable(hass: HomeAssistant) -> None:
     """Test history stats with empty data or unavailable states."""
-    mock_connection = MagicMock()
+    MagicMock()
 
     start = dt_util.utcnow()
 
@@ -1103,9 +1066,8 @@ async def test_websocket_history_empty_and_unavailable(hass: HomeAssistant) -> N
             "significant_changes_only": True,
         }
 
-        await websocket_get_history_stats(hass, mock_connection, msg)
+        result = await websocket_get_history_stats(hass, MagicMock(), msg)
 
-        result = mock_connection.send_result.call_args[0][1]
         assert result["sensor.empty"] == []
         # sensor.unavail should produce empty list because we filter out unavailable/unknown
         assert result["sensor.unavail"] == []
@@ -1257,13 +1219,10 @@ async def test_websocket_history_stats_uses_statistics_api_for_long_intervals(
             "significant_changes_only": True,
         }
 
-        await websocket_get_history_stats(hass, mock_connection, msg)
+        result = await websocket_get_history_stats(hass, MagicMock(), msg)
 
         # Should use statistics API
         mock_stats.assert_called_once()
-        mock_connection.send_result.assert_called_once()
-
-        result = mock_connection.send_result.call_args[0][1]
         assert "sensor.test" in result
         assert len(result["sensor.test"]) == 2
         assert result["sensor.test"][0]["s"] == "22.5"
@@ -1317,11 +1276,9 @@ async def test_websocket_history_stats_falls_back_when_statistics_fails(
             "significant_changes_only": True,
         }
 
-        await websocket_get_history_stats(hass, mock_connection, msg)
+        result = await websocket_get_history_stats(hass, MagicMock(), msg)
 
         # Should fallback and still succeed
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
         assert "sensor.test" in result
 
 
@@ -1372,11 +1329,11 @@ async def test_websocket_history_stats_short_interval_uses_binary_search(
             "significant_changes_only": True,
         }
 
-        await websocket_get_history_stats(hass, mock_connection, msg)
+        result = await websocket_get_history_stats(hass, MagicMock(), msg)
 
         # Should NOT call statistics API for short intervals
         mock_stats.assert_not_called()
-        mock_connection.send_result.assert_called_once()
+        assert result is not None
 
 
 @pytest.mark.asyncio
@@ -1419,7 +1376,7 @@ async def test_websocket_history_stats_uses_daily_period_for_large_intervals(
             "significant_changes_only": True,
         }
 
-        await websocket_get_history_stats(hass, mock_connection, msg)
+        await websocket_get_history_stats(hass, MagicMock(), msg)
 
         # Verify daily period was used
         mock_stats.assert_called_once()
@@ -1468,9 +1425,8 @@ async def test_websocket_history_stats_statistics_with_state_instead_of_mean(
             "significant_changes_only": True,
         }
 
-        await websocket_get_history_stats(hass, mock_connection, msg)
+        result = await websocket_get_history_stats(hass, MagicMock(), msg)
 
-        result = mock_connection.send_result.call_args[0][1]
         assert result["sensor.test"][0]["s"] == "on"
 
 
@@ -1510,9 +1466,7 @@ async def test_websocket_history_stats_empty_statistics(hass: HomeAssistant) -> 
             "significant_changes_only": True,
         }
 
-        await websocket_get_history_stats(hass, mock_connection, msg)
+        result = await websocket_get_history_stats(hass, MagicMock(), msg)
 
         # Should fallback to binary search when stats are empty
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
         assert "sensor.test" in result

--- a/tests/core/test_websocket_ai_assistant.py
+++ b/tests/core/test_websocket_ai_assistant.py
@@ -6,7 +6,23 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.growspace_manager.exceptions import (
+    CoordinatorNotReadyError,
+    EntityNotFoundError,
+    GrowspaceError,
+    RateLimitedError,
+)
 from homeassistant.exceptions import ServiceValidationError
+
+
+def _coord(**overrides):
+    """A coordinator stub for the payload-returning handlers."""
+    coord = MagicMock()
+    coord.growspaces = {}
+    coord.options = {"ai_settings": {}}
+    for key, value in overrides.items():
+        setattr(coord, key, value)
+    return coord
 
 
 def _make_converse_result(speech: str, conv_id: str = "conv-abc"):
@@ -54,14 +70,12 @@ async def test_start_conversation_returns_conversation_id(
             "message": "How are my plants?",
             "agent_id": "test_agent",
         }
-        await websocket_start_conversation(MagicMock(), mock_connection, msg)
+        result = await websocket_start_conversation(MagicMock(), _coord(), msg)
 
     mock_converse.assert_awaited_once()
     call_kwargs = mock_converse.call_args[1]
     assert call_kwargs.get("conversation_id") is None
 
-    mock_connection.send_result.assert_called_once()
-    result = mock_connection.send_result.call_args[0][1]
     assert result["thread_id"] == "conv-123"
     assert result["growspace_id"] == "tent1"
     assert len(result["messages"]) == 1
@@ -92,9 +106,8 @@ async def test_start_conversation_extracts_action_block(
             "message": "What should I do?",
             "agent_id": "agent1",
         }
-        await websocket_start_conversation(MagicMock(), mock_connection, msg)
+        result = await websocket_start_conversation(MagicMock(), _coord(), msg)
 
-    result = mock_connection.send_result.call_args[0][1]
     ai_msg = result["messages"][0]
     assert ai_msg["suggestedAction"] == {"type": "water", "confidence": 0.9}
     assert "[ACTION]" not in ai_msg["text"]
@@ -123,9 +136,8 @@ async def test_start_conversation_malformed_action_block_is_plain_text(
             "message": "Any issues?",
             "agent_id": "agent1",
         }
-        await websocket_start_conversation(MagicMock(), mock_connection, msg)
+        result = await websocket_start_conversation(MagicMock(), _coord(), msg)
 
-    result = mock_connection.send_result.call_args[0][1]
     ai_msg = result["messages"][0]
     assert "suggestedAction" not in ai_msg
     assert ai_msg["text"] is not None
@@ -148,12 +160,8 @@ async def test_start_conversation_invalid_image_entity_domain(
         "agent_id": "agent1",
         "image_entities": ["sensor.temperature"],  # wrong domain
     }
-    await websocket_start_conversation(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    err_args = mock_connection.send_error.call_args[0]
-    assert err_args[0] == 4
-    assert err_args[1] == "invalid_entity"
+    with pytest.raises(ServiceValidationError):
+        await websocket_start_conversation(MagicMock(), _coord(), msg)
 
 
 @pytest.mark.asyncio
@@ -184,10 +192,7 @@ async def test_start_conversation_valid_camera_entity_accepted(
             "agent_id": "agent1",
             "image_entities": ["camera.tent_cam"],
         }
-        await websocket_start_conversation(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_not_called()
-    mock_connection.send_result.assert_called_once()
+        await websocket_start_conversation(hass, _coord(), msg)
 
 
 @pytest.mark.asyncio
@@ -218,10 +223,7 @@ async def test_start_conversation_valid_image_entity_accepted(
             "agent_id": "agent1",
             "image_entities": ["image.plant_snapshot"],
         }
-        await websocket_start_conversation(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_not_called()
-    mock_connection.send_result.assert_called_once()
+        await websocket_start_conversation(hass, _coord(), msg)
 
 
 # ---------------------------------------------------------------------------
@@ -251,12 +253,11 @@ async def test_send_message_passes_conversation_id(
             "growspace_id": "tent1",
             "message": "Tell me more",
         }
-        await websocket_send_message(MagicMock(), mock_connection, msg)
+        result = await websocket_send_message(MagicMock(), _coord(), msg)
 
     call_kwargs = mock_converse.call_args[1]
     assert call_kwargs["conversation_id"] == "conv-existing"
 
-    result = mock_connection.send_result.call_args[0][1]
     assert result["thread_id"] == "conv-existing"
     assert result["growspace_id"] == "tent1"
     assert len(result["messages"]) == 1
@@ -287,9 +288,8 @@ async def test_send_message_extracts_action_block(
             "growspace_id": "tent1",
             "message": "What should I adjust?",
         }
-        await websocket_send_message(MagicMock(), mock_connection, msg)
+        result = await websocket_send_message(MagicMock(), _coord(), msg)
 
-    result = mock_connection.send_result.call_args[0][1]
     ai_msg = result["messages"][0]
     assert ai_msg["suggestedAction"] == {"type": "adjust_ph", "value": 6.2}
     assert "[ACTION]" not in ai_msg["text"]
@@ -312,11 +312,8 @@ async def test_send_message_invalid_image_entity_domain(
         "message": "Check this",
         "image_entities": ["binary_sensor.door"],  # wrong domain
     }
-    await websocket_send_message(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    err_args = mock_connection.send_error.call_args[0]
-    assert err_args[1] == "invalid_entity"
+    with pytest.raises(ServiceValidationError):
+        await websocket_send_message(MagicMock(), _coord(), msg)
 
 
 @pytest.mark.asyncio
@@ -339,11 +336,8 @@ async def test_send_message_empty_response_returns_error(
             "growspace_id": "tent1",
             "message": "Hello",
         }
-        await websocket_send_message(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    err_args = mock_connection.send_error.call_args[0]
-    assert err_args[1] == "ai_error"
+        with pytest.raises(GrowspaceError):
+            await websocket_send_message(MagicMock(), _coord(), msg)
 
 
 # ---------------------------------------------------------------------------
@@ -370,10 +364,8 @@ async def test_start_conversation_service_validation_error_returns_error(
             "growspace_id": "tent1",
             "message": "Hello",
         }
-        await websocket_start_conversation(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "ai_error"
+        with pytest.raises(GrowspaceError):
+            await websocket_start_conversation(MagicMock(), _coord(), msg)
 
 
 @pytest.mark.asyncio
@@ -395,10 +387,8 @@ async def test_start_conversation_generic_exception_returns_error(
             "growspace_id": "tent1",
             "message": "Hello",
         }
-        await websocket_start_conversation(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "ai_error"
+        with pytest.raises(GrowspaceError):
+            await websocket_start_conversation(MagicMock(), _coord(), msg)
 
 
 @pytest.mark.asyncio
@@ -420,10 +410,8 @@ async def test_start_conversation_empty_response_returns_error(
             "growspace_id": "tent1",
             "message": "Hello",
         }
-        await websocket_start_conversation(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "ai_error"
+        with pytest.raises(GrowspaceError):
+            await websocket_start_conversation(MagicMock(), _coord(), msg)
 
 
 # ---------------------------------------------------------------------------
@@ -451,10 +439,8 @@ async def test_send_message_service_validation_error_returns_error(
             "growspace_id": "tent1",
             "message": "Continue",
         }
-        await websocket_send_message(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "ai_error"
+        with pytest.raises(GrowspaceError):
+            await websocket_send_message(MagicMock(), _coord(), msg)
 
 
 @pytest.mark.asyncio
@@ -477,10 +463,8 @@ async def test_send_message_generic_exception_returns_error(
             "growspace_id": "tent1",
             "message": "Continue",
         }
-        await websocket_send_message(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "ai_error"
+        with pytest.raises(GrowspaceError):
+            await websocket_send_message(MagicMock(), _coord(), msg)
 
 
 # ---------------------------------------------------------------------------
@@ -488,59 +472,9 @@ async def test_send_message_generic_exception_returns_error(
 # ---------------------------------------------------------------------------
 
 
-def test_get_coordinator_returns_none_on_exception() -> None:
-    """_get_coordinator swallows any exception and returns None."""
-    from custom_components.growspace_manager.websocket.ai_assistant import (
-        _get_coordinator,
-    )
-
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant.GrowspaceCoordinator.get_for_service_call",
-        side_effect=ServiceValidationError("not loaded"),
-    ):
-        result = _get_coordinator(MagicMock(), MagicMock())
-
-    assert result is None
-
-
-def test_get_coordinator_returns_none_on_generic_exception() -> None:
-    """_get_coordinator also swallows generic exceptions and returns None."""
-    from custom_components.growspace_manager.websocket.ai_assistant import (
-        _get_coordinator,
-    )
-
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant.GrowspaceCoordinator.get_for_service_call",
-        side_effect=RuntimeError("crash"),
-    ):
-        result = _get_coordinator(MagicMock(), MagicMock())
-
-    assert result is None
-
-
 # ---------------------------------------------------------------------------
 # websocket_get_ai_alerts
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_get_ai_alerts_coordinator_not_loaded(
-    mock_connection: MagicMock,
-) -> None:
-    """get_ai_alerts sends not_found when coordinator is unavailable."""
-    from custom_components.growspace_manager.websocket.ai_assistant import (
-        websocket_get_ai_alerts,
-    )
-
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-        return_value=None,
-    ):
-        msg = {"id": 20, "type": "growspace_manager/get_ai_alerts"}
-        await websocket_get_ai_alerts(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "not_found"
 
 
 @pytest.mark.asyncio
@@ -553,54 +487,29 @@ async def test_get_ai_alerts_returns_filtered_alerts(
     )
 
     coordinator = MagicMock()
-    coordinator.services.notifications.get_alerts.return_value = [{"id": "a1", "type": "stress"}]
+    coordinator.growspaces = {}
+    coordinator.services.notifications.get_alerts.return_value = [
+        {"id": "a1", "type": "stress"}
+    ]
 
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 22,
             "type": "growspace_manager/get_ai_alerts",
             "growspace_id": "tent1",
             "alert_type": "stress",
         }
-        await websocket_get_ai_alerts(MagicMock(), mock_connection, msg)
+        result = await websocket_get_ai_alerts(MagicMock(), coordinator, msg)
 
     coordinator.services.notifications.get_alerts.assert_called_once_with(
         growspace_id="tent1", alert_type="stress"
     )
-    result = mock_connection.send_result.call_args[0][1]
     assert result == [{"id": "a1", "type": "stress"}]
 
 
 # ---------------------------------------------------------------------------
 # websocket_resolve_ai_alert
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_resolve_ai_alert_coordinator_not_loaded(
-    mock_connection: MagicMock,
-) -> None:
-    """resolve_ai_alert sends not_found when coordinator is unavailable."""
-    from custom_components.growspace_manager.websocket.ai_assistant import (
-        websocket_resolve_ai_alert,
-    )
-
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-        return_value=None,
-    ):
-        msg = {
-            "id": 30,
-            "type": "growspace_manager/resolve_ai_alert",
-            "alert_id": "abc",
-        }
-        await websocket_resolve_ai_alert(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "not_found"
 
 
 @pytest.mark.asyncio
@@ -613,21 +522,17 @@ async def test_resolve_ai_alert_alert_not_found_sends_error(
     )
 
     coordinator = MagicMock()
+    coordinator.growspaces = {}
     coordinator.services.notifications.resolve_alert = AsyncMock(return_value=False)
 
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 32,
             "type": "growspace_manager/resolve_ai_alert",
             "alert_id": "missing-id",
         }
-        await websocket_resolve_ai_alert(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "not_found"
+        with pytest.raises(EntityNotFoundError):
+            await websocket_resolve_ai_alert(MagicMock(), coordinator, msg)
 
 
 @pytest.mark.asyncio
@@ -640,22 +545,21 @@ async def test_resolve_ai_alert_success(
     )
 
     coordinator = MagicMock()
+    coordinator.growspaces = {}
     coordinator.services.notifications.resolve_alert = AsyncMock(return_value=True)
 
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 33,
             "type": "growspace_manager/resolve_ai_alert",
             "alert_id": "alert-xyz",
             "resolution_note": "All fixed",
         }
-        await websocket_resolve_ai_alert(MagicMock(), mock_connection, msg)
+        result = await websocket_resolve_ai_alert(MagicMock(), coordinator, msg)
 
-    coordinator.services.notifications.resolve_alert.assert_awaited_once_with("alert-xyz", notes="All fixed")
-    result = mock_connection.send_result.call_args[0][1]
+    coordinator.services.notifications.resolve_alert.assert_awaited_once_with(
+        "alert-xyz", notes="All fixed"
+    )
     assert result == {"success": True, "alert_id": "alert-xyz"}
 
 
@@ -681,6 +585,7 @@ async def test_send_message_uses_configured_agent_id(
     fake_result = _make_converse_result("VPD is 1.1 kPa.", conv_id="conv-existing")
 
     coordinator = MagicMock()
+    coordinator.growspaces = {}
     coordinator.options = {
         "ai_settings": {"assistant_id": "conversation.google_ai_conversation"}
     }
@@ -690,10 +595,6 @@ async def test_send_message_uses_configured_agent_id(
             "custom_components.growspace_manager.websocket.ai_assistant.conversation.async_converse",
             new=AsyncMock(return_value=fake_result),
         ) as mock_converse,
-        patch(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            return_value=coordinator,
-        ),
     ):
         msg = {
             "id": 50,
@@ -702,7 +603,7 @@ async def test_send_message_uses_configured_agent_id(
             "growspace_id": "tent1",
             "message": "What is the current VPD?",
         }
-        await websocket_send_message(MagicMock(), mock_connection, msg)
+        await websocket_send_message(MagicMock(), coordinator, msg)
 
     call_kwargs = mock_converse.call_args[1]
     assert call_kwargs["agent_id"] == "conversation.google_ai_conversation"
@@ -725,6 +626,7 @@ async def test_start_conversation_uses_configured_agent_when_no_agent_id_in_mess
     fake_result = _make_converse_result("Looking healthy!", conv_id="conv-new")
 
     coordinator = MagicMock()
+    coordinator.growspaces = {}
     coordinator.options = {
         "ai_settings": {"assistant_id": "conversation.google_ai_conversation"}
     }
@@ -734,10 +636,6 @@ async def test_start_conversation_uses_configured_agent_when_no_agent_id_in_mess
             "custom_components.growspace_manager.websocket.ai_assistant.conversation.async_converse",
             new=AsyncMock(return_value=fake_result),
         ) as mock_converse,
-        patch(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            return_value=coordinator,
-        ),
     ):
         msg = {
             "id": 51,
@@ -746,7 +644,7 @@ async def test_start_conversation_uses_configured_agent_when_no_agent_id_in_mess
             "message": "What is the current VPD?",
             # No agent_id in message — frontend never sends it
         }
-        await websocket_start_conversation(MagicMock(), mock_connection, msg)
+        await websocket_start_conversation(MagicMock(), coordinator, msg)
 
     call_kwargs = mock_converse.call_args[1]
     assert call_kwargs["agent_id"] == "conversation.google_ai_conversation"
@@ -764,6 +662,7 @@ async def test_start_conversation_explicit_agent_id_takes_precedence(
     fake_result = _make_converse_result("Good to go.", conv_id="conv-explicit")
 
     coordinator = MagicMock()
+    coordinator.growspaces = {}
     coordinator.options = {
         "ai_settings": {"assistant_id": "conversation.google_ai_conversation"}
     }
@@ -773,10 +672,6 @@ async def test_start_conversation_explicit_agent_id_takes_precedence(
             "custom_components.growspace_manager.websocket.ai_assistant.conversation.async_converse",
             new=AsyncMock(return_value=fake_result),
         ) as mock_converse,
-        patch(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            return_value=coordinator,
-        ),
     ):
         msg = {
             "id": 52,
@@ -785,7 +680,7 @@ async def test_start_conversation_explicit_agent_id_takes_precedence(
             "message": "Hello",
             "agent_id": "conversation.override_agent",
         }
-        await websocket_start_conversation(MagicMock(), mock_connection, msg)
+        await websocket_start_conversation(MagicMock(), coordinator, msg)
 
     call_kwargs = mock_converse.call_args[1]
     assert call_kwargs["agent_id"] == "conversation.override_agent"
@@ -794,30 +689,6 @@ async def test_start_conversation_explicit_agent_id_takes_precedence(
 # ---------------------------------------------------------------------------
 # websocket_get_briefing
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_get_briefing_coordinator_not_loaded(
-    mock_connection: MagicMock,
-) -> None:
-    """get_briefing sends not_found when coordinator is unavailable."""
-    from custom_components.growspace_manager.websocket.ai_assistant import (
-        websocket_get_briefing,
-    )
-
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-        return_value=None,
-    ):
-        msg = {
-            "id": 40,
-            "type": "growspace_manager/get_briefing",
-            "force_refresh": False,
-        }
-        await websocket_get_briefing(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "not_found"
 
 
 @pytest.mark.asyncio
@@ -831,19 +702,14 @@ async def test_get_briefing_no_scheduler_sends_error(
 
     coordinator = MagicMock(spec=[])  # no briefing_scheduler attribute
 
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 41,
             "type": "growspace_manager/get_briefing",
             "force_refresh": False,
         }
-        await websocket_get_briefing(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "not_found"
+        with pytest.raises(CoordinatorNotReadyError):
+            await websocket_get_briefing(MagicMock(), coordinator, msg)
 
 
 @pytest.mark.asyncio
@@ -862,21 +728,18 @@ async def test_get_briefing_returns_briefing_data(
     scheduler = MagicMock()
     scheduler.async_get_briefing = AsyncMock(return_value=briefing_data)
     coordinator = MagicMock()
+    coordinator.growspaces = {}
     coordinator.briefing_scheduler = scheduler
 
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 42,
             "type": "growspace_manager/get_briefing",
             "force_refresh": True,
         }
-        await websocket_get_briefing(MagicMock(), mock_connection, msg)
+        result = await websocket_get_briefing(MagicMock(), coordinator, msg)
 
     scheduler.async_get_briefing.assert_awaited_once_with(force_refresh=True)
-    result = mock_connection.send_result.call_args[0][1]
     assert result == briefing_data
 
 
@@ -895,6 +758,7 @@ async def test_save_ai_settings_persists_full_dict(
     )
 
     coordinator = MagicMock()
+    coordinator.growspaces = {}
     coordinator.config_entry.options = {"other": "kept"}
     coordinator.async_commit = AsyncMock()
 
@@ -911,42 +775,15 @@ async def test_save_ai_settings_persists_full_dict(
     }
 
     mock_hass = MagicMock()
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {"id": 7, "type": "growspace_manager/save_ai_settings", **payload}
-        await websocket_save_ai_settings(mock_hass, mock_connection, msg)
+        result = await websocket_save_ai_settings(mock_hass, coordinator, msg)
 
     mock_hass.config_entries.async_update_entry.assert_called_once()
     saved_options = mock_hass.config_entries.async_update_entry.call_args[1]["options"]
     assert saved_options["other"] == "kept"
     assert saved_options["ai_settings"] == payload
-    mock_connection.send_result.assert_called_once_with(7, {"success": True})
-
-
-@pytest.mark.asyncio
-async def test_save_ai_settings_returns_error_when_no_coordinator(
-    mock_connection: MagicMock,
-) -> None:
-    """save_ai_settings sends not_found error when coordinator is absent."""
-    from custom_components.growspace_manager.websocket.ai_assistant import (
-        websocket_save_ai_settings,
-    )
-
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-        return_value=None,
-    ):
-        msg = {
-            "id": 8,
-            "type": "growspace_manager/save_ai_settings",
-            "ai_enabled": False,
-        }
-        await websocket_save_ai_settings(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "not_found"
+    assert result == {"success": True}
 
 
 # ---------------------------------------------------------------------------
@@ -976,6 +813,7 @@ def _make_coordinator_with_growspace(
     growspace.environment_config = env
 
     coordinator = MagicMock()
+    coordinator.growspaces = {}
     coordinator.growspaces = {"tent1": growspace}
     coordinator.services.growspaces.get_growspace_plants.return_value = plants or []
     return coordinator
@@ -1072,6 +910,7 @@ def test_build_context_message_returns_plain_message_when_growspace_missing() ->
 
     coordinator = MagicMock()
     coordinator.growspaces = {}
+    coordinator.growspaces = {}
     hass = MagicMock()
 
     result = _build_context_message(hass, coordinator, "unknown", "Hello")
@@ -1115,10 +954,6 @@ async def test_start_conversation_injects_context_when_coordinator_available(
             "custom_components.growspace_manager.websocket.ai_assistant.conversation.async_converse",
             new=AsyncMock(return_value=fake_result),
         ) as mock_converse,
-        patch(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            return_value=coordinator,
-        ),
     ):
         msg = {
             "id": 1,
@@ -1127,7 +962,7 @@ async def test_start_conversation_injects_context_when_coordinator_available(
             "message": "What is the VPD?",
             "agent_id": "test_agent",
         }
-        await websocket_start_conversation(hass, mock_connection, msg)
+        await websocket_start_conversation(hass, coordinator, msg)
 
     call_kwargs = mock_converse.call_args[1]
     assert "[Growspace: Tent 1" in call_kwargs["text"]
@@ -1152,10 +987,6 @@ async def test_send_message_injects_context_when_coordinator_available(
             "custom_components.growspace_manager.websocket.ai_assistant.conversation.async_converse",
             new=AsyncMock(return_value=fake_result),
         ) as mock_converse,
-        patch(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            return_value=coordinator,
-        ),
     ):
         msg = {
             "id": 2,
@@ -1164,7 +995,7 @@ async def test_send_message_injects_context_when_coordinator_available(
             "growspace_id": "tent1",
             "message": "How can I optimize?",
         }
-        await websocket_send_message(hass, mock_connection, msg)
+        await websocket_send_message(hass, coordinator, msg)
 
     call_kwargs = mock_converse.call_args[1]
     assert "[Growspace: Tent 1" in call_kwargs["text"]
@@ -1270,10 +1101,8 @@ async def test_start_conversation_rate_limited_service_validation_error(
             "growspace_id": "tent1",
             "message": "Hello",
         }
-        await websocket_start_conversation(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "rate_limited"
+        with pytest.raises(RateLimitedError):
+            await websocket_start_conversation(MagicMock(), _coord(), msg)
 
 
 @pytest.mark.asyncio
@@ -1295,10 +1124,8 @@ async def test_start_conversation_rate_limited_generic_exception(
             "growspace_id": "tent1",
             "message": "Hello",
         }
-        await websocket_start_conversation(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "rate_limited"
+        with pytest.raises(RateLimitedError):
+            await websocket_start_conversation(MagicMock(), _coord(), msg)
 
 
 @pytest.mark.asyncio
@@ -1313,7 +1140,9 @@ async def test_start_conversation_rate_limited_result(
     fake_result = MagicMock()
     fake_result.conversation_id = "conv-123"
     fake_result.response = MagicMock()
-    fake_result.response.speech = {"plain": {"speech": "Error: Too Many Requests (429)"}}
+    fake_result.response.speech = {
+        "plain": {"speech": "Error: Too Many Requests (429)"}
+    }
     fake_result.response.error_code = "RESOURCE_EXHAUSTED"
 
     with patch(
@@ -1326,10 +1155,8 @@ async def test_start_conversation_rate_limited_result(
             "growspace_id": "tent1",
             "message": "Hello",
         }
-        await websocket_start_conversation(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "rate_limited"
+        with pytest.raises(RateLimitedError):
+            await websocket_start_conversation(MagicMock(), _coord(), msg)
 
 
 @pytest.mark.asyncio
@@ -1352,10 +1179,8 @@ async def test_send_message_rate_limited_service_validation_error(
             "growspace_id": "tent1",
             "message": "Hello",
         }
-        await websocket_send_message(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "rate_limited"
+        with pytest.raises(RateLimitedError):
+            await websocket_send_message(MagicMock(), _coord(), msg)
 
 
 @pytest.mark.asyncio
@@ -1378,10 +1203,8 @@ async def test_send_message_rate_limited_generic_exception(
             "growspace_id": "tent1",
             "message": "Hello",
         }
-        await websocket_send_message(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "rate_limited"
+        with pytest.raises(RateLimitedError):
+            await websocket_send_message(MagicMock(), _coord(), msg)
 
 
 @pytest.mark.asyncio
@@ -1410,35 +1233,8 @@ async def test_send_message_rate_limited_result(
             "growspace_id": "tent1",
             "message": "Hello",
         }
-        await websocket_send_message(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "rate_limited"
-
-
-@pytest.mark.asyncio
-async def test_save_ai_agent_coordinator_not_loaded(
-    mock_connection: MagicMock,
-) -> None:
-    """save_ai_agent returns a not_found error if the coordinator is missing."""
-    from custom_components.growspace_manager.websocket.ai_assistant import (
-        websocket_save_ai_agent,
-    )
-
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-        return_value=None,
-    ):
-        msg = {
-            "id": 30,
-            "type": "growspace_manager/save_ai_agent",
-            "agent_id": "agent-xyz",
-        }
-        await websocket_save_ai_agent(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once_with(
-        30, "not_found", "Growspace Manager integration not loaded"
-    )
+        with pytest.raises(RateLimitedError):
+            await websocket_send_message(MagicMock(), _coord(), msg)
 
 
 @pytest.mark.asyncio
@@ -1452,9 +1248,12 @@ async def test_save_ai_agent_success(
 
     # Mock config entry and options
     config_entry = MagicMock()
-    config_entry.options = {"ai_settings": {"assistant_id": "old-agent", "ai_enabled": False}}
+    config_entry.options = {
+        "ai_settings": {"assistant_id": "old-agent", "ai_enabled": False}
+    }
 
     coordinator = MagicMock()
+    coordinator.growspaces = {}
     coordinator.config_entry = config_entry
     coordinator.options = config_entry.options
     coordinator.async_commit = AsyncMock()
@@ -1462,16 +1261,13 @@ async def test_save_ai_agent_success(
     hass = MagicMock()
     hass.config_entries.async_update_entry = MagicMock()
 
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 31,
             "type": "growspace_manager/save_ai_agent",
             "agent_id": "new-agent-abc",
         }
-        await websocket_save_ai_agent(hass, mock_connection, msg)
+        result = await websocket_save_ai_agent(hass, coordinator, msg)
 
     # Verify options update
     expected_options = {
@@ -1485,9 +1281,7 @@ async def test_save_ai_agent_success(
         config_entry, options=expected_options
     )
     coordinator.async_commit.assert_called_once()
-    mock_connection.send_result.assert_called_once_with(
-        31, {"success": True, "agent_id": "new-agent-abc"}
-    )
+    assert result == {"success": True, "agent_id": "new-agent-abc"}
 
 
 @pytest.mark.asyncio
@@ -1500,9 +1294,12 @@ async def test_save_ai_agent_without_options_attribute(
     )
 
     config_entry = MagicMock()
-    config_entry.options = {"ai_settings": {"assistant_id": "old-agent", "ai_enabled": False}}
+    config_entry.options = {
+        "ai_settings": {"assistant_id": "old-agent", "ai_enabled": False}
+    }
 
     coordinator = MagicMock()
+    coordinator.growspaces = {}
     coordinator.config_entry = config_entry
     del coordinator.options
     coordinator.async_commit = AsyncMock()
@@ -1510,20 +1307,16 @@ async def test_save_ai_agent_without_options_attribute(
     hass = MagicMock()
     hass.config_entries.async_update_entry = MagicMock()
 
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 32,
             "type": "growspace_manager/save_ai_agent",
             "agent_id": "new-agent-abc",
         }
-        await websocket_save_ai_agent(hass, mock_connection, msg)
+        await websocket_save_ai_agent(hass, coordinator, msg)
 
     assert not hasattr(coordinator, "options")
     hass.config_entries.async_update_entry.assert_called_once()
-    mock_connection.send_result.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -1539,26 +1332,20 @@ async def test_save_ai_settings_without_options_attribute(
     config_entry.options = {"other": "kept"}
 
     coordinator = MagicMock()
+    coordinator.growspaces = {}
     coordinator.config_entry = config_entry
     del coordinator.options
     coordinator.async_commit = AsyncMock()
 
     mock_hass = MagicMock()
-    with patch(
-        "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 33,
             "type": "growspace_manager/save_ai_settings",
             "ai_enabled": True,
         }
-        await websocket_save_ai_settings(mock_hass, mock_connection, msg)
+        result = await websocket_save_ai_settings(mock_hass, coordinator, msg)
 
     assert not hasattr(coordinator, "options")
     mock_hass.config_entries.async_update_entry.assert_called_once()
-    mock_connection.send_result.assert_called_once_with(33, {"success": True})
-
-
-
-
+    assert result == {"success": True}

--- a/tests/core/test_websocket_conversation_threads.py
+++ b/tests/core/test_websocket_conversation_threads.py
@@ -109,14 +109,9 @@ async def test_get_conversation_threads_returns_threads(
     coordinator = _make_coordinator(_SAMPLE_THREADS)
     msg = {"id": 1, "type": WS_TYPE_GET_CONVERSATION_THREADS, "growspace_id": "gs1"}
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: coordinator,
-        )
-        await websocket_get_conversation_threads(MagicMock(), mock_connection, msg)
+    result = await websocket_get_conversation_threads(MagicMock(), coordinator, msg)
 
-    mock_connection.send_result.assert_called_once_with(1, _SAMPLE_THREADS)
+    assert result == _SAMPLE_THREADS
     coordinator.conversation_store.get_threads.assert_called_once_with("gs1")
 
 
@@ -128,39 +123,12 @@ async def test_get_conversation_threads_returns_empty_list_when_none(
     coordinator = _make_coordinator([])
     msg = {"id": 1, "type": WS_TYPE_GET_CONVERSATION_THREADS, "growspace_id": "new-gs"}
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: coordinator,
-        )
-        await websocket_get_conversation_threads(MagicMock(), mock_connection, msg)
+    result = await websocket_get_conversation_threads(MagicMock(), coordinator, msg)
 
-    mock_connection.send_result.assert_called_once_with(1, [])
+    assert result == []
 
 
 @pytest.mark.asyncio
-async def test_get_conversation_threads_sends_error_when_coordinator_missing(
-    mock_connection: MagicMock,
-) -> None:
-    """Handler sends not_found when coordinator is unavailable."""
-    msg = {"id": 1, "type": WS_TYPE_GET_CONVERSATION_THREADS, "growspace_id": "gs1"}
-
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: None,
-        )
-        await websocket_get_conversation_threads(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "not_found"
-
-
-# ---------------------------------------------------------------------------
-# save_conversation_threads handler
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_save_conversation_threads_persists_threads(
     mock_connection: MagicMock,
@@ -174,17 +142,12 @@ async def test_save_conversation_threads_persists_threads(
         "threads": _SAMPLE_THREADS,
     }
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: coordinator,
-        )
-        await websocket_save_conversation_threads(MagicMock(), mock_connection, msg)
+    result = await websocket_save_conversation_threads(MagicMock(), coordinator, msg)
 
     coordinator.conversation_store.save_threads.assert_awaited_once_with(
         "gs1", _SAMPLE_THREADS
     )
-    mock_connection.send_result.assert_called_once_with(2, {"success": True})
+    assert result == {"success": True}
 
 
 @pytest.mark.asyncio
@@ -200,35 +163,7 @@ async def test_save_conversation_threads_accepts_empty_list(
         "threads": [],
     }
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: coordinator,
-        )
-        await websocket_save_conversation_threads(MagicMock(), mock_connection, msg)
+    result = await websocket_save_conversation_threads(MagicMock(), coordinator, msg)
 
     coordinator.conversation_store.save_threads.assert_awaited_once_with("gs1", [])
-    mock_connection.send_result.assert_called_once_with(3, {"success": True})
-
-
-@pytest.mark.asyncio
-async def test_save_conversation_threads_sends_error_when_coordinator_missing(
-    mock_connection: MagicMock,
-) -> None:
-    """Handler sends not_found when coordinator is unavailable."""
-    msg = {
-        "id": 4,
-        "type": WS_TYPE_SAVE_CONVERSATION_THREADS,
-        "growspace_id": "gs1",
-        "threads": [],
-    }
-
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: None,
-        )
-        await websocket_save_conversation_threads(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "not_found"
+    assert result == {"success": True}

--- a/tests/core/test_websocket_get_ai_settings.py
+++ b/tests/core/test_websocket_get_ai_settings.py
@@ -51,15 +51,8 @@ async def test_get_ai_settings_returns_full_settings_dict(
     coordinator = _make_coordinator(settings)
     msg = {"id": 1, "type": f"{DOMAIN}/get_ai_settings"}
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: coordinator,
-        )
-        await websocket_get_ai_settings(MagicMock(), mock_connection, msg)
+    result = await websocket_get_ai_settings(MagicMock(), coordinator, msg)
 
-    mock_connection.send_result.assert_called_once()
-    result = mock_connection.send_result.call_args[0][1]
     assert result == settings
 
 
@@ -76,35 +69,6 @@ async def test_get_ai_settings_returns_empty_dict_when_no_ai_settings(
     coordinator.options = {}
     msg = {"id": 2, "type": f"{DOMAIN}/get_ai_settings"}
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: coordinator,
-        )
-        await websocket_get_ai_settings(MagicMock(), mock_connection, msg)
+    result = await websocket_get_ai_settings(MagicMock(), coordinator, msg)
 
-    result = mock_connection.send_result.call_args[0][1]
     assert result == {}
-
-
-@pytest.mark.asyncio
-async def test_get_ai_settings_sends_error_when_coordinator_missing(
-    mock_connection: MagicMock,
-) -> None:
-    """get_ai_settings sends a not_found error when the coordinator is not loaded."""
-    from custom_components.growspace_manager.websocket.ai_assistant import (
-        websocket_get_ai_settings,
-    )
-
-    msg = {"id": 3, "type": f"{DOMAIN}/get_ai_settings"}
-
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: None,
-        )
-        await websocket_get_ai_settings(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    error_code = mock_connection.send_error.call_args[0][1]
-    assert error_code == "not_found"

--- a/tests/core/test_websocket_get_ai_status.py
+++ b/tests/core/test_websocket_get_ai_status.py
@@ -40,15 +40,8 @@ async def test_get_ai_status_returns_true_when_ai_enabled(
     coordinator = _make_coordinator(ai_enabled=True)
     msg = {"id": 1, "type": f"{DOMAIN}/get_ai_status"}
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: coordinator,
-        )
-        await websocket_get_ai_status(MagicMock(), mock_connection, msg)
+    result = await websocket_get_ai_status(MagicMock(), coordinator, msg)
 
-    mock_connection.send_result.assert_called_once()
-    result = mock_connection.send_result.call_args[0][1]
     assert result == {"ai_enabled": True}
 
 
@@ -64,15 +57,8 @@ async def test_get_ai_status_returns_false_when_ai_disabled(
     coordinator = _make_coordinator(ai_enabled=False)
     msg = {"id": 2, "type": f"{DOMAIN}/get_ai_status"}
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: coordinator,
-        )
-        await websocket_get_ai_status(MagicMock(), mock_connection, msg)
+    result = await websocket_get_ai_status(MagicMock(), coordinator, msg)
 
-    mock_connection.send_result.assert_called_once()
-    result = mock_connection.send_result.call_args[0][1]
     assert result == {"ai_enabled": False}
 
 
@@ -89,35 +75,6 @@ async def test_get_ai_status_returns_false_when_no_ai_settings(
     coordinator.options = {}
     msg = {"id": 3, "type": f"{DOMAIN}/get_ai_status"}
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: coordinator,
-        )
-        await websocket_get_ai_status(MagicMock(), mock_connection, msg)
+    result = await websocket_get_ai_status(MagicMock(), coordinator, msg)
 
-    result = mock_connection.send_result.call_args[0][1]
     assert result == {"ai_enabled": False}
-
-
-@pytest.mark.asyncio
-async def test_get_ai_status_sends_error_when_coordinator_missing(
-    mock_connection: MagicMock,
-) -> None:
-    """get_ai_status sends a not_found error when the coordinator is not loaded."""
-    from custom_components.growspace_manager.websocket.ai_assistant import (
-        websocket_get_ai_status,
-    )
-
-    msg = {"id": 4, "type": f"{DOMAIN}/get_ai_status"}
-
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: None,
-        )
-        await websocket_get_ai_status(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    error_code = mock_connection.send_error.call_args[0][1]
-    assert error_code == "not_found"

--- a/tests/core/test_websocket_get_briefing.py
+++ b/tests/core/test_websocket_get_briefing.py
@@ -96,45 +96,24 @@ async def test_get_briefing_returns_briefing(mock_connection: MagicMock) -> None
     coordinator = _make_coordinator(stub_briefing)
     msg = {"id": 1, "type": WS_TYPE_GET_BRIEFING, "growspace_id": "tent1"}
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: coordinator,
-        )
-        await websocket_get_briefing(MagicMock(), mock_connection, msg)
+    result = await websocket_get_briefing(MagicMock(), coordinator, msg)
 
-    mock_connection.send_result.assert_called_once_with(1, stub_briefing)
+    assert result == stub_briefing
 
 
 @pytest.mark.asyncio
 async def test_get_briefing_passes_force_refresh(mock_connection: MagicMock) -> None:
     """Handler passes force_refresh=True to the scheduler."""
     coordinator = _make_coordinator({"summary": "Fresh"})
-    msg = {"id": 2, "type": WS_TYPE_GET_BRIEFING, "growspace_id": "", "force_refresh": True}
+    msg = {
+        "id": 2,
+        "type": WS_TYPE_GET_BRIEFING,
+        "growspace_id": "",
+        "force_refresh": True,
+    }
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: coordinator,
-        )
-        await websocket_get_briefing(MagicMock(), mock_connection, msg)
+    await websocket_get_briefing(MagicMock(), coordinator, msg)
 
-    coordinator.briefing_scheduler.async_get_briefing.assert_called_once_with(force_refresh=True)
-
-
-@pytest.mark.asyncio
-async def test_get_briefing_sends_error_when_coordinator_missing(
-    mock_connection: MagicMock,
-) -> None:
-    """Handler sends not_found when the coordinator is unavailable."""
-    msg = {"id": 3, "type": WS_TYPE_GET_BRIEFING}
-
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: None,
-        )
-        await websocket_get_briefing(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "not_found"
+    coordinator.briefing_scheduler.async_get_briefing.assert_called_once_with(
+        force_refresh=True
+    )

--- a/tests/core/test_websocket_irrigation_analytics.py
+++ b/tests/core/test_websocket_irrigation_analytics.py
@@ -1,7 +1,8 @@
 """Tests for irrigation analytics WebSocket handler."""
+
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -35,17 +36,16 @@ async def test_get_irrigation_analytics_returns_stage_aggregates(
     tracker_b = MagicMock()
     tracker_b.get_stage_aggregates.return_value = {"veg": 8.0}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call"
-    ) as mock_get:
+    if True:
+        mock_get = MagicMock()
         mock_get.return_value.services.growspaces.get_all_trackers_for_growspace.return_value = {
             "sensor.tank_a": tracker_a,
             "sensor.tank_b": tracker_b,
         }
-        await websocket_get_irrigation_analytics(hass, mock_connection, msg)
+        result = await websocket_get_irrigation_analytics(
+            hass, mock_get.return_value, msg
+        )
 
-    mock_connection.send_result.assert_called_once()
-    result = mock_connection.send_result.call_args[0][1]
     assert result["growspace_id"] == "gs1"
     assert result["stage_aggregates"]["veg"] == pytest.approx(20.0)
     assert result["stage_aggregates"]["flower_early"] == pytest.approx(5.0)
@@ -61,14 +61,13 @@ async def test_get_irrigation_analytics_no_trackers_returns_empty(
         "type": WS_TYPE_GET_IRRIGATION_ANALYTICS,
         "growspace_id": "gs1",
     }
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call"
-    ) as mock_get:
+    if True:
+        mock_get = MagicMock()
         mock_get.return_value.services.growspaces.get_all_trackers_for_growspace.return_value = {}
-        await websocket_get_irrigation_analytics(hass, mock_connection, msg)
+        result = await websocket_get_irrigation_analytics(
+            hass, mock_get.return_value, msg
+        )
 
-    mock_connection.send_result.assert_called_once()
-    result = mock_connection.send_result.call_args[0][1]
     assert result["stage_aggregates"] == {}
 
 
@@ -82,31 +81,11 @@ async def test_get_irrigation_analytics_unknown_growspace_returns_empty(
         "type": WS_TYPE_GET_IRRIGATION_ANALYTICS,
         "growspace_id": "unknown",
     }
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call"
-    ) as mock_get:
+    if True:
+        mock_get = MagicMock()
         mock_get.return_value.services.growspaces.get_all_trackers_for_growspace.return_value = {}
-        await websocket_get_irrigation_analytics(hass, mock_connection, msg)
+        result = await websocket_get_irrigation_analytics(
+            hass, mock_get.return_value, msg
+        )
 
-    mock_connection.send_result.assert_called_once()
-    result = mock_connection.send_result.call_args[0][1]
     assert result["stage_aggregates"] == {}
-
-
-@pytest.mark.asyncio
-async def test_get_irrigation_analytics_handles_coordinator_error(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    """Handler sends error when coordinator lookup fails."""
-    msg = {
-        "id": 1,
-        "type": WS_TYPE_GET_IRRIGATION_ANALYTICS,
-        "growspace_id": "gs1",
-    }
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-        side_effect=Exception("no coordinator"),
-    ):
-        await websocket_get_irrigation_analytics(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()

--- a/tests/core/test_websocket_notifications.py
+++ b/tests/core/test_websocket_notifications.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
-from homeassistant.exceptions import ServiceValidationError
 
 
 @pytest.fixture
@@ -43,17 +41,14 @@ async def test_save_notification_settings_writes_settings_and_ai_auto_alerts(
     }
 
     mock_hass = MagicMock()
-    with patch(
-        "custom_components.growspace_manager.websocket.notifications._get_coordinator",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 1,
             "type": "growspace_manager/save_notification_settings",
             "notification_settings": settings,
             "ai_auto_alerts": False,
         }
-        await websocket_save_notification_settings(mock_hass, mock_connection, msg)
+        result = await websocket_save_notification_settings(mock_hass, coordinator, msg)
 
     mock_hass.config_entries.async_update_entry.assert_called_once()
     saved_options = mock_hass.config_entries.async_update_entry.call_args[1]["options"]
@@ -63,7 +58,7 @@ async def test_save_notification_settings_writes_settings_and_ai_auto_alerts(
     assert saved_options["ai_settings"]["ai_enabled"] is True
     assert saved_options["ai_settings"]["assistant_id"] == "agent.x"
     assert saved_options["ai_settings"]["ai_auto_alerts"] is False
-    mock_connection.send_result.assert_called_once_with(1, {"success": True})
+    assert result == {"success": True}
 
 
 @pytest.mark.asyncio
@@ -90,10 +85,7 @@ async def test_save_notification_settings_persists_timed_notifications(
     ]
 
     mock_hass = MagicMock()
-    with patch(
-        "custom_components.growspace_manager.websocket.notifications._get_coordinator",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 2,
             "type": "growspace_manager/save_notification_settings",
@@ -101,7 +93,7 @@ async def test_save_notification_settings_persists_timed_notifications(
             "ai_auto_alerts": True,
             "timed_notifications": timed,
         }
-        await websocket_save_notification_settings(mock_hass, mock_connection, msg)
+        await websocket_save_notification_settings(mock_hass, coordinator, msg)
 
     saved_options = mock_hass.config_entries.async_update_entry.call_args[1]["options"]
     assert saved_options["timed_notifications"] == timed
@@ -122,97 +114,14 @@ async def test_save_notification_settings_leaves_timed_notifications_untouched_w
     coordinator.async_commit = AsyncMock()
 
     mock_hass = MagicMock()
-    with patch(
-        "custom_components.growspace_manager.websocket.notifications._get_coordinator",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 3,
             "type": "growspace_manager/save_notification_settings",
             "notification_settings": {},
             "ai_auto_alerts": True,
         }
-        await websocket_save_notification_settings(mock_hass, mock_connection, msg)
+        await websocket_save_notification_settings(mock_hass, coordinator, msg)
 
     saved_options = mock_hass.config_entries.async_update_entry.call_args[1]["options"]
     assert saved_options["timed_notifications"] == existing
-
-
-@pytest.mark.asyncio
-async def test_save_notification_settings_sends_error_when_no_coordinator(
-    mock_connection: MagicMock,
-) -> None:
-    """save_notification_settings sends not_found error when coordinator is absent."""
-    from custom_components.growspace_manager.websocket.notifications import (
-        websocket_save_notification_settings,
-    )
-
-    with patch(
-        "custom_components.growspace_manager.websocket.notifications._get_coordinator",
-        return_value=None,
-    ):
-        msg = {
-            "id": 2,
-            "type": "growspace_manager/save_notification_settings",
-            "notification_settings": {},
-            "ai_auto_alerts": True,
-        }
-        await websocket_save_notification_settings(MagicMock(), mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "not_found"
-
-
-@pytest.mark.asyncio
-async def test_get_coordinator_returns_coordinator_when_available(
-    mock_connection: MagicMock,
-) -> None:
-    """_get_coordinator returns coordinator when get_for_service_call succeeds."""
-    from custom_components.growspace_manager.websocket.notifications import (
-        _get_coordinator,
-    )
-
-    coordinator = MagicMock()
-    with patch(
-        "custom_components.growspace_manager.websocket.notifications.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
-        result = _get_coordinator(MagicMock(), mock_connection)
-
-    assert result is coordinator
-
-
-@pytest.mark.asyncio
-async def test_get_coordinator_returns_none_on_service_validation_error(
-    mock_connection: MagicMock,
-) -> None:
-    """_get_coordinator returns None when get_for_service_call raises ServiceValidationError."""
-    from custom_components.growspace_manager.websocket.notifications import (
-        _get_coordinator,
-    )
-
-    with patch(
-        "custom_components.growspace_manager.websocket.notifications.GrowspaceCoordinator.get_for_service_call",
-        side_effect=ServiceValidationError("not found"),
-    ):
-        result = _get_coordinator(MagicMock(), mock_connection)
-
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_get_coordinator_returns_none_on_unexpected_exception(
-    mock_connection: MagicMock,
-) -> None:
-    """_get_coordinator returns None when get_for_service_call raises any exception."""
-    from custom_components.growspace_manager.websocket.notifications import (
-        _get_coordinator,
-    )
-
-    with patch(
-        "custom_components.growspace_manager.websocket.notifications.GrowspaceCoordinator.get_for_service_call",
-        side_effect=RuntimeError("unexpected"),
-    ):
-        result = _get_coordinator(MagicMock(), mock_connection)
-
-    assert result is None

--- a/tests/core/test_websocket_snapshots.py
+++ b/tests/core/test_websocket_snapshots.py
@@ -8,6 +8,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from custom_components.growspace_manager.const import DOMAIN
+from custom_components.growspace_manager.exceptions import GrowspaceNotFoundError
 from custom_components.growspace_manager.websocket import (
     websocket_add_growspace_note,
     websocket_add_timeline_note,
@@ -52,15 +53,10 @@ async def test_websocket_get_growspace_data_snapshot(
         ],
     }
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {"id": 1, "type": f"{DOMAIN}/get_data", "growspace_id": "gs1"}
-        await websocket_get_growspace_data(hass, mock_connection, msg)
+        result = await websocket_get_growspace_data(hass, coordinator, msg)
 
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
         assert result == snapshot
 
 
@@ -80,15 +76,10 @@ async def test_websocket_get_strain_library_snapshot(
     coordinator._strain_library = strain_library
     coordinator.services.config.strain_library = strain_library
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_any",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {"id": 2, "type": f"{DOMAIN}/get_strain_library"}
-        websocket_get_strain_library(hass, mock_connection, msg)
+        result = websocket_get_strain_library(hass, coordinator, msg)
 
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
         assert result == snapshot
 
 
@@ -113,19 +104,13 @@ async def test_websocket_get_nutrient_inventory_snapshot(
 
     with (
         patch(
-            "custom_components.growspace_manager.GrowspaceCoordinator.get_any",
-            return_value=coordinator,
-        ),
-        patch(
             "custom_components.growspace_manager.websocket.nutrients.asdict",
             return_value=inventory_data,
         ),
     ):
         msg = {"id": 3, "type": f"{DOMAIN}/get_nutrient_inventory"}
-        websocket_get_nutrient_inventory(hass, mock_connection, msg)
+        result = websocket_get_nutrient_inventory(hass, coordinator, msg)
 
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
         assert result == snapshot
 
 
@@ -144,15 +129,10 @@ async def test_websocket_get_nutrient_presets_snapshot(
         "ipm_presets": [],
     }
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {"id": 4, "type": f"{DOMAIN}/get_nutrient_presets"}
-        websocket_get_nutrient_presets(hass, mock_connection, msg)
+        result = websocket_get_nutrient_presets(hass, coordinator, msg)
 
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
         assert result == snapshot
 
 
@@ -170,15 +150,10 @@ async def test_websocket_get_ipm_presets_snapshot(
         ],
     }
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {"id": 5, "type": f"{DOMAIN}/get_ipm_presets"}
-        websocket_get_ipm_presets(hass, mock_connection, msg)
+        result = websocket_get_ipm_presets(hass, coordinator, msg)
 
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
         assert result == snapshot
 
 
@@ -193,12 +168,7 @@ async def test_websocket_add_timeline_note_snapshot(
     coordinator.services.add_timeline_note = AsyncMock()
     coordinator._strain_library = MagicMock()
 
-    with (
-        patch(
-            "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-            return_value=coordinator,
-        ),
-    ):
+    if True:
         msg = {
             "id": 6,
             "type": f"{DOMAIN}/add_timeline_note",
@@ -212,10 +182,9 @@ async def test_websocket_add_timeline_note_snapshot(
             "amount_ml": 500,
             "metadata": {"source": "manual"},
         }
-        await websocket_add_timeline_note(hass, mock_connection, msg)
+        await websocket_add_timeline_note(hass, coordinator, msg)
 
         coordinator.services.add_timeline_note.assert_called_once()
-        mock_connection.send_result.assert_called_once_with(6)
 
 
 @pytest.mark.asyncio
@@ -230,10 +199,7 @@ async def test_websocket_add_growspace_note_snapshot(
     coordinator.services = MagicMock()
     coordinator.services.growspaces.add_growspace_note = AsyncMock()
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 7,
             "type": f"{DOMAIN}/add_growspace_note",
@@ -241,10 +207,9 @@ async def test_websocket_add_growspace_note_snapshot(
             "notes": "Tent looking healthy today.",
             "images": [],
         }
-        await websocket_add_growspace_note(hass, mock_connection, msg)
+        await websocket_add_growspace_note(hass, coordinator, msg)
 
         coordinator.services.growspaces.add_growspace_note.assert_called_once()
-        mock_connection.send_result.assert_called_once_with(7)
 
 
 @freeze_time("2024-01-01 12:00:00", tz_offset=0)
@@ -301,10 +266,8 @@ async def test_websocket_get_event_log_snapshot(
         mock_session_scope.return_value.__enter__.return_value = mock_session
 
         msg = {"id": 7, "type": f"{DOMAIN}/get_log", "growspace_id": "gs1"}
-        await websocket_get_event_log(hass, mock_connection, msg)
+        result = await websocket_get_event_log(hass, MagicMock(), msg)
 
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
         assert result == snapshot
 
 
@@ -362,10 +325,8 @@ async def test_websocket_get_alerts_snapshot(
         mock_session_scope.return_value.__enter__.return_value = mock_session
 
         msg = {"id": 8, "type": f"{DOMAIN}/get_alerts", "growspace_id": "gs1"}
-        await websocket_get_alerts(hass, mock_connection, msg)
+        result = await websocket_get_alerts(hass, MagicMock(), msg)
 
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
         assert result == snapshot
 
 
@@ -394,10 +355,8 @@ async def test_websocket_get_history_stats_snapshot(
             "start_time": "2026-01-12T11:00:00+00:00",
             "interval_minutes": 5,
         }
-        await websocket_get_history_stats(hass, mock_connection, msg)
+        result = await websocket_get_history_stats(hass, MagicMock(), msg)
 
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
         assert result == snapshot
 
 
@@ -414,10 +373,7 @@ async def test_websocket_update_breeder_snapshot(
     coordinator._strain_library = strain_library
     coordinator.services.config.strain_library = strain_library
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_any",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 10,
             "type": f"{DOMAIN}/update_breeder",
@@ -425,9 +381,9 @@ async def test_websocket_update_breeder_snapshot(
             "new_name": "New Breeder",
             "logo": "new_logo.png",
         }
-        await websocket_update_breeder(hass, mock_connection, msg)
+        result = await websocket_update_breeder(hass, coordinator, msg)
 
-        mock_connection.send_result.assert_called_once_with(10, {"updated": 5})
+        assert result == {"updated": 5}
         assert snapshot == {"updated": 5}
 
 
@@ -444,18 +400,15 @@ async def test_websocket_delete_breeder_snapshot(
     coordinator._strain_library = strain_library
     coordinator.services.config.strain_library = strain_library
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_any",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 11,
             "type": f"{DOMAIN}/delete_breeder",
             "breeder_name": "Breeder to Delete",
         }
-        await websocket_delete_breeder(hass, mock_connection, msg)
+        result = await websocket_delete_breeder(hass, coordinator, msg)
 
-        mock_connection.send_result.assert_called_once_with(11, {"deleted": 3})
+        assert result == {"deleted": 3}
         assert snapshot == {"deleted": 3}
 
 
@@ -469,18 +422,15 @@ async def test_websocket_get_vision_history_empty(
     growspace.vision_checkup_history = []
     coordinator.growspaces = {"tent1": growspace}
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 12,
             "type": f"{DOMAIN}/get_vision_history",
             "growspace_id": "tent1",
         }
-        await websocket_get_vision_history(hass, mock_connection, msg)
+        result = await websocket_get_vision_history(hass, coordinator, msg)
 
-    mock_connection.send_result.assert_called_once_with(12, {"history": [], "total": 0})
+        assert result == {"history": [], "total": 0}
 
 
 @pytest.mark.asyncio
@@ -512,21 +462,15 @@ async def test_websocket_get_vision_history_with_results(
     growspace.vision_checkup_history = [result1, result2]
     coordinator.growspaces = {"tent1": growspace}
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 13,
             "type": f"{DOMAIN}/get_vision_history",
             "growspace_id": "tent1",
             "limit": 10,
         }
-        await websocket_get_vision_history(hass, mock_connection, msg)
+        result = await websocket_get_vision_history(hass, coordinator, msg)
 
-    mock_connection.send_result.assert_called_once()
-    call_id, result = mock_connection.send_result.call_args[0]
-    assert call_id == 13
     assert result["total"] == 2
     assert len(result["history"]) == 2
 
@@ -548,20 +492,13 @@ async def test_websocket_get_vision_history_growspace_not_found(
     coordinator = MagicMock()
     coordinator.growspaces = {}
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
-        msg = {
-            "id": 14,
-            "type": f"{DOMAIN}/get_vision_history",
-            "growspace_id": "nonexistent",
-        }
-        await websocket_get_vision_history(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once_with(
-        14, "not_found", "Growspace nonexistent not found"
-    )
+    msg = {
+        "id": 14,
+        "type": f"{DOMAIN}/get_vision_history",
+        "growspace_id": "nonexistent",
+    }
+    with pytest.raises(GrowspaceNotFoundError, match="'nonexistent' not found"):
+        await websocket_get_vision_history(hass, coordinator, msg)
 
 
 @pytest.mark.asyncio
@@ -587,20 +524,14 @@ async def test_websocket_get_vision_history_limit(
     growspace.vision_checkup_history = results
     coordinator.growspaces = {"tent1": growspace}
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 15,
             "type": f"{DOMAIN}/get_vision_history",
             "growspace_id": "tent1",
             "limit": 2,
         }
-        await websocket_get_vision_history(hass, mock_connection, msg)
+        result = await websocket_get_vision_history(hass, coordinator, msg)
 
-    mock_connection.send_result.assert_called_once()
-    call_id, result = mock_connection.send_result.call_args[0]
-    assert call_id == 15
     assert result["total"] == 5
     assert len(result["history"]) == 2

--- a/tests/core/test_websocket_subareas.py
+++ b/tests/core/test_websocket_subareas.py
@@ -1,7 +1,8 @@
 """Tests for subarea WebSocket commands."""
+
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -34,13 +35,12 @@ async def test_websocket_get_subareas_success(
     hass: HomeAssistant, mock_connection: MagicMock, mock_subarea: Subarea
 ) -> None:
     msg = {"id": 1, "type": "growspace_manager/get_subareas", "growspace_id": "gs1"}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call"
-    ) as mock_get:
-        mock_get.return_value.services.growspaces.get_subareas.return_value = [mock_subarea]
-        await websocket_get_subareas(hass, mock_connection, msg)
-    mock_connection.send_result.assert_called_once()
-    result = mock_connection.send_result.call_args[0][1]
+    if True:
+        mock_get = MagicMock()
+        mock_get.return_value.services.growspaces.get_subareas.return_value = [
+            mock_subarea
+        ]
+        result = await websocket_get_subareas(hass, mock_get.return_value, msg)
     assert result[0]["id"] == "sub1"
     assert result[0]["name"] == "Undercanopy"
 
@@ -49,14 +49,19 @@ async def test_websocket_get_subareas_success(
 async def test_websocket_add_subarea_success(
     hass: HomeAssistant, mock_connection: MagicMock, mock_subarea: Subarea
 ) -> None:
-    msg = {"id": 1, "type": "growspace_manager/add_subarea", "growspace_id": "gs1", "name": "Undercanopy"}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call"
-    ) as mock_get:
-        mock_get.return_value.services.growspaces.add_subarea = AsyncMock(return_value=mock_subarea)
-        await websocket_add_subarea(hass, mock_connection, msg)
-    mock_connection.send_result.assert_called_once()
-    assert mock_connection.send_result.call_args[0][1]["name"] == "Undercanopy"
+    msg = {
+        "id": 1,
+        "type": "growspace_manager/add_subarea",
+        "growspace_id": "gs1",
+        "name": "Undercanopy",
+    }
+    if True:
+        mock_get = MagicMock()
+        mock_get.return_value.services.growspaces.add_subarea = AsyncMock(
+            return_value=mock_subarea
+        )
+        result = await websocket_add_subarea(hass, mock_get.return_value, msg)
+    assert result["name"] == "Undercanopy"
 
 
 @pytest.mark.asyncio
@@ -70,12 +75,12 @@ async def test_websocket_update_subarea_success(
         "subarea_id": "sub1",
         "environment_config": {"temperature_sensors": ["sensor.t"]},
     }
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call"
-    ) as mock_get:
-        mock_get.return_value.services.growspaces.update_subarea = AsyncMock(return_value=mock_subarea)
-        await websocket_update_subarea(hass, mock_connection, msg)
-    mock_connection.send_result.assert_called_once()
+    if True:
+        mock_get = MagicMock()
+        mock_get.return_value.services.growspaces.update_subarea = AsyncMock(
+            return_value=mock_subarea
+        )
+        await websocket_update_subarea(hass, mock_get.return_value, msg)
 
 
 @pytest.mark.asyncio
@@ -88,38 +93,28 @@ async def test_websocket_remove_subarea_success(
         "growspace_id": "gs1",
         "subarea_id": "sub1",
     }
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call"
-    ) as mock_get:
+    if True:
+        mock_get = MagicMock()
         mock_get.return_value.services.growspaces.remove_subarea = AsyncMock()
-        await websocket_remove_subarea(hass, mock_connection, msg)
-    mock_connection.send_result.assert_called_once_with(1, {"success": True})
+        result = await websocket_remove_subarea(hass, mock_get.return_value, msg)
+    assert result == {"success": True}
 
 
 @pytest.mark.asyncio
-async def test_websocket_get_subareas_error(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    msg = {"id": 1, "type": "growspace_manager/get_subareas", "growspace_id": "gs1"}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        side_effect=Exception("boom"),
-    ):
-        await websocket_get_subareas(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once()
-
-
 @pytest.mark.asyncio
 async def test_websocket_add_subarea_validation_error(
     hass: HomeAssistant, mock_connection: MagicMock
 ) -> None:
-    msg = {"id": 1, "type": "growspace_manager/add_subarea", "growspace_id": "gs1", "name": "X"}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call"
-    ) as mock_get:
+    msg = {
+        "id": 1,
+        "type": "growspace_manager/add_subarea",
+        "growspace_id": "gs1",
+        "name": "X",
+    }
+    if True:
+        mock_get = MagicMock()
         mock_get.return_value.services.growspaces.add_subarea = AsyncMock(
             side_effect=ServiceValidationError("not found")
         )
-        await websocket_add_subarea(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "invalid_args"
+        with pytest.raises(ServiceValidationError, match="not found"):
+            await websocket_add_subarea(hass, mock_get.return_value, msg)

--- a/tests/core/test_ws_command_lifecycle.py
+++ b/tests/core/test_ws_command_lifecycle.py
@@ -1,0 +1,207 @@
+"""Unit tests for the WS Command Lifecycle (ADR-0027).
+
+The registration wrapper owns resolve → execute → send_result → error
+mapping for every command, so those behaviours are tested once here — handler
+tests assert on returned payloads and raised typed exceptions instead of mock
+connections.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import voluptuous as vol
+
+from custom_components.growspace_manager.exceptions import (
+    CoordinatorNotReadyError,
+    GrowspaceError,
+    PlantNotFoundError,
+    RateLimitedError,
+)
+from custom_components.growspace_manager.websocket._common import (
+    DEFAULT_WS_ERROR_MAP,
+    WSCommand,
+    register_ws_command,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+
+_SCHEMA = vol.Schema({}, extra=vol.ALLOW_EXTRA)
+
+
+def _registered_wrapper(hass: HomeAssistant, command: WSCommand) -> Any:
+    """Register the command and capture the wrapper handed to websocket_api."""
+    with patch(
+        "custom_components.growspace_manager.websocket._common.websocket_api"
+    ) as ws_api:
+        ws_api.async_response = lambda func: func
+        register_ws_command(hass, command)
+        return ws_api.async_register_command.call_args[0][2]
+
+
+async def test_async_payload_is_sent_as_result(hass: HomeAssistant) -> None:
+    """The handler's return value becomes the send_result payload."""
+
+    async def handler(hass: HomeAssistant, coordinator: Any, msg: dict) -> dict:
+        return {"echo": msg["value"]}
+
+    wrapper = _registered_wrapper(
+        hass, WSCommand("growspace_manager/test", handler, _SCHEMA)
+    )
+    connection = MagicMock()
+    with patch(
+        "custom_components.growspace_manager.websocket._common.GrowspaceCoordinator"
+    ) as coord_cls:
+        coord_cls.get_for_service_call.return_value = MagicMock()
+        await wrapper(hass, connection, {"id": 5, "value": 42})
+
+    connection.send_result.assert_called_once_with(5, {"echo": 42})
+
+
+async def test_sync_handler_registers_and_sends(hass: HomeAssistant) -> None:
+    """sync=True commands run through the callback wrapper."""
+
+    def handler(hass: HomeAssistant, coordinator: Any, msg: dict) -> dict:
+        return {"ok": True}
+
+    wrapper = _registered_wrapper(
+        hass, WSCommand("growspace_manager/test", handler, _SCHEMA, sync=True)
+    )
+    connection = MagicMock()
+    with patch(
+        "custom_components.growspace_manager.websocket._common.GrowspaceCoordinator"
+    ) as coord_cls:
+        coord_cls.get_for_service_call.return_value = MagicMock()
+        wrapper(hass, connection, {"id": 1})
+
+    connection.send_result.assert_called_once_with(1, {"ok": True})
+
+
+@pytest.mark.parametrize(
+    ("resolve", "expected_accessor"),
+    [
+        ("targeted", "get_for_service_call"),
+        ("any", "get_any"),
+    ],
+)
+async def test_resolve_modes(
+    hass: HomeAssistant, resolve: str, expected_accessor: str
+) -> None:
+    """resolve='targeted' uses id-based lookup; 'any' uses get_any."""
+    seen: dict[str, Any] = {}
+
+    async def handler(hass: HomeAssistant, coordinator: Any, msg: dict) -> None:
+        seen["coordinator"] = coordinator
+
+    wrapper = _registered_wrapper(
+        hass, WSCommand("growspace_manager/test", handler, _SCHEMA, resolve=resolve)
+    )
+    connection = MagicMock()
+    with patch(
+        "custom_components.growspace_manager.websocket._common.GrowspaceCoordinator"
+    ) as coord_cls:
+        expected = MagicMock()
+        getattr(coord_cls, expected_accessor).return_value = expected
+        await wrapper(hass, connection, {"id": 1})
+
+    assert seen["coordinator"] is expected
+
+
+@pytest.mark.parametrize(
+    ("raised", "expected_code"),
+    [
+        (PlantNotFoundError("Plant 'p9' not found"), "entity_not_found"),
+        (CoordinatorNotReadyError("no instance loaded"), "coordinator_not_ready"),
+        (RateLimitedError("rate_limited"), "rate_limited"),
+        (ServiceValidationError("bad input"), "validation_failed"),
+        (GrowspaceError("domain failure"), "validation_failed"),
+        (ValueError("bad value"), "validation_failed"),
+        (RuntimeError("boom"), "internal_error"),
+    ],
+)
+async def test_error_map_produces_typed_codes(
+    hass: HomeAssistant, raised: Exception, expected_code: str
+) -> None:
+    """Raised exceptions map to the Typed Error Codes vocabulary (ADR-0005)."""
+
+    async def handler(hass: HomeAssistant, coordinator: Any, msg: dict) -> None:
+        raise raised
+
+    wrapper = _registered_wrapper(
+        hass, WSCommand("growspace_manager/test", handler, _SCHEMA)
+    )
+    connection = MagicMock()
+    with patch(
+        "custom_components.growspace_manager.websocket._common.GrowspaceCoordinator"
+    ) as coord_cls:
+        coord_cls.get_for_service_call.return_value = MagicMock()
+        await wrapper(hass, connection, {"id": 7})
+
+    connection.send_result.assert_not_called()
+    connection.send_error.assert_called_once_with(7, expected_code, str(raised))
+
+
+async def test_resolution_failure_maps_before_handler_runs(
+    hass: HomeAssistant,
+) -> None:
+    """A coordinator-resolution failure never reaches the handler."""
+    ran: list[bool] = []
+
+    async def handler(hass: HomeAssistant, coordinator: Any, msg: dict) -> None:
+        ran.append(True)
+
+    wrapper = _registered_wrapper(
+        hass, WSCommand("growspace_manager/test", handler, _SCHEMA)
+    )
+    connection = MagicMock()
+    with patch(
+        "custom_components.growspace_manager.websocket._common.GrowspaceCoordinator"
+    ) as coord_cls:
+        coord_cls.get_for_service_call.side_effect = CoordinatorNotReadyError(
+            "No Growspace Manager instance is currently loaded."
+        )
+        await wrapper(hass, connection, {"id": 3})
+
+    assert not ran
+    connection.send_error.assert_called_once_with(
+        3,
+        "coordinator_not_ready",
+        "No Growspace Manager instance is currently loaded.",
+    )
+
+
+async def test_custom_error_map_overrides_default(hass: HomeAssistant) -> None:
+    """A WSCommand-level error_map replaces the default table."""
+    custom_map = ((Exception, "validation_failed", False, "fixed message"),)
+
+    async def handler(hass: HomeAssistant, coordinator: Any, msg: dict) -> None:
+        raise RuntimeError("original")
+
+    wrapper = _registered_wrapper(
+        hass,
+        WSCommand("growspace_manager/test", handler, _SCHEMA, error_map=custom_map),
+    )
+    connection = MagicMock()
+    with patch(
+        "custom_components.growspace_manager.websocket._common.GrowspaceCoordinator"
+    ) as coord_cls:
+        coord_cls.get_for_service_call.return_value = MagicMock()
+        await wrapper(hass, connection, {"id": 9})
+
+    connection.send_error.assert_called_once_with(
+        9, "validation_failed", "fixed message"
+    )
+
+
+def test_default_map_covers_the_full_typed_vocabulary() -> None:
+    """The default table emits exactly the five codes the card types."""
+    codes = {row[1] for row in DEFAULT_WS_ERROR_MAP}
+    assert codes == {
+        "entity_not_found",
+        "coordinator_not_ready",
+        "rate_limited",
+        "validation_failed",
+        "internal_error",
+    }

--- a/tests/integration/test_alert_monitor_websocket.py
+++ b/tests/integration/test_alert_monitor_websocket.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.growspace_manager.const import DOMAIN
+from custom_components.growspace_manager.exceptions import EntityNotFoundError
 
 GROWSPACE_ID = "tent1"
 
@@ -15,20 +16,22 @@ GROWSPACE_ID = "tent1"
 def mock_alert_monitor():
     """Mock AlertMonitor returning wire-format dicts (as the real get_alerts() now does)."""
     monitor = MagicMock()
-    monitor.get_alerts = MagicMock(return_value=[
-        {
-            "id": "aaaaaaaa-0000-0000-0000-000000000001",
-            "growspace_id": GROWSPACE_ID,
-            "type": "stress",
-            "severity": "danger",
-            "bayesian_reasons": ["High VPD"],
-            "bayesian_probability": 0.91,
-            "ai_reasoning": "Adjust humidity",
-            "timestamp": 1736683200,
-            "resolved": False,
-            "resolution_note": None,
-        }
-    ])
+    monitor.get_alerts = MagicMock(
+        return_value=[
+            {
+                "id": "aaaaaaaa-0000-0000-0000-000000000001",
+                "growspace_id": GROWSPACE_ID,
+                "type": "stress",
+                "severity": "danger",
+                "bayesian_reasons": ["High VPD"],
+                "bayesian_probability": 0.91,
+                "ai_reasoning": "Adjust humidity",
+                "timestamp": 1736683200,
+                "resolved": False,
+                "resolution_note": None,
+            }
+        ]
+    )
     monitor.resolve_alert = AsyncMock(return_value=True)
     return monitor
 
@@ -71,18 +74,11 @@ async def test_get_ai_alerts_returns_all_alerts(
     hass = MagicMock()
     hass.data = {DOMAIN: {}}
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: mock_coordinator,
-        )
-        await websocket_get_ai_alerts(hass, mock_connection, msg)
+    result = await websocket_get_ai_alerts(hass, mock_coordinator, msg)
 
     mock_alert_monitor.get_alerts.assert_called_once_with(
         growspace_id=None, alert_type=None
     )
-    mock_connection.send_result.assert_called_once()
-    result = mock_connection.send_result.call_args[0][1]
     assert len(result) == 1
     assert result[0]["type"] == "stress"
     assert result[0]["severity"] == "danger"
@@ -106,44 +102,11 @@ async def test_get_ai_alerts_passes_filters(
     }
     hass = MagicMock()
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: mock_coordinator,
-        )
-        await websocket_get_ai_alerts(hass, mock_connection, msg)
+    await websocket_get_ai_alerts(hass, mock_coordinator, msg)
 
     mock_alert_monitor.get_alerts.assert_called_once_with(
         growspace_id=GROWSPACE_ID, alert_type="mold"
     )
-
-
-async def test_get_ai_alerts_no_coordinator_sends_error(
-    mock_connection: MagicMock,
-) -> None:
-    """websocket_get_ai_alerts sends an error when no coordinator is found."""
-    from custom_components.growspace_manager.websocket.ai_assistant import (
-        websocket_get_ai_alerts,
-    )
-
-    msg = {"id": 3, "type": f"{DOMAIN}/get_ai_alerts"}
-    hass = MagicMock()
-
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: None,
-        )
-        await websocket_get_ai_alerts(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    error_code = mock_connection.send_error.call_args[0][1]
-    assert error_code == "not_found"
-
-
-# ---------------------------------------------------------------------------
-# resolve_ai_alert
-# ---------------------------------------------------------------------------
 
 
 async def test_resolve_ai_alert_success(
@@ -164,16 +127,9 @@ async def test_resolve_ai_alert_success(
     }
     hass = MagicMock()
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: mock_coordinator,
-        )
-        await websocket_resolve_ai_alert(hass, mock_connection, msg)
+    result = await websocket_resolve_ai_alert(hass, mock_coordinator, msg)
 
     mock_alert_monitor.resolve_alert.assert_awaited_once_with(alert_id, notes=None)
-    mock_connection.send_result.assert_called_once()
-    result = mock_connection.send_result.call_args[0][1]
     assert result["success"] is True
 
 
@@ -196,12 +152,7 @@ async def test_resolve_ai_alert_with_resolution_note(
     }
     hass = MagicMock()
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: mock_coordinator,
-        )
-        await websocket_resolve_ai_alert(hass, mock_connection, msg)
+    await websocket_resolve_ai_alert(hass, mock_coordinator, msg)
 
     mock_alert_monitor.resolve_alert.assert_awaited_once_with(
         alert_id, notes="Fixed the dehumidifier"
@@ -215,7 +166,9 @@ async def test_resolve_ai_alert_not_found_sends_error(
 ) -> None:
     """websocket_resolve_ai_alert sends an error when alert_id is not found."""
     mock_alert_monitor.resolve_alert = AsyncMock(return_value=False)
-    mock_coordinator.services.notifications.resolve_alert = mock_alert_monitor.resolve_alert
+    mock_coordinator.services.notifications.resolve_alert = (
+        mock_alert_monitor.resolve_alert
+    )
 
     from custom_components.growspace_manager.websocket.ai_assistant import (
         websocket_resolve_ai_alert,
@@ -228,38 +181,5 @@ async def test_resolve_ai_alert_not_found_sends_error(
     }
     hass = MagicMock()
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: mock_coordinator,
-        )
-        await websocket_resolve_ai_alert(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    error_code = mock_connection.send_error.call_args[0][1]
-    assert error_code == "not_found"
-
-
-async def test_resolve_ai_alert_no_coordinator_sends_error(
-    mock_connection: MagicMock,
-) -> None:
-    """websocket_resolve_ai_alert sends error when no coordinator found."""
-    from custom_components.growspace_manager.websocket.ai_assistant import (
-        websocket_resolve_ai_alert,
-    )
-
-    msg = {
-        "id": 7,
-        "type": f"{DOMAIN}/resolve_ai_alert",
-        "alert_id": "some-id",
-    }
-    hass = MagicMock()
-
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            "custom_components.growspace_manager.websocket.ai_assistant._get_coordinator",
-            lambda h, c: None,
-        )
-        await websocket_resolve_ai_alert(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
+    with pytest.raises(EntityNotFoundError, match="'nonexistent-id' not found"):
+        await websocket_resolve_ai_alert(hass, mock_coordinator, msg)

--- a/tests/integration/test_coverage_top_off.py
+++ b/tests/integration/test_coverage_top_off.py
@@ -71,7 +71,9 @@ async def test_dehumidifier_stages_coverage(hass: HomeAssistant) -> None:
     plant_cure = create_plant(
         plant_id="p1", growspace_id="gs1", strain="S1", cure_start="2024-01-01"
     )
-    mock_coordinator.services.growspaces.get_growspace_plants.return_value = [plant_cure]
+    mock_coordinator.services.growspaces.get_growspace_plants.return_value = [
+        plant_cure
+    ]
     with patch(
         "custom_components.growspace_manager.domain.stage_calculator.calculate_days_in_stage",
         side_effect=lambda p, s: 1 if s == PlantStage.CURE else 0,
@@ -96,7 +98,9 @@ async def test_dehumidifier_stages_coverage(hass: HomeAssistant) -> None:
     plant_seedling = create_plant(
         plant_id="p1", growspace_id="gs1", strain="S1", seedling_start="2024-01-01"
     )
-    mock_coordinator.services.growspaces.get_growspace_plants.return_value = [plant_seedling]
+    mock_coordinator.services.growspaces.get_growspace_plants.return_value = [
+        plant_seedling
+    ]
     with patch(
         "custom_components.growspace_manager.domain.stage_calculator.calculate_days_in_stage",
         side_effect=lambda p, s: 1 if s == PlantStage.SEEDLING else 0,
@@ -288,7 +292,9 @@ async def test_batch_add_mother_auto_date_coverage(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
     mock_coordinator = GrowspaceCoordinator.build(hass, entry, data={})
 
-    mock_coordinator._data_repository.add_growspace(Growspace(id="mother", name="mother"))
+    mock_coordinator._data_repository.add_growspace(
+        Growspace(id="mother", name="mother")
+    )
     with patch.object(
         mock_coordinator.validator, "find_first_available_position", return_value=(1, 1)
     ):
@@ -411,12 +417,14 @@ async def test_websocket_get_event_log_spam_filter_coverage(
     hass: HomeAssistant,
 ) -> None:
     """Test websocket_get_event_log with SQL-level spam filtering."""
-    connection = MagicMock()
+    MagicMock()
     msg = {"id": 1, "type": "growspace_manager/get_event_log", "limit": 10}
 
     # With SQL-level filtering, only normal events are returned from DB
     # Spam events (optimal/stress/mold) are excluded at SQL query level
-    normal_data = json.dumps({"category": "info", "growspace_id": "gs1", "sensor_type": "moisture"})
+    normal_data = json.dumps(
+        {"category": "info", "growspace_id": "gs1", "sensor_type": "moisture"}
+    )
 
     class MockEvent:
         def __init__(self, event_id, time_fired_ts) -> None:
@@ -466,10 +474,7 @@ async def test_websocket_get_event_log_spam_filter_coverage(
 
         mock_get_recorder.return_value.async_add_executor_job.side_effect = mock_add_job
 
-        await websocket_get_event_log(hass, connection, msg)
-
-        connection.send_result.assert_called_once()
-        result = connection.send_result.call_args[0][1]
+        result = await websocket_get_event_log(hass, MagicMock(), msg)
 
         # With SQL filtering, we only get the 10 requested normal events
         # (limit=10), not spam events
@@ -500,15 +505,15 @@ async def test_websocket_get_event_log_recorder_missing_coverage(
     hass: HomeAssistant,
 ) -> None:
     """Test websocket_get_event_log when recorder is missing."""
-    connection = MagicMock()
+    MagicMock()
     msg = {"id": 1, "type": "growspace_manager/get_event_log"}
 
     with patch(
         "custom_components.growspace_manager.websocket.logbook.get_instance",
         side_effect=ImportError("No recorder"),
     ):
-        await websocket_get_event_log(hass, connection, msg)
-        connection.send_result.assert_called_once()
+        result = await websocket_get_event_log(hass, MagicMock(), msg)
+        assert result == {}
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_final_coverage_gaps.py
+++ b/tests/integration/test_final_coverage_gaps.py
@@ -32,10 +32,7 @@ from custom_components.growspace_manager.services.watering_service import (
 )
 from custom_components.growspace_manager.storage_manager import StorageManager
 from custom_components.growspace_manager.strain_library import StrainLibrary
-from custom_components.growspace_manager.websocket import (
-    websocket_get_ec_ramp_curves,
-    websocket_get_event_log,
-)
+from custom_components.growspace_manager.websocket import websocket_get_event_log
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
@@ -488,7 +485,7 @@ async def test_event_log_skips_event_with_different_plant_id(
     hass: HomeAssistant,
 ) -> None:
     """Test events with a different plant_id are skipped when filtering by plant_id."""
-    connection = MagicMock()
+    MagicMock()
     msg = {"id": 1, "plant_id": "plant_target", "limit": 10}
 
     session_mock = MagicMock()
@@ -532,11 +529,9 @@ async def test_event_log_skips_event_with_different_plant_id(
 
         instance.async_add_executor_job.side_effect = fake_executor
 
-        await websocket_get_event_log(hass, connection, msg)
+        result = await websocket_get_event_log(hass, MagicMock(), msg)
 
-    connection.send_result.assert_called_once()
     # The filtered event should produce an empty list for all growspaces
-    result = connection.send_result.call_args[0][1]
     all_events = [evt for evts in result.values() for evt in evts]
     assert all_events == []
 
@@ -546,7 +541,7 @@ async def test_event_log_skips_shared_event_with_different_growspace(
     hass: HomeAssistant,
 ) -> None:
     """Test shared events (no plant_id) from a different growspace are skipped."""
-    connection = MagicMock()
+    MagicMock()
     msg = {
         "id": 1,
         "plant_id": "plant_target",
@@ -594,41 +589,14 @@ async def test_event_log_skips_shared_event_with_different_growspace(
 
         instance.async_add_executor_job.side_effect = fake_executor
 
-        await websocket_get_event_log(hass, connection, msg)
+        result = await websocket_get_event_log(hass, MagicMock(), msg)
 
-    connection.send_result.assert_called_once()
-    result = connection.send_result.call_args[0][1]
     all_events = [evt for evts in result.values() for evt in evts]
     assert all_events == []
 
 
 # ---------------------------------------------------------------------------
 # websocket_get_ec_ramp_curves – exception path (lines 573-575)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_websocket_get_ec_ramp_curves_exception(
-    hass: HomeAssistant,
-) -> None:
-    """Test that exceptions in websocket_get_ec_ramp_curves are reported via send_error."""
-    connection = MagicMock()
-    msg = {"id": 42}
-
-    with patch(
-        "custom_components.growspace_manager.websocket.nutrients.GrowspaceCoordinator"
-    ) as mock_coord_cls:
-        mock_coord_cls.get_for_service_call.side_effect = Exception("DB error")
-
-        websocket_get_ec_ramp_curves(hass, connection, msg)
-
-    connection.send_error.assert_called_once_with(42, "unknown_error", "DB error")
-    connection.send_result.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# GrowspaceCoordinator.get_any / ServiceCoordinatorLocator.get_any success
-# (coordinator.py:147, service_coordinator_locator.py:99)
 # ---------------------------------------------------------------------------
 
 
@@ -660,7 +628,9 @@ def test_coordinator_get_plant_delegates_to_repository() -> None:
     entry.data = {}
     entry.options = {}
 
-    coordinator = GrowspaceCoordinator.build(hass, entry, data={}, strain_library=MagicMock())
+    coordinator = GrowspaceCoordinator.build(
+        hass, entry, data={}, strain_library=MagicMock()
+    )
     plant = MagicMock()
     coordinator._data_repository = MagicMock()
     coordinator._data_repository.get_plant.return_value = plant
@@ -679,7 +649,9 @@ def test_coordinator_get_growspace_delegates_to_repository() -> None:
     entry.data = {}
     entry.options = {}
 
-    coordinator = GrowspaceCoordinator.build(hass, entry, data={}, strain_library=MagicMock())
+    coordinator = GrowspaceCoordinator.build(
+        hass, entry, data={}, strain_library=MagicMock()
+    )
     growspace = MagicMock()
     coordinator._data_repository = MagicMock()
     coordinator._data_repository.get_growspace.return_value = growspace

--- a/tests/integration/test_history_datetime_strings.py
+++ b/tests/integration/test_history_datetime_strings.py
@@ -56,11 +56,9 @@ async def test_websocket_history_datetime_strings(hass: HomeAssistant):
             "significant_changes_only": True,
         }
 
-        await websocket_get_history_stats(hass, mock_connection, msg)
+        result = await websocket_get_history_stats(hass, MagicMock(), msg)
 
         # Verify success - should parse ISO strings and not crash
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
         assert "sensor.test" in result
         stats = result["sensor.test"]
         assert len(stats) >= 1

--- a/tests/integration/test_history_fix.py
+++ b/tests/integration/test_history_fix.py
@@ -49,7 +49,7 @@ async def test_websocket_history_handles_dicts(hass: HomeAssistant):
             "significant_changes_only": True,
         }
 
-        await websocket_get_history_stats(hass, mock_connection, msg)
+        result = await websocket_get_history_stats(hass, MagicMock(), msg)
 
         # If it fails with AttributeError, send_result wont be called (validation)
         # or it will raise uncaught exception depending on test harness.
@@ -63,7 +63,5 @@ async def test_websocket_history_handles_dicts(hass: HomeAssistant):
         # If the code uses try/except generic, it will catch it and send_error.
         # We want to verify it SUCCEEDS.
 
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
         assert "sensor.test" in result
         assert len(result["sensor.test"]) > 0

--- a/tests/integration/test_history_missing_key.py
+++ b/tests/integration/test_history_missing_key.py
@@ -49,9 +49,7 @@ async def test_websocket_history_missing_last_updated(hass: HomeAssistant) -> No
             "significant_changes_only": True,
         }
 
-        await websocket_get_history_stats(hass, mock_connection, msg)
+        result = await websocket_get_history_stats(hass, MagicMock(), msg)
 
         # Verify success - we should get a result even if keys were missing (fallback)
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
         assert "sensor.test" in result

--- a/tests/integration/test_history_stats.py
+++ b/tests/integration/test_history_stats.py
@@ -97,10 +97,7 @@ async def test_websocket_get_history_stats_binary_search(
                 "interval_minutes": 100,  # Should downsample to ~10 points
             }
 
-            await websocket_get_history_stats(mock_hass, mock_connection, msg)
-
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
+            result = await websocket_get_history_stats(mock_hass, MagicMock(), msg)
 
         assert "sensor.test" in result
         points = result["sensor.test"]
@@ -147,11 +144,9 @@ async def test_websocket_get_history_stats_statistics_api(
             "interval_minutes": 60,  # >= 60 triggers statistics API
         }
 
-        await websocket_get_history_stats(mock_hass, mock_connection, msg)
+        result = await websocket_get_history_stats(mock_hass, MagicMock(), msg)
 
         mock_stats.assert_called_once()
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
 
         assert "sensor.test" in result
         assert len(result["sensor.test"]) == 2
@@ -190,15 +185,13 @@ async def test_websocket_get_history_stats_statistics_daily_and_missing_and_exce
             "interval_minutes": 1440,  # >= 1440 triggers period = "day"
         }
 
-        await websocket_get_history_stats(mock_hass, mock_connection, msg)
+        result = await websocket_get_history_stats(mock_hass, MagicMock(), msg)
 
         mock_stats.assert_called_once()
         # Verify period="day" is passed
         args, kwargs = mock_stats.call_args
         assert args[4] == "day"
 
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
         assert "sensor.test" in result
         assert "sensor.missing" in result
         assert result["sensor.missing"] == []
@@ -211,7 +204,9 @@ async def test_websocket_get_history_stats_statistics_daily_and_missing_and_exce
         mock_stats.side_effect = Exception("Stats API failure")
         history_data = {"sensor.test": []}
         mock_recorder = MagicMock()
-        mock_recorder.async_add_executor_job = AsyncMock(side_effect=lambda f, *args: f(*args))
+        mock_recorder.async_add_executor_job = AsyncMock(
+            side_effect=lambda f, *args: f(*args)
+        )
 
         with (
             patch(
@@ -224,9 +219,7 @@ async def test_websocket_get_history_stats_statistics_daily_and_missing_and_exce
                 return_value=mock_recorder,
             ),
         ):
-            await websocket_get_history_stats(mock_hass, mock_connection, msg)
-            mock_connection.send_result.assert_called_once()
-            result = mock_connection.send_result.call_args[0][1]
+            result = await websocket_get_history_stats(mock_hass, MagicMock(), msg)
             assert "sensor.test" in result
             assert result["sensor.test"] == []
 
@@ -270,7 +263,9 @@ async def test_websocket_get_history_stats_binary_search_edge_cases(
 
     history_data = {"sensor.test": states}
     mock_recorder = MagicMock()
-    mock_recorder.async_add_executor_job = AsyncMock(side_effect=lambda f, *args: f(*args))
+    mock_recorder.async_add_executor_job = AsyncMock(
+        side_effect=lambda f, *args: f(*args)
+    )
 
     with (
         patch(
@@ -292,10 +287,8 @@ async def test_websocket_get_history_stats_binary_search_edge_cases(
             "interval_minutes": 50,
         }
 
-        await websocket_get_history_stats(mock_hass, mock_connection, msg)
+        result = await websocket_get_history_stats(mock_hass, MagicMock(), msg)
 
-    mock_connection.send_result.assert_called_once()
-    result = mock_connection.send_result.call_args[0][1]
     assert "sensor.test" in result
     points = result["sensor.test"]
     assert len(points) > 0
@@ -323,9 +316,7 @@ async def test_websocket_get_history_stats_binary_search_edge_cases(
             return_value=mock_recorder,
         ),
     ):
-        await websocket_get_history_stats(mock_hass, mock_connection, msg)
-        mock_connection.send_result.assert_called_once()
-        result = mock_connection.send_result.call_args[0][1]
+        result = await websocket_get_history_stats(mock_hass, MagicMock(), msg)
         assert result["sensor.test"] == []
 
 
@@ -372,13 +363,20 @@ async def test_websocket_get_history_stats_sparse_and_fan_data(
     sensor_state_obj.last_updated = start_time + timedelta(minutes=50)
 
     history_data = {
-        "fan.test_fan": [fan_state_dict, fan_state_obj, fan_state_dict_no_pct, sentinel_state],
+        "fan.test_fan": [
+            fan_state_dict,
+            fan_state_obj,
+            fan_state_dict_no_pct,
+            sentinel_state,
+        ],
         "sensor.test_sensor": [sensor_state_dict, sensor_state_obj],
         "sensor.empty_sensor": [],
     }
 
     mock_recorder = MagicMock()
-    mock_recorder.async_add_executor_job = AsyncMock(side_effect=lambda f, *args: f(*args))
+    mock_recorder.async_add_executor_job = AsyncMock(
+        side_effect=lambda f, *args: f(*args)
+    )
 
     with (
         patch(
@@ -400,7 +398,7 @@ async def test_websocket_get_history_stats_sparse_and_fan_data(
             "interval_minutes": 5,
         }
 
-        await websocket_get_history_stats(mock_hass, mock_connection, msg)
+        result = await websocket_get_history_stats(mock_hass, MagicMock(), msg)
 
         # Verify that get_significant_states was called twice (once for non-fan, once for fan)
         assert mock_get_states.call_count == 2
@@ -422,9 +420,6 @@ async def test_websocket_get_history_stats_sparse_and_fan_data(
         assert sensor_call is not None
         assert "fan.test_fan" in fan_call[0][3]
         assert "sensor.test_sensor" in sensor_call[0][3]
-
-    mock_connection.send_result.assert_called_once()
-    result = mock_connection.send_result.call_args[0][1]
 
     # Verify results
     assert "fan.test_fan" in result
@@ -468,12 +463,11 @@ async def test_websocket_get_history_stats_general_exception(
     }
 
     # Mock parse_datetime to raise a generic Exception
-    with patch(
-        "custom_components.growspace_manager.websocket.environment.dt_util.parse_datetime",
-        side_effect=RuntimeError("Unexpected parsing failure"),
+    with (
+        patch(
+            "custom_components.growspace_manager.websocket.environment.dt_util.parse_datetime",
+            side_effect=RuntimeError("Unexpected parsing failure"),
+        ),
+        pytest.raises(RuntimeError, match="Unexpected parsing failure"),
     ):
-        await websocket_get_history_stats(mock_hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once_with(
-        6, "unknown_error", "Unexpected parsing failure"
-    )
+        await websocket_get_history_stats(mock_hass, MagicMock(), msg)

--- a/tests/integration/test_init_coverage.py
+++ b/tests/integration/test_init_coverage.py
@@ -23,10 +23,7 @@ from custom_components.growspace_manager.websocket import (
     _downsample_entity_binary_search,
     websocket_add_timeline_note,
     websocket_get_event_log,
-    websocket_get_growspace_data,
     websocket_get_history_stats,
-    websocket_get_ipm_presets,
-    websocket_get_nutrient_presets,
     websocket_remove_timeline_event,
 )
 from homeassistant.core import HomeAssistant
@@ -36,30 +33,9 @@ from tests.common import MockConfigEntry
 # --- Websocket Tests ---
 
 
-async def test_websocket_commands_errors(hass: HomeAssistant) -> None:
-    """Test websocket command error handling."""
-    connection = MagicMock()
-    msg = {"id": 1, "type": "test"}
-
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        side_effect=Exception("Coord Fail"),
-    ):
-        websocket_get_nutrient_presets(hass, connection, msg)
-        connection.send_error.assert_called_with(1, "unknown_error", "Coord Fail")
-
-    connection.reset_mock()
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        side_effect=Exception("Coord Fail"),
-    ):
-        websocket_get_ipm_presets(hass, connection, msg)
-        connection.send_error.assert_called_with(1, "unknown_error", "Coord Fail")
-
-
 async def test_websocket_add_timeline_note(hass: HomeAssistant) -> None:
     """Test add timeline note websocket command."""
-    connection = MagicMock()
+    MagicMock()
     msg = {
         "id": 1,
         ATTR_PLANT_ID: "plant1",
@@ -74,24 +50,18 @@ async def test_websocket_add_timeline_note(hass: HomeAssistant) -> None:
     mock_strain_lib = MagicMock()
     hass.data[DOMAIN] = {"strain_library": mock_strain_lib}
 
-    with (
-        patch(
-            "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-            return_value=mock_coordinator,
-        ),
-    ):
-        await websocket_add_timeline_note(hass, connection, msg)
-        connection.send_result.assert_called_with(1)
+    await websocket_add_timeline_note(hass, mock_coordinator, msg)
+    mock_add_note.assert_awaited_once()
 
-        mock_add_note.side_effect = Exception("Boom")
-        msg["id"] = 3
-        await websocket_add_timeline_note(hass, connection, msg)
-        connection.send_error.assert_called_with(3, "unknown_error", "Boom")
+    mock_add_note.side_effect = Exception("Boom")
+    msg["id"] = 3
+    with pytest.raises(Exception, match="Boom"):
+        await websocket_add_timeline_note(hass, mock_coordinator, msg)
 
 
 async def test_websocket_remove_timeline_event(hass: HomeAssistant) -> None:
     """Test remove timeline event logic."""
-    connection = MagicMock()
+    MagicMock()
     msg = {"id": 1, "event_id": "evt1"}
 
     with patch(
@@ -114,8 +84,7 @@ async def test_websocket_remove_timeline_event(hass: HomeAssistant) -> None:
                 mock_session  # chaining
             )
 
-            await websocket_remove_timeline_event(hass, connection, msg)
-            connection.send_result.assert_called_with(1)
+            await websocket_remove_timeline_event(hass, MagicMock(), msg)
             mock_session.delete.assert_called_once()
 
 
@@ -165,35 +134,6 @@ async def test_async_reload_entry(hass: HomeAssistant) -> None:
 
 
 # --- Websocket Get Growspace Data Test ---
-
-
-async def test_websocket_get_growspace_data_errors(hass: HomeAssistant) -> None:
-    """Test websocket get growspace data errors."""
-
-    connection = MagicMock()
-    msg = {"id": 1, "growspace_id": "gs1"}
-
-    # 1. ServiceValidationError
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        side_effect=ServiceValidationError("Invalid"),
-    ):
-        await websocket_get_growspace_data(hass, connection, msg)
-        connection.send_error.assert_called_with(
-            1, "coordinator_not_ready", "Growspace Manager integration not loaded"
-        )
-
-    # 2. General Exception
-    connection.reset_mock()
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        side_effect=Exception("Boom"),
-    ):
-        await websocket_get_growspace_data(hass, connection, msg)
-        connection.send_error.assert_called_with(1, "internal_error", "Boom")
-
-
-# --- Pending Growspace Failure Test ---
 
 
 async def test_async_setup_entry_pending_growspace_failure(hass: HomeAssistant) -> None:
@@ -298,10 +238,10 @@ async def test_websocket_get_event_log_coverage(hass: HomeAssistant) -> None:
         # Query for event_type returns None
         mock_session.query.return_value.filter.return_value.first.return_value = None
 
-        await websocket_get_event_log(hass, connection, msg)
+        result = await websocket_get_event_log(hass, MagicMock(), msg)
 
         # Should return empty result for growspace
-        connection.send_result.assert_called_with(1, {"gs1": []})
+        assert result == {"gs1": []}
 
     # 2. Test Recorder Import/Key Error
     connection.reset_mock()
@@ -309,8 +249,8 @@ async def test_websocket_get_event_log_coverage(hass: HomeAssistant) -> None:
         "custom_components.growspace_manager.websocket.logbook.get_instance",
         side_effect=ImportError,
     ):
-        await websocket_get_event_log(hass, connection, msg)
-        connection.send_result.assert_called_with(1, {"gs1": []})
+        result = await websocket_get_event_log(hass, MagicMock(), msg)
+        assert result == {"gs1": []}
 
     # 3. Test General Exception
     connection.reset_mock()
@@ -318,8 +258,8 @@ async def test_websocket_get_event_log_coverage(hass: HomeAssistant) -> None:
         "custom_components.growspace_manager.websocket.logbook.get_instance",
         side_effect=ValueError("Boom"),
     ):
-        await websocket_get_event_log(hass, connection, msg)
-        connection.send_error.assert_called_with(1, "unknown_error", "Boom")
+        with pytest.raises(ValueError, match="Boom"):
+            await websocket_get_event_log(hass, MagicMock(), msg)
 
 
 async def test_websocket_history_stats_coverage(hass: HomeAssistant) -> None:
@@ -334,8 +274,8 @@ async def test_websocket_history_stats_coverage(hass: HomeAssistant) -> None:
         "type": "custom_components.growspace_manager/get_history_stats",
     }
 
-    await websocket_get_history_stats(hass, connection, msg_invalid)
-    connection.send_error.assert_called_with(1, "invalid_args", "Invalid start_time")
+    with pytest.raises(ServiceValidationError, match="Invalid start_time"):
+        await websocket_get_history_stats(hass, MagicMock(), msg_invalid)
 
     # Verify fallback when interval is small (handled by logic, but ensuring stats API skipped)
     msg_short = {
@@ -356,11 +296,11 @@ async def test_websocket_history_stats_coverage(hass: HomeAssistant) -> None:
         ) as mock_downsample,
     ):
         mock_downsample.return_value = {"sensor.test": []}
-        await websocket_get_history_stats(hass, connection, msg_short)
+        result = await websocket_get_history_stats(hass, MagicMock(), msg_short)
 
         mock_stats.assert_not_called()
         mock_downsample.assert_called_once()
-        connection.send_result.assert_called_with(2, {"sensor.test": []})
+        assert result == {"sensor.test": []}
 
     # Verify exception handling
     connection.reset_mock()
@@ -375,8 +315,8 @@ async def test_websocket_history_stats_coverage(hass: HomeAssistant) -> None:
         # Ensure we use a large interval so _get_statistics_data is called
         msg_long = msg_short.copy()
         msg_long["interval_minutes"] = 120
-        await websocket_get_history_stats(hass, connection, msg_long)
-        connection.send_error.assert_called_with(2, "unknown_error", "Boom")
+        with pytest.raises(ValueError, match="Boom"):
+            await websocket_get_history_stats(hass, MagicMock(), msg_long)
 
 
 def test_downsample_binary_search_logic() -> None:

--- a/tests/integration/test_init_simple_coverage.py
+++ b/tests/integration/test_init_simple_coverage.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp import web
+import pytest
 
 from custom_components.growspace_manager.const import ATTR_NOTES, DOMAIN
 from custom_components.growspace_manager.views import StrainLibraryImageView
@@ -78,58 +79,31 @@ async def test_strain_library_image_view_filesystem_errors(
 
 async def test_websocket_simple_getters_error_handling(hass: HomeAssistant) -> None:
     """Test error handling in simple websocket getters."""
-    connection = MagicMock()
     msg = {"id": 1}
 
-    # 1. websocket_get_strain_library
-    # Case A: Strain library not in hass.data
-    if DOMAIN in hass.data:
-        del hass.data[DOMAIN]
-
-    websocket_get_strain_library(hass, connection, msg)
-    connection.send_error.assert_called_with(
-        1, "not_loaded", "Growspace Manager strain library not loaded"
-    )
-
-    # Case B: Exception during get_all()
-    hass.data[DOMAIN] = {}
+    # 1. websocket_get_strain_library — exception during get_all() propagates
+    # (the lifecycle maps it to internal_error on the wire).
+    coordinator = MagicMock()
     strain_lib = MagicMock()
     strain_lib.get_all.side_effect = Exception("Boom")
-    hass.data[DOMAIN]["strain_library"] = strain_lib
+    coordinator.services.config.strain_library = strain_lib
+    with pytest.raises(Exception, match="Boom"):
+        websocket_get_strain_library(hass, coordinator, msg)
 
-    websocket_get_strain_library(hass, connection, msg)
-    # Check that send_error was called (ignoring arguments from previous call)
-    assert connection.send_error.call_count == 2
-
-    # 2. websocket_get_nutrient_presets
-    # Mock GrowspaceCoordinator.get_for_service_call to return our mock
+    # 2. websocket_get_nutrient_presets — serialization failures propagate
     coordinator = MagicMock()
-    coordinator._nutrient_manager = MagicMock()
-
-    # Make get_serialization_data raise exception
     coordinator.services.config.get_nutrient_serialization_data.side_effect = Exception(
         "Nutrient Fail"
     )
-
-    with patch(
-        "custom_components.growspace_manager.coordinator.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
-        websocket_get_nutrient_presets(hass, connection, msg)
-        assert connection.send_error.call_count == 3
+    with pytest.raises(Exception, match="Nutrient Fail"):
+        websocket_get_nutrient_presets(hass, coordinator, msg)
 
     # 3. websocket_get_ipm_presets
-    # Re-setup mock for second call
     coordinator.services.config.get_nutrient_serialization_data.side_effect = Exception(
         "IPM Fail"
     )
-
-    with patch(
-        "custom_components.growspace_manager.coordinator.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
-        websocket_get_ipm_presets(hass, connection, msg)
-        assert connection.send_error.call_count == 4
+    with pytest.raises(Exception, match="IPM Fail"):
+        websocket_get_ipm_presets(hass, coordinator, msg)
 
 
 # ========================================================================================
@@ -139,18 +113,20 @@ async def test_websocket_simple_getters_error_handling(hass: HomeAssistant) -> N
 
 async def test_websocket_timeline_operations_errors(hass: HomeAssistant) -> None:
     """Test error handling in timeline operations."""
-    connection = MagicMock()
+    MagicMock()
     # 1. websocket_remove_timeline_event
     msg_remove = {"id": 1, "plant_id": "p1", "event_id": 123}
 
     # This uses recorder directly.
     # Mock get_instance to raise or fail.
-    with patch(
-        "custom_components.growspace_manager.websocket.timeline.get_instance",
-        side_effect=Exception("Recorder Fail"),
+    with (
+        patch(
+            "custom_components.growspace_manager.websocket.timeline.get_instance",
+            side_effect=Exception("Recorder Fail"),
+        ),
+        pytest.raises(Exception, match="Recorder Fail"),
     ):
-        await websocket_remove_timeline_event(hass, connection, msg_remove)
-        connection.send_error.assert_called_with(1, "unknown_error", "Recorder Fail")
+        await websocket_remove_timeline_event(hass, MagicMock(), msg_remove)
 
     # 2. websocket_add_timeline_note
     msg_note = {
@@ -172,23 +148,19 @@ async def test_websocket_timeline_operations_errors(hass: HomeAssistant) -> None
     # IMPORTANT: We must patch get_for_service_call to return mock_coordinator
     # AND patch async_add_timeline_note in custom_components.growspace_manager because it's imported there
 
-    with patch(
-        "custom_components.growspace_manager.coordinator.GrowspaceCoordinator.get_for_service_call",
-        return_value=mock_coordinator,
-    ):
-        # Case A: ServiceValidationError
-        mock_coordinator.services.add_timeline_note = AsyncMock(
-            side_effect=ServiceValidationError("Invalid")
-        )
-        await websocket_add_timeline_note(hass, connection, msg_note)
-        connection.send_error.assert_called_with(2, "invalid_args", "Invalid")
+    # Case A: ServiceValidationError propagates for the lifecycle to map
+    mock_coordinator.services.add_timeline_note = AsyncMock(
+        side_effect=ServiceValidationError("Invalid")
+    )
+    with pytest.raises(ServiceValidationError, match="Invalid"):
+        await websocket_add_timeline_note(hass, mock_coordinator, msg_note)
 
-        # Case B: Generic Exception
-        mock_coordinator.services.add_timeline_note = AsyncMock(
-            side_effect=Exception("General")
-        )
-        await websocket_add_timeline_note(hass, connection, msg_note)
-        connection.send_error.assert_called_with(2, "unknown_error", "General")
+    # Case B: Generic Exception propagates
+    mock_coordinator.services.add_timeline_note = AsyncMock(
+        side_effect=Exception("General")
+    )
+    with pytest.raises(Exception, match="General"):
+        await websocket_add_timeline_note(hass, mock_coordinator, msg_note)
 
 
 # ========================================================================================
@@ -198,7 +170,7 @@ async def test_websocket_timeline_operations_errors(hass: HomeAssistant) -> None
 
 async def test_websocket_event_log_complex_logic(hass: HomeAssistant) -> None:
     """Test websocket_get_event_log complex filtering and limits."""
-    connection = MagicMock()
+    MagicMock()
     msg = {"id": 1, "growspace_id": "g1", "limit": 5}
 
     # Mock query chain
@@ -225,9 +197,19 @@ async def test_websocket_event_log_complex_logic(hass: HomeAssistant) -> None:
         return (e, d)
 
     row1 = mk_event(
-        1, 1000.0, json.dumps({"category": "irrigation", "growspace_id": "g1", "sensor_type": "moisture"})
+        1,
+        1000.0,
+        json.dumps(
+            {"category": "irrigation", "growspace_id": "g1", "sensor_type": "moisture"}
+        ),
     )
-    row2 = mk_event(2, 2000.0, json.dumps({"category": "alert", "growspace_id": "g1", "sensor_type": "moisture"}))
+    row2 = mk_event(
+        2,
+        2000.0,
+        json.dumps(
+            {"category": "alert", "growspace_id": "g1", "sensor_type": "moisture"}
+        ),
+    )
     row3 = mk_event(3, 3000.0, "{bad json")
     row4 = mk_event(
         4, 4000.0, json.dumps({"category": "alert", "growspace_id": "other"})
@@ -259,12 +241,7 @@ async def test_websocket_event_log_complex_logic(hass: HomeAssistant) -> None:
 
         instance.async_add_executor_job.side_effect = fake_executor
 
-        await websocket_get_event_log(hass, connection, msg)
-
-        # Verify result
-        connection.send_result.assert_called()
-        args = connection.send_result.call_args[0]
-        result_data = args[1]
+        result_data = await websocket_get_event_log(hass, MagicMock(), msg)
 
         assert "g1" in result_data
         events = result_data["g1"]

--- a/tests/integration/test_logbook_deduplication.py
+++ b/tests/integration/test_logbook_deduplication.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 @pytest.mark.asyncio
 async def test_websocket_event_log_merging(hass: HomeAssistant) -> None:
     """Test that consecutive identical alerts are merged."""
-    connection = MagicMock()
+    MagicMock()
     msg = {"id": 1, "limit": 10}
 
     # Setup mocks
@@ -89,11 +89,7 @@ async def test_websocket_event_log_merging(hass: HomeAssistant) -> None:
 
         instance.async_add_executor_job.side_effect = fake_executor
 
-        await websocket_get_event_log(hass, connection, msg)
-
-        # Verify result
-        connection.send_result.assert_called()
-        result_data = connection.send_result.call_args[0][1]
+        result_data = await websocket_get_event_log(hass, MagicMock(), msg)
 
         events = result_data["g1"]
         # Expected:

--- a/tests/integration/test_timeline_fix_spam.py
+++ b/tests/integration/test_timeline_fix_spam.py
@@ -4,6 +4,8 @@ import json
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from custom_components.growspace_manager.websocket import (
     WS_TYPE_GET_ALERTS,
     WS_TYPE_GET_LOG,
@@ -12,6 +14,16 @@ from custom_components.growspace_manager.websocket import (
 from homeassistant.core import HomeAssistant
 
 WebSocketGenerator = Any
+
+
+@pytest.fixture(autouse=True)
+def _any_coordinator_available():
+    """resolve="any" commands need a loaded coordinator under the lifecycle."""
+    with patch(
+        "custom_components.growspace_manager.websocket._common.GrowspaceCoordinator.get_any",
+        return_value=MagicMock(),
+    ):
+        yield
 
 
 async def test_websocket_get_log_filters_new_spam_categories(

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from custom_components.growspace_manager.const import DOMAIN
+from custom_components.growspace_manager.exceptions import CoordinatorNotReadyError
 from custom_components.growspace_manager.strain_library import StrainLibrary
 from custom_components.growspace_manager.websocket import (
     _EPOCH_SENTINEL,
@@ -36,6 +37,16 @@ from homeassistant.exceptions import ServiceValidationError
 from tests.common import MockConfigEntry
 
 WebSocketGenerator = Any
+
+
+@pytest.fixture(autouse=True)
+def _any_coordinator_available():
+    """resolve="any" commands need a loaded coordinator under the lifecycle."""
+    with patch(
+        "custom_components.growspace_manager.websocket._common.GrowspaceCoordinator.get_any",
+        return_value=MagicMock(),
+    ):
+        yield
 
 
 @pytest.fixture
@@ -91,14 +102,18 @@ async def test_websocket_get_strain_library(
     async_register_websocket_api(hass)
     client = await hass_ws_client(hass)
 
-    await client.send_json(
-        {
-            "id": 1,
-            "type": WS_TYPE_GET_STRAIN_LIBRARY,
-        }
-    )
+    with patch(
+        "custom_components.growspace_manager.websocket._common.GrowspaceCoordinator.get_any",
+        return_value=mock_coord,
+    ):
+        await client.send_json(
+            {
+                "id": 1,
+                "type": WS_TYPE_GET_STRAIN_LIBRARY,
+            }
+        )
 
-    response = await client.receive_json()
+        response = await client.receive_json()
     assert response["success"]
     assert len(response["result"]["strains"]) == 2
     assert "Strain A" in response["result"]["strain_list"]
@@ -108,23 +123,25 @@ async def test_websocket_get_strain_library_not_loaded(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test getting strain library when not loaded."""
-    # Ensure no config entries exist for DOMAIN
-    for entry in hass.config_entries.async_entries(DOMAIN):
-        await hass.config_entries.async_remove(entry.entry_id)
-
     async_register_websocket_api(hass)
     client = await hass_ws_client(hass)
 
-    await client.send_json(
-        {
-            "id": 1,
-            "type": WS_TYPE_GET_STRAIN_LIBRARY,
-        }
-    )
+    with patch(
+        "custom_components.growspace_manager.websocket._common.GrowspaceCoordinator.get_any",
+        side_effect=CoordinatorNotReadyError(
+            "No Growspace Manager instance is currently loaded."
+        ),
+    ):
+        await client.send_json(
+            {
+                "id": 1,
+                "type": WS_TYPE_GET_STRAIN_LIBRARY,
+            }
+        )
 
-    response = await client.receive_json()
+        response = await client.receive_json()
     assert not response["success"]
-    assert response["error"]["code"] == "not_loaded"
+    assert response["error"]["code"] == "coordinator_not_ready"
 
 
 async def test_websocket_get_growspace_data(
@@ -836,7 +853,7 @@ async def test_websocket_get_growspace_data_validation_error(
 
         response = await client.receive_json()
         assert not response["success"]
-        assert response["error"]["code"] == "coordinator_not_ready"
+        assert response["error"]["code"] == "validation_failed"
 
 
 async def test_websocket_get_vision_history_validation_error(
@@ -861,7 +878,7 @@ async def test_websocket_get_vision_history_validation_error(
 
         response = await client.receive_json()
         assert not response["success"]
-        assert response["error"]["code"] == "not_loaded"
+        assert response["error"]["code"] == "validation_failed"
 
 
 async def test_websocket_get_event_log_internals_no_type(
@@ -1250,7 +1267,7 @@ async def test_websocket_exceptions(
             await client.send_json(cmd)
             resp = await client.receive_json()
             assert not resp["success"]
-            assert resp["error"]["code"] == "unknown_error"
+            assert resp["error"]["code"] == "internal_error"
 
         # get_data uses typed error codes
         await client.send_json(
@@ -1276,7 +1293,7 @@ async def test_websocket_exceptions(
         await client.send_json({"id": 8, "type": WS_TYPE_GET_STRAIN_LIBRARY})
         resp = await client.receive_json()
         assert not resp["success"]
-        assert resp["error"]["code"] == "unknown_error"
+        assert resp["error"]["code"] == "internal_error"
 
     # History Stats exception
     with patch(
@@ -1294,7 +1311,7 @@ async def test_websocket_exceptions(
         )
         resp = await client.receive_json()
         assert not resp["success"]
-        assert resp["error"]["code"] == "unknown_error"
+        assert resp["error"]["code"] == "internal_error"
 
 
 async def test_websocket_history_stats_missing_start(
@@ -1316,7 +1333,7 @@ async def test_websocket_history_stats_missing_start(
     )
     resp = await client.receive_json()
     assert not resp["success"]
-    assert resp["error"]["code"] == "invalid_args"
+    assert resp["error"]["code"] == "validation_failed"
 
 
 async def test_websocket_statistics_edge_cases(

--- a/tests/integration/test_websocket_apply_steering_mode.py
+++ b/tests/integration/test_websocket_apply_steering_mode.py
@@ -1,6 +1,6 @@
 """Tests for the apply_steering_mode WebSocket command (ADR-0012)."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -28,15 +28,9 @@ async def test_apply_steering_mode_delegates_and_echoes_intent(
     coord.services.growspaces.apply_steering_mode = AsyncMock()
     msg = {"id": 1, "growspace_id": "tent1", "steering_mode": "generative"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-        return_value=coord,
-    ):
-        await websocket_apply_steering_mode(hass, mock_connection, msg)
+    result = await websocket_apply_steering_mode(hass, coord, msg)
 
     coord.services.growspaces.apply_steering_mode.assert_awaited_once_with(
         "tent1", SteeringMode.GENERATIVE
     )
-    mock_connection.send_error.assert_not_called()
-    result = mock_connection.send_result.call_args[0][1]
     assert result == {"growspace_id": "tent1", "declared_steering_mode": "generative"}

--- a/tests/integration/test_websocket_camera_coverage.py
+++ b/tests/integration/test_websocket_camera_coverage.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.growspace_manager.exceptions import GrowspaceNotFoundError
 from custom_components.growspace_manager.websocket import (
     websocket_capture_snapshot,
     websocket_get_snapshots,
@@ -37,7 +38,9 @@ def _make_growspace(camera_entities: list[str] | None = None) -> MagicMock:
     return gs
 
 
-def _make_coordinator(growspace: MagicMock | None = None, gs_id: str = "gs1") -> MagicMock:
+def _make_coordinator(
+    growspace: MagicMock | None = None, gs_id: str = "gs1"
+) -> MagicMock:
     """Create a mock coordinator with an optional growspace."""
     coord = MagicMock()
     coord.growspaces = {gs_id: growspace} if growspace else {}
@@ -49,22 +52,6 @@ def _make_coordinator(growspace: MagicMock | None = None, gs_id: str = "gs1") ->
 # =============================================================================
 
 
-async def test_capture_snapshot_coordinator_not_found(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    """Test capture_snapshot sends error when coordinator not found (lines 1002-1006)."""
-    msg = {"id": 1, "growspace_id": "gs1"}
-
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        side_effect=ServiceValidationError("Not loaded"),
-    ):
-        await websocket_capture_snapshot(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once_with(1, "not_loaded", "Not loaded")
-    mock_connection.send_result.assert_not_called()
-
-
 async def test_capture_snapshot_growspace_not_found(
     hass: HomeAssistant, mock_connection: MagicMock
 ) -> None:
@@ -72,15 +59,8 @@ async def test_capture_snapshot_growspace_not_found(
     msg = {"id": 1, "growspace_id": "nonexistent"}
     coord = _make_coordinator()  # no growspaces
 
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        return_value=coord,
-    ):
-        await websocket_capture_snapshot(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once_with(
-        1, "not_found", "Growspace 'nonexistent' not found"
-    )
+    with pytest.raises(GrowspaceNotFoundError, match="'nonexistent' not found"):
+        await websocket_capture_snapshot(hass, coord, msg)
 
 
 async def test_capture_snapshot_no_cameras(
@@ -91,15 +71,8 @@ async def test_capture_snapshot_no_cameras(
     gs = _make_growspace(camera_entities=[])  # no cameras
     coord = _make_coordinator(growspace=gs)
 
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        return_value=coord,
-    ):
-        await websocket_capture_snapshot(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once_with(
-        1, "no_cameras", "No cameras configured for growspace 'gs1'"
-    )
+    with pytest.raises(ServiceValidationError, match="No cameras configured"):
+        await websocket_capture_snapshot(hass, coord, msg)
 
 
 async def test_capture_snapshot_success(
@@ -111,20 +84,14 @@ async def test_capture_snapshot_success(
     coord = _make_coordinator(growspace=gs)
 
     with (
-        patch(
-            "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-            return_value=coord,
-        ),
         patch.object(hass.config, "path", return_value=str(tmp_path)),
         patch(
             "homeassistant.core.ServiceRegistry.async_call",
             new_callable=AsyncMock,
         ),
     ):
-        await websocket_capture_snapshot(hass, mock_connection, msg)
+        result = await websocket_capture_snapshot(hass, coord, msg)
 
-    mock_connection.send_result.assert_called_once()
-    result = mock_connection.send_result.call_args[0][1]
     assert result["growspace_id"] == "gs1"
     assert len(result["snapshots"]) == 1
     assert result["snapshots"][0].startswith("/local/growspace_manager/snapshots/gs1/")
@@ -147,20 +114,14 @@ async def test_capture_snapshot_camera_service_fails(
             raise Exception("Camera error")
 
     with (
-        patch(
-            "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-            return_value=coord,
-        ),
         patch.object(hass.config, "path", return_value=str(tmp_path)),
         patch(
             "homeassistant.core.ServiceRegistry.async_call",
             side_effect=_side_effect,
         ),
     ):
-        await websocket_capture_snapshot(hass, mock_connection, msg)
+        result = await websocket_capture_snapshot(hass, coord, msg)
 
-    mock_connection.send_result.assert_called_once()
-    result = mock_connection.send_result.call_args[0][1]
     # Only the successful camera contributes a path
     assert len(result["snapshots"]) == 1
     assert "camera_ok" in result["snapshots"][0]
@@ -175,19 +136,14 @@ async def test_capture_snapshot_multiple_cameras(
     coord = _make_coordinator(growspace=gs)
 
     with (
-        patch(
-            "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-            return_value=coord,
-        ),
         patch.object(hass.config, "path", return_value=str(tmp_path)),
         patch(
             "homeassistant.core.ServiceRegistry.async_call",
             new_callable=AsyncMock,
         ),
     ):
-        await websocket_capture_snapshot(hass, mock_connection, msg)
+        result = await websocket_capture_snapshot(hass, coord, msg)
 
-    result = mock_connection.send_result.call_args[0][1]
     assert len(result["snapshots"]) == 2
 
 
@@ -203,11 +159,9 @@ async def test_get_snapshots_directory_not_exists(
     msg = {"id": 1, "growspace_id": "gs_no_dir"}
 
     with patch.object(hass.config, "path", return_value=str(tmp_path)):
-        await websocket_get_snapshots(hass, mock_connection, msg)
+        result = await websocket_get_snapshots(hass, MagicMock(), msg)
 
-    mock_connection.send_result.assert_called_once_with(
-        1, {"snapshots": [], "total": 0}
-    )
+    assert result == {"snapshots": [], "total": 0}
 
 
 async def test_get_snapshots_with_files(
@@ -224,14 +178,15 @@ async def test_get_snapshots_with_files(
     (snap_dir / "20260112_120100_camera_cam.jpg").write_bytes(b"fake_jpg")
 
     with patch.object(hass.config, "path", return_value=str(tmp_path / "www")):
-        await websocket_get_snapshots(hass, mock_connection, msg)
+        result = await websocket_get_snapshots(hass, MagicMock(), msg)
 
-    mock_connection.send_result.assert_called_once()
-    result = mock_connection.send_result.call_args[0][1]
     assert result["growspace_id"] == gs_id
     assert result["total"] == 2
     assert len(result["snapshots"]) == 2
-    assert all(s["path"].startswith("/local/growspace_manager/snapshots/gs1/") for s in result["snapshots"])
+    assert all(
+        s["path"].startswith("/local/growspace_manager/snapshots/gs1/")
+        for s in result["snapshots"]
+    )
 
 
 async def test_get_snapshots_pagination(
@@ -247,9 +202,8 @@ async def test_get_snapshots_pagination(
         (snap_dir / f"2026011{i}_120000_cam.jpg").write_bytes(b"x")
 
     with patch.object(hass.config, "path", return_value=str(tmp_path / "www")):
-        await websocket_get_snapshots(hass, mock_connection, msg)
+        result = await websocket_get_snapshots(hass, MagicMock(), msg)
 
-    result = mock_connection.send_result.call_args[0][1]
     assert result["total"] == 3
     assert len(result["snapshots"]) == 1  # limited to 1
 
@@ -268,10 +222,6 @@ async def test_get_snapshots_exception(
     with (
         patch.object(hass.config, "path", return_value=str(tmp_path / "www")),
         patch("pathlib.Path.glob", side_effect=PermissionError("Access denied")),
+        pytest.raises(PermissionError, match="Access denied"),
     ):
-        await websocket_get_snapshots(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once()
-    error_args = mock_connection.send_error.call_args[0]
-    assert error_args[0] == 1
-    assert error_args[1] == "unknown_error"
+        await websocket_get_snapshots(hass, MagicMock(), msg)

--- a/tests/integration/test_websocket_coverage.py
+++ b/tests/integration/test_websocket_coverage.py
@@ -58,23 +58,24 @@ async def test_websocket_get_event_log_recorder_error(
         "custom_components.growspace_manager.websocket.logbook.get_instance",
         side_effect=ImportError("Recorder not found"),
     ):
-        await websocket_get_event_log(hass, mock_connection, mock_msg)
+        result = await websocket_get_event_log(hass, MagicMock(), mock_msg)
 
         # Sould return empty result, not error
-        mock_connection.send_result.assert_called_with(1, {"gs1": []})
+        assert result == {"gs1": []}
 
 
 async def test_websocket_get_event_log_generic_error(
     hass: HomeAssistant, mock_connection, mock_msg
 ) -> None:
     """Test get_event_log handles generic exceptions."""
-    with patch(
-        "custom_components.growspace_manager.websocket.logbook.get_instance",
-        side_effect=Exception("Boom"),
+    with (
+        patch(
+            "custom_components.growspace_manager.websocket.logbook.get_instance",
+            side_effect=Exception("Boom"),
+        ),
+        pytest.raises(Exception, match="Boom"),
     ):
-        await websocket_get_event_log(hass, mock_connection, mock_msg)
-
-        mock_connection.send_error.assert_called_with(1, "unknown_error", "Boom")
+        await websocket_get_event_log(hass, MagicMock(), mock_msg)
 
 
 async def test_websocket_get_alerts_no_event_type(
@@ -112,10 +113,10 @@ async def test_websocket_get_alerts_no_event_type(
 
         mock_recorder.async_add_executor_job.side_effect = run_job
 
-        await websocket_get_alerts(hass, mock_connection, mock_msg)
+        result = await websocket_get_alerts(hass, MagicMock(), mock_msg)
 
         # Should return empty dict/list structure
-        mock_connection.send_result.assert_called_with(1, {"gs1": []})
+        assert result == {"gs1": []}
 
 
 async def test_websocket_get_alerts_recorder_error(
@@ -126,20 +127,22 @@ async def test_websocket_get_alerts_recorder_error(
         "custom_components.growspace_manager.websocket.logbook.get_instance",
         side_effect=ImportError("Recorder fail"),
     ):
-        await websocket_get_alerts(hass, mock_connection, mock_msg)
-        mock_connection.send_result.assert_called_with(1, {"gs1": []})
+        result = await websocket_get_alerts(hass, MagicMock(), mock_msg)
+        assert result == {"gs1": []}
 
 
 async def test_websocket_get_alerts_generic_error(
     hass: HomeAssistant, mock_connection, mock_msg
 ) -> None:
     """Test get_alerts handles generic errors."""
-    with patch(
-        "custom_components.growspace_manager.websocket.logbook.get_instance",
-        side_effect=Exception("Boom Alerts"),
+    with (
+        patch(
+            "custom_components.growspace_manager.websocket.logbook.get_instance",
+            side_effect=Exception("Boom Alerts"),
+        ),
+        pytest.raises(Exception, match="Boom Alerts"),
     ):
-        await websocket_get_alerts(hass, mock_connection, mock_msg)
-        mock_connection.send_error.assert_called_with(1, "unknown_error", "Boom Alerts")
+        await websocket_get_alerts(hass, MagicMock(), mock_msg)
 
 
 async def test_websocket_nutrient_inventory_service_missing(
@@ -149,13 +152,9 @@ async def test_websocket_nutrient_inventory_service_missing(
     mock_coord = MagicMock()
     mock_coord.services.config.get_inventory.return_value = None
 
-    with patch(
-        "custom_components.growspace_manager.coordinator.GrowspaceCoordinator.get_any",
-        return_value=mock_coord,
-    ):
-        # get_nutrient_inventory returns empty stocks when inventory is absent
-        websocket_get_nutrient_inventory(hass, mock_connection, mock_msg)
-        mock_connection.send_result.assert_called_with(1, {"stocks": {}})
+    # get_nutrient_inventory returns empty stocks when inventory is absent
+    result = websocket_get_nutrient_inventory(hass, mock_coord, mock_msg)
+    assert result == {"stocks": {}}
 
 
 async def test_websocket_nutrient_inventory_success(
@@ -171,10 +170,7 @@ async def test_websocket_nutrient_inventory_success(
     mock_coord.config_entry = mock_config_entry
     mock_coord.async_commit = AsyncMock()
 
-    with patch(
-        "custom_components.growspace_manager.coordinator.GrowspaceCoordinator.get_any",
-        return_value=mock_coord,
-    ):
+    if True:
         # Update Stock Success
         msg_update = {
             "id": 1,
@@ -188,7 +184,7 @@ async def test_websocket_nutrient_inventory_success(
             "dose_ml_l": 0.0,
             "notes": "",
         }
-        websocket_update_nutrient_stock(hass, mock_connection, msg_update)
+        websocket_update_nutrient_stock(hass, mock_coord, msg_update)
         await asyncio.sleep(0)  # Yield to background tasks
 
         mock_coord.services.config.update_stock.assert_called_with(
@@ -202,7 +198,6 @@ async def test_websocket_nutrient_inventory_success(
             dose_ml_l=0.0,
             notes="",
         )
-        mock_connection.send_result.assert_called_with(1)
         mock_coord.async_commit.assert_awaited()
 
         # Reset
@@ -212,11 +207,10 @@ async def test_websocket_nutrient_inventory_success(
 
         # Remove Stock Success
         msg_remove = {"id": 2, "nutrient_id": "n1"}
-        websocket_remove_nutrient_stock(hass, mock_connection, msg_remove)
+        websocket_remove_nutrient_stock(hass, mock_coord, msg_remove)
         await asyncio.sleep(0)  # Yield to background tasks
 
         mock_coord.services.config.remove_stock.assert_called_with("n1")
-        mock_connection.send_result.assert_called_with(2)
         mock_coord.async_commit.assert_awaited()
 
 
@@ -240,11 +234,8 @@ async def test_websocket_add_timeline_note_validation_error(
         # We need mock strain library in hass.data
         hass.data[DOMAIN] = {"strain_library": MagicMock()}
 
-        await websocket_add_timeline_note(hass, mock_connection, msg)
-
-        mock_connection.send_error.assert_called_with(
-            1, "invalid_args", "Invalid Plant"
-        )
+        with pytest.raises(ServiceValidationError, match="Invalid Plant"):
+            await websocket_add_timeline_note(hass, mock_coord, msg)
 
 
 async def test_websocket_remove_timeline_event_error(
@@ -253,13 +244,14 @@ async def test_websocket_remove_timeline_event_error(
     """Test remove_timeline_event handles errors."""
     msg = {"id": 1, "event_id": 123}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.timeline.get_instance",
-        side_effect=Exception("DB Error"),
+    with (
+        patch(
+            "custom_components.growspace_manager.websocket.timeline.get_instance",
+            side_effect=Exception("DB Error"),
+        ),
+        pytest.raises(Exception, match="DB Error"),
     ):
-        await websocket_remove_timeline_event(hass, mock_connection, msg)
-
-        mock_connection.send_error.assert_called_with(1, "unknown_error", "DB Error")
+        await websocket_remove_timeline_event(hass, MagicMock(), msg)
 
 
 async def test_websocket_get_alerts_filtering(
@@ -292,20 +284,32 @@ async def test_websocket_get_alerts_filtering(
     row_valid_1 = (
         MagicMock(time_fired_ts=100),
         MagicMock(
-            shared_data=json.dumps({"growspace_id": "gs1", "category": "optimal", "sensor_type": "moisture"})
+            shared_data=json.dumps(
+                {
+                    "growspace_id": "gs1",
+                    "category": "optimal",
+                    "sensor_type": "moisture",
+                }
+            )
         ),
     )
 
     row_valid_2 = (
         MagicMock(time_fired_ts=101),
         MagicMock(
-            shared_data=json.dumps({"growspace_id": "gs1", "category": "stress", "sensor_type": "moisture"})
+            shared_data=json.dumps(
+                {"growspace_id": "gs1", "category": "stress", "sensor_type": "moisture"}
+            )
         ),
     )
 
     row_valid_3 = (
         MagicMock(time_fired_ts=102),
-        MagicMock(shared_data=json.dumps({"growspace_id": "gs1", "category": "mold", "sensor_type": "moisture"})),
+        MagicMock(
+            shared_data=json.dumps(
+                {"growspace_id": "gs1", "category": "mold", "sensor_type": "moisture"}
+            )
+        ),
     )
 
     mock_recorder = AsyncMock()
@@ -335,11 +339,10 @@ async def test_websocket_get_alerts_filtering(
         # Execute plain function immediately
         mock_recorder.async_add_executor_job.side_effect = lambda f, *a: f(*a)
 
-        await websocket_get_alerts(hass, mock_connection, mock_msg)
+        result = await websocket_get_alerts(hass, MagicMock(), mock_msg)
 
         # Verify result contains only the 2 valid alerts allowed by limit
-        args, _ = mock_connection.send_result.call_args
-        res = args[1]["gs1"]
+        res = result["gs1"]
         assert len(res) == 2
         assert res[0]["category"] == "optimal"
         assert res[1]["category"] == "stress"
@@ -367,8 +370,8 @@ async def test_websocket_get_alerts_invalid_json(
         ),
     ):
         mock_recorder.async_add_executor_job.side_effect = lambda f, *a: f(*a)
-        await websocket_get_alerts(hass, mock_connection, mock_msg)
-        mock_connection.send_result.assert_called_with(1, {"gs1": []})
+        result = await websocket_get_alerts(hass, MagicMock(), mock_msg)
+        assert result == {"gs1": []}
 
 
 async def test_websocket_get_alerts_no_growspace_id(
@@ -379,7 +382,11 @@ async def test_websocket_get_alerts_no_growspace_id(
 
     row_valid = (
         MagicMock(time_fired_ts=100),
-        MagicMock(shared_data=json.dumps({"growspace_id": "gs1", "category": "mold", "sensor_type": "moisture"})),
+        MagicMock(
+            shared_data=json.dumps(
+                {"growspace_id": "gs1", "category": "mold", "sensor_type": "moisture"}
+            )
+        ),
     )
 
     mock_recorder = AsyncMock()
@@ -398,10 +405,8 @@ async def test_websocket_get_alerts_no_growspace_id(
         ),
     ):
         mock_recorder.async_add_executor_job.side_effect = lambda f, *a: f(*a)
-        await websocket_get_alerts(hass, mock_connection, mock_msg)
+        res = await websocket_get_alerts(hass, MagicMock(), mock_msg)
 
-        args, _ = mock_connection.send_result.call_args
-        res = args[1]
         assert "gs1" in res
         assert len(res["gs1"]) == 1
 
@@ -418,12 +423,8 @@ async def test_websocket_get_nutrient_inventory_success_get(
     mock_coord = MagicMock()
     mock_coord.services.config.get_inventory.return_value = MockInventory(stocks={})
 
-    with patch(
-        "custom_components.growspace_manager.coordinator.GrowspaceCoordinator.get_any",
-        return_value=mock_coord,
-    ):
-        websocket_get_nutrient_inventory(hass, mock_connection, mock_msg)
-        mock_connection.send_result.assert_called()
+    result = websocket_get_nutrient_inventory(hass, mock_coord, mock_msg)
+    assert result == {"stocks": {}}
 
 
 async def test_websocket_get_history_stats_sub_hourly(
@@ -470,39 +471,6 @@ async def test_websocket_get_history_stats_empty(
         mock_fallback.assert_awaited()
 
 
-async def test_websocket_breeder_commands_strain_library_missing(
-    hass: HomeAssistant, mock_connection
-) -> None:
-    """Test breeder commands when strain library is not loaded."""
-    if DOMAIN in hass.data:
-        hass.data[DOMAIN].pop("strain_library", None)
-    else:
-        hass.data[DOMAIN] = {}
-
-    msg_update = {
-        "id": 12,
-        "type": f"{DOMAIN}/update_breeder",
-        "original_name": "O",
-        "new_name": "N",
-    }
-    await websocket_update_breeder(hass, mock_connection, msg_update)
-    mock_connection.send_error.assert_called_with(
-        12, "not_loaded", "Growspace Manager strain library not loaded"
-    )
-
-    mock_connection.reset_mock()
-
-    msg_delete = {
-        "id": 13,
-        "type": f"{DOMAIN}/delete_breeder",
-        "breeder_name": "B",
-    }
-    await websocket_delete_breeder(hass, mock_connection, msg_delete)
-    mock_connection.send_error.assert_called_with(
-        13, "not_loaded", "Growspace Manager strain library not loaded"
-    )
-
-
 async def test_websocket_breeder_commands_generic_error(
     hass: HomeAssistant, mock_connection
 ) -> None:
@@ -522,14 +490,8 @@ async def test_websocket_breeder_commands_generic_error(
         "original_name": "O",
         "new_name": "N",
     }
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        return_value=mock_coordinator,
-    ):
-        await websocket_update_breeder(hass, mock_connection, msg_update)
-    mock_connection.send_error.assert_called_with(
-        14, "unknown_error", "Breeder Update Fail"
-    )
+    with pytest.raises(Exception, match="Breeder Update Fail"):
+        await websocket_update_breeder(hass, mock_coordinator, msg_update)
 
     mock_connection.reset_mock()
 
@@ -538,14 +500,8 @@ async def test_websocket_breeder_commands_generic_error(
         "type": f"{DOMAIN}/delete_breeder",
         "breeder_name": "B",
     }
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        return_value=mock_coordinator,
-    ):
-        await websocket_delete_breeder(hass, mock_connection, msg_delete)
-    mock_connection.send_error.assert_called_with(
-        15, "unknown_error", "Breeder Delete Fail"
-    )
+    with pytest.raises(Exception, match="Breeder Delete Fail"):
+        await websocket_delete_breeder(hass, mock_coordinator, msg_delete)
 
 
 def test_websocket_get_genetics_data_success(
@@ -554,16 +510,13 @@ def test_websocket_get_genetics_data_success(
     """Test websocket_get_genetics_data sends result on success (websocket.py:596-603)."""
     hass = MagicMock()
     coordinator = MagicMock()
-    coordinator.services.genetics.get_serialization_data.return_value = {"seed_batches": {}}
+    coordinator.services.genetics.get_serialization_data.return_value = {
+        "seed_batches": {}
+    }
 
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
-        websocket_get_genetics_data(hass, mock_connection, mock_msg)
+    result = websocket_get_genetics_data(hass, coordinator, mock_msg)
 
-    mock_connection.send_result.assert_called_once_with(1, {"seed_batches": {}})
-    mock_connection.send_error.assert_not_called()
+    assert result == {"seed_batches": {}}
 
 
 def test_websocket_get_genetics_data_error(
@@ -572,16 +525,12 @@ def test_websocket_get_genetics_data_error(
     """Test websocket_get_genetics_data sends error on exception (websocket.py:604-606)."""
     hass = MagicMock()
 
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        side_effect=Exception("Something went wrong"),
-    ):
-        websocket_get_genetics_data(hass, mock_connection, mock_msg)
-
-    mock_connection.send_error.assert_called_once_with(
-        1, "unknown_error", "Something went wrong"
+    coordinator = MagicMock()
+    coordinator.services.genetics.get_serialization_data.side_effect = Exception(
+        "Something went wrong"
     )
-    mock_connection.send_result.assert_not_called()
+    with pytest.raises(Exception, match="Something went wrong"):
+        websocket_get_genetics_data(hass, coordinator, mock_msg)
 
 
 @pytest.mark.asyncio
@@ -601,36 +550,23 @@ async def test_websocket_get_strain_lineage_tree_success(mock_hass: MagicMock) -
     mock_coordinator._strain_library = strain_library
     mock_coordinator.services.config.strain_library = strain_library
     mock_coordinator.services.config.strain_library = strain_library
-    connection = MagicMock()
+    MagicMock()
 
-    msg = {"id": 1, "type": f"{DOMAIN}/get_strain_lineage_tree", "strain_name": "Gelato #41"}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        return_value=mock_coordinator,
-    ):
-        await websocket_get_strain_lineage_tree(mock_hass, connection, msg)
+    msg = {
+        "id": 1,
+        "type": f"{DOMAIN}/get_strain_lineage_tree",
+        "strain_name": "Gelato #41",
+    }
+    result = await websocket_get_strain_lineage_tree(mock_hass, mock_coordinator, msg)
 
-    connection.send_result.assert_called_once_with(
-        1, {"name": "Gelato #41", "source": "library", "parents": []}
-    )
+    assert result == {"name": "Gelato #41", "source": "library", "parents": []}
 
 
 @pytest.mark.asyncio
-async def test_websocket_get_strain_lineage_tree_not_loaded(mock_hass: MagicMock) -> None:
-    """Test get_strain_lineage_tree when strain library not loaded."""
-    from custom_components.growspace_manager.websocket import (
-        websocket_get_strain_lineage_tree,
-    )
-
-    mock_hass.data = {}
-    connection = MagicMock()
-    msg = {"id": 1, "type": f"{DOMAIN}/get_strain_lineage_tree", "strain_name": "X"}
-    await websocket_get_strain_lineage_tree(mock_hass, connection, msg)
-    connection.send_error.assert_called_once()
-
-
 @pytest.mark.asyncio
-async def test_websocket_update_strain_lineage_tree_success(mock_hass: MagicMock) -> None:
+async def test_websocket_update_strain_lineage_tree_success(
+    mock_hass: MagicMock,
+) -> None:
     """Test update_strain_lineage_tree saves and returns flat lineage."""
     from custom_components.growspace_manager.websocket import (
         websocket_update_strain_lineage_tree,
@@ -642,7 +578,7 @@ async def test_websocket_update_strain_lineage_tree_success(mock_hass: MagicMock
     mock_coordinator._strain_library = strain_library
     mock_coordinator.services.config.strain_library = strain_library
     mock_coordinator.services.config.strain_library = strain_library
-    connection = MagicMock()
+    MagicMock()
 
     parents = [
         {"name": "OG Kush", "source": "library"},
@@ -654,32 +590,7 @@ async def test_websocket_update_strain_lineage_tree_success(mock_hass: MagicMock
         "strain_name": "Hybrid",
         "parents": parents,
     }
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        return_value=mock_coordinator,
-    ):
-        await websocket_update_strain_lineage_tree(mock_hass, connection, msg)
-    connection.send_result.assert_called_once_with(
-        2, {"lineage": "OG Kush × Durban Poison"}
+    result = await websocket_update_strain_lineage_tree(
+        mock_hass, mock_coordinator, msg
     )
-
-
-@pytest.mark.asyncio
-async def test_websocket_update_strain_lineage_tree_not_loaded(
-    mock_hass: MagicMock,
-) -> None:
-    """Test update_strain_lineage_tree when strain library not loaded."""
-    from custom_components.growspace_manager.websocket import (
-        websocket_update_strain_lineage_tree,
-    )
-
-    mock_hass.data = {}
-    connection = MagicMock()
-    msg = {
-        "id": 3,
-        "type": f"{DOMAIN}/update_strain_lineage_tree",
-        "strain_name": "X",
-        "parents": [],
-    }
-    await websocket_update_strain_lineage_tree(mock_hass, connection, msg)
-    connection.send_error.assert_called_once()
+    assert result == {"lineage": "OG Kush × Durban Poison"}

--- a/tests/integration/test_websocket_crop_steering_history.py
+++ b/tests/integration/test_websocket_crop_steering_history.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.growspace_manager.exceptions import GrowspaceNotFoundError
 from custom_components.growspace_manager.websocket.irrigation import (
     websocket_get_crop_steering_history,
 )
@@ -40,22 +41,14 @@ async def test_returns_history_for_known_growspace(
         "pore_ec": [],
     }
 
-    with (
-        patch(
-            "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-            return_value=coord,
-        ),
-        patch(
-            "custom_components.growspace_manager.websocket.irrigation.CropSteeringHistoryAnalyzer"
-        ) as mock_analyzer_cls,
-    ):
+    with patch(
+        "custom_components.growspace_manager.websocket.irrigation.CropSteeringHistoryAnalyzer"
+    ) as mock_analyzer_cls:
         mock_analyzer = mock_analyzer_cls.return_value
         mock_analyzer.async_get_history = AsyncMock(return_value=analyzer_result)
 
-        await websocket_get_crop_steering_history(hass, mock_connection, msg)
+        result = await websocket_get_crop_steering_history(hass, coord, msg)
 
-    mock_connection.send_error.assert_not_called()
-    result = mock_connection.send_result.call_args[0][1]
     assert result == {"growspace_id": "tent1", **analyzer_result}
 
 
@@ -66,15 +59,8 @@ async def test_unknown_growspace_sends_error(
     coord = _make_coordinator(growspace_id=None)
     msg = {"id": 1, "growspace_id": "missing"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-        return_value=coord,
-    ):
-        await websocket_get_crop_steering_history(hass, mock_connection, msg)
-
-    mock_connection.send_result.assert_not_called()
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "not_found"
+    with pytest.raises(GrowspaceNotFoundError, match="missing"):
+        await websocket_get_crop_steering_history(hass, coord, msg)
 
 
 async def test_exception_sends_error(
@@ -84,20 +70,11 @@ async def test_exception_sends_error(
     coord = _make_coordinator()
     msg = {"id": 1, "growspace_id": "tent1"}
 
-    with (
-        patch(
-            "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-            return_value=coord,
-        ),
-        patch(
-            "custom_components.growspace_manager.websocket.irrigation.CropSteeringHistoryAnalyzer"
-        ) as mock_analyzer_cls,
-    ):
+    with patch(
+        "custom_components.growspace_manager.websocket.irrigation.CropSteeringHistoryAnalyzer"
+    ) as mock_analyzer_cls:
         mock_analyzer = mock_analyzer_cls.return_value
         mock_analyzer.async_get_history = AsyncMock(side_effect=RuntimeError("boom"))
 
-        await websocket_get_crop_steering_history(hass, mock_connection, msg)
-
-    mock_connection.send_result.assert_not_called()
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "unknown_error"
+        with pytest.raises(RuntimeError, match="boom"):
+            await websocket_get_crop_steering_history(hass, coord, msg)

--- a/tests/integration/test_websocket_missing_coverage.py
+++ b/tests/integration/test_websocket_missing_coverage.py
@@ -10,19 +10,12 @@ from custom_components.growspace_manager.websocket import (
     websocket_add_growspace_note,
     websocket_add_subarea,
     websocket_download_strain_image,
-    websocket_get_ec_ramp_curves,
     websocket_get_external_strain_details,
-    websocket_get_ipm_presets,
     websocket_get_lineage_tree,
-    websocket_get_nutrient_inventory,
-    websocket_get_nutrient_presets,
     websocket_get_strain_lineage_tree,
-    websocket_get_subareas,
     websocket_import_strain_lineage_tree,
     websocket_query_external_strain,
-    websocket_remove_nutrient_stock,
     websocket_remove_subarea,
-    websocket_update_nutrient_stock,
     websocket_update_strain_lineage_tree,
     websocket_update_subarea,
 )
@@ -44,112 +37,6 @@ def mock_connection() -> MagicMock:
 # ---------------------------------------------------------------------------
 
 
-def test_websocket_get_nutrient_inventory_not_loaded(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    """Cover ServiceValidationError branch in websocket_get_nutrient_inventory."""
-    msg = {"id": 1}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        side_effect=ServiceValidationError("not loaded"),
-    ):
-        websocket_get_nutrient_inventory(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        1, "not_loaded", "Growspace Manager integration not loaded"
-    )
-
-
-def test_websocket_update_nutrient_stock_not_loaded(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    """Cover ServiceValidationError branch in websocket_update_nutrient_stock."""
-    msg = {
-        "id": 2,
-        "nutrient_id": "n1",
-        "name": "N1",
-        "current_ml": 500,
-        "initial_ml": 1000,
-    }
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        side_effect=ServiceValidationError("not loaded"),
-    ):
-        websocket_update_nutrient_stock(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        2, "not_loaded", "Growspace Manager integration not loaded"
-    )
-
-
-def test_websocket_remove_nutrient_stock_not_loaded(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    """Cover ServiceValidationError branch in websocket_remove_nutrient_stock."""
-    msg = {"id": 3, "nutrient_id": "n1"}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        side_effect=ServiceValidationError("not loaded"),
-    ):
-        websocket_remove_nutrient_stock(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        3, "not_loaded", "Growspace Manager integration not loaded"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Nutrient/IPM/EC-ramp ServiceValidationError paths (lines 597, 619, 640)
-# ---------------------------------------------------------------------------
-
-
-def test_websocket_get_nutrient_presets_not_loaded(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    """Cover ServiceValidationError in websocket_get_nutrient_presets."""
-    msg = {"id": 4}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        side_effect=ServiceValidationError("not loaded"),
-    ):
-        websocket_get_nutrient_presets(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        4, "not_loaded", "Growspace Manager integration not loaded"
-    )
-
-
-def test_websocket_get_ipm_presets_not_loaded(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    """Cover ServiceValidationError in websocket_get_ipm_presets."""
-    msg = {"id": 5}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        side_effect=ServiceValidationError("not loaded"),
-    ):
-        websocket_get_ipm_presets(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        5, "not_loaded", "Growspace Manager integration not loaded"
-    )
-
-
-def test_websocket_get_ec_ramp_curves_not_loaded(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    """Cover ServiceValidationError in websocket_get_ec_ramp_curves."""
-    msg = {"id": 6}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        side_effect=ServiceValidationError("not loaded"),
-    ):
-        websocket_get_ec_ramp_curves(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        6, "not_loaded", "Growspace Manager integration not loaded"
-    )
-
-
-# ---------------------------------------------------------------------------
-# websocket_add_growspace_note generic Exception path (lines 715-719)
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_websocket_add_growspace_note_validation_error(
     hass: HomeAssistant, mock_connection: MagicMock
@@ -160,14 +47,9 @@ async def test_websocket_add_growspace_note_validation_error(
     coordinator.services.growspaces.add_growspace_note = AsyncMock(
         side_effect=ServiceValidationError("invalid growspace")
     )
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
-        await websocket_add_growspace_note(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        7, "invalid_args", "invalid growspace"
-    )
+    if True:
+        with pytest.raises(ServiceValidationError, match=r"invalid\ growspace"):
+            await websocket_add_growspace_note(hass, coordinator, msg)
 
 
 @pytest.mark.asyncio
@@ -180,12 +62,9 @@ async def test_websocket_add_growspace_note_generic_error(
     coordinator.services.growspaces.add_growspace_note = AsyncMock(
         side_effect=RuntimeError("boom")
     )
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
-        await websocket_add_growspace_note(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(8, "unknown_error", "boom")
+    if True:
+        with pytest.raises(Exception, match=r"boom"):
+            await websocket_add_growspace_note(hass, coordinator, msg)
 
 
 # ---------------------------------------------------------------------------
@@ -194,54 +73,18 @@ async def test_websocket_add_growspace_note_generic_error(
 
 
 @pytest.mark.asyncio
-async def test_websocket_get_subareas_validation_error(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    """Cover ServiceValidationError branch in websocket_get_subareas."""
-    msg = {"id": 8, "growspace_id": "gs1"}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        side_effect=ServiceValidationError("invalid"),
-    ):
-        await websocket_get_subareas(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "invalid_args"
-
-
-@pytest.mark.asyncio
 async def test_websocket_add_subarea_generic_error(
     hass: HomeAssistant, mock_connection: MagicMock
 ) -> None:
     """Cover generic Exception branch in websocket_add_subarea."""
     msg = {"id": 9, "growspace_id": "gs1", "name": "Sub1"}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call"
-    ) as mock_get:
+    if True:
+        mock_get = MagicMock()
         mock_get.return_value.services.growspaces.add_subarea = AsyncMock(
             side_effect=RuntimeError("fail")
         )
-        await websocket_add_subarea(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(9, "unknown_error", "fail")
-
-
-@pytest.mark.asyncio
-async def test_websocket_update_subarea_validation_error(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    """Cover ServiceValidationError branch in websocket_update_subarea."""
-    msg = {
-        "id": 10,
-        "growspace_id": "gs1",
-        "subarea_id": "sub1",
-        "environment_config": {},
-    }
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        side_effect=ServiceValidationError("not found"),
-    ):
-        await websocket_update_subarea(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "invalid_args"
+        with pytest.raises(Exception, match=r"fail"):
+            await websocket_add_subarea(hass, mock_get.return_value, msg)
 
 
 @pytest.mark.asyncio
@@ -255,29 +98,13 @@ async def test_websocket_update_subarea_generic_error(
         "subarea_id": "sub1",
         "environment_config": {},
     }
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call"
-    ) as mock_get:
+    if True:
+        mock_get = MagicMock()
         mock_get.return_value.services.growspaces.update_subarea = AsyncMock(
             side_effect=RuntimeError("oops")
         )
-        await websocket_update_subarea(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(11, "unknown_error", "oops")
-
-
-@pytest.mark.asyncio
-async def test_websocket_remove_subarea_validation_error(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    """Cover ServiceValidationError branch in websocket_remove_subarea."""
-    msg = {"id": 12, "growspace_id": "gs1", "subarea_id": "sub1"}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        side_effect=ServiceValidationError("not found"),
-    ):
-        await websocket_remove_subarea(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "invalid_args"
+        with pytest.raises(Exception, match=r"oops"):
+            await websocket_update_subarea(hass, mock_get.return_value, msg)
 
 
 @pytest.mark.asyncio
@@ -286,49 +113,18 @@ async def test_websocket_remove_subarea_generic_error(
 ) -> None:
     """Cover generic Exception branch in websocket_remove_subarea."""
     msg = {"id": 13, "growspace_id": "gs1", "subarea_id": "sub1"}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call"
-    ) as mock_get:
+    if True:
+        mock_get = MagicMock()
         mock_get.return_value.services.growspaces.remove_subarea = AsyncMock(
             side_effect=RuntimeError("fail")
         )
-        await websocket_remove_subarea(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(13, "unknown_error", "fail")
+        with pytest.raises(Exception, match=r"fail"):
+            await websocket_remove_subarea(hass, mock_get.return_value, msg)
 
 
 # ---------------------------------------------------------------------------
 # websocket_get_lineage_tree error paths (lines 1497-1502, 1521-1522)
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_websocket_get_lineage_tree_validation_error_on_coordinator(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    """Cover ServiceValidationError from get_for_service_call in websocket_get_lineage_tree."""
-    msg = {"id": 14, "plant_id": "p1"}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        side_effect=ServiceValidationError("not loaded"),
-    ):
-        await websocket_get_lineage_tree(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "invalid_args"
-
-
-@pytest.mark.asyncio
-async def test_websocket_get_lineage_tree_generic_error_on_coordinator(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    """Cover generic Exception from get_for_service_call in websocket_get_lineage_tree."""
-    msg = {"id": 15, "plant_id": "p1"}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        side_effect=RuntimeError("crash"),
-    ):
-        await websocket_get_lineage_tree(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once()
-    assert mock_connection.send_error.call_args[0][1] == "unknown_error"
 
 
 @pytest.mark.asyncio
@@ -342,14 +138,9 @@ async def test_websocket_get_lineage_tree_inner_exception(
     mock_coordinator.services.genetics.get_lineage_tree.side_effect = RuntimeError(
         "inner crash"
     )
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        return_value=mock_coordinator,
-    ):
-        await websocket_get_lineage_tree(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        16, "unknown_error", "inner crash"
-    )
+    if True:
+        with pytest.raises(Exception, match=r"inner\ crash"):
+            await websocket_get_lineage_tree(hass, mock_coordinator, msg)
 
 
 # ---------------------------------------------------------------------------
@@ -368,12 +159,9 @@ async def test_websocket_get_strain_lineage_tree_generic_error(
         "fail"
     )
     mock_coordinator.services.config.strain_library = mock_coordinator._strain_library
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        return_value=mock_coordinator,
-    ):
-        await websocket_get_strain_lineage_tree(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(17, "unknown_error", "fail")
+    if True:
+        with pytest.raises(Exception, match=r"fail"):
+            await websocket_get_strain_lineage_tree(hass, mock_coordinator, msg)
 
 
 @pytest.mark.asyncio
@@ -392,12 +180,9 @@ async def test_websocket_update_strain_lineage_tree_generic_error(
     mock_coordinator._strain_library.update_strain_lineage_tree.side_effect = (
         RuntimeError("fail")
     )
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        return_value=mock_coordinator,
-    ):
-        await websocket_update_strain_lineage_tree(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(18, "unknown_error", "fail")
+    if True:
+        with pytest.raises(Exception, match=r"fail"):
+            await websocket_update_strain_lineage_tree(hass, mock_coordinator, msg)
 
 
 # ---------------------------------------------------------------------------
@@ -415,26 +200,9 @@ async def test_websocket_import_strain_lineage_tree_success(
     mock_coordinator._strain_library = AsyncMock()
     mock_coordinator.services.config.strain_library = mock_coordinator._strain_library
     mock_coordinator._strain_library.async_import_seedfinder_lineage_tree = AsyncMock()
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        return_value=mock_coordinator,
-    ):
-        await websocket_import_strain_lineage_tree(hass, mock_connection, msg)
-    mock_connection.send_result.assert_called_once_with(19, {"ok": True})
-
-
-@pytest.mark.asyncio
-async def test_websocket_import_strain_lineage_tree_not_loaded(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    """Cover ServiceValidationError branch in websocket_import_strain_lineage_tree."""
-    msg = {"id": 20, "strain_name": "Gelato", "tree": {}}
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        side_effect=ServiceValidationError("not loaded"),
-    ):
-        await websocket_import_strain_lineage_tree(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(20, "not_loaded", "not loaded")
+    if True:
+        result = await websocket_import_strain_lineage_tree(hass, mock_coordinator, msg)
+    assert result == {"ok": True}
 
 
 @pytest.mark.asyncio
@@ -446,17 +214,12 @@ async def test_websocket_import_strain_lineage_tree_generic_error(
     mock_coordinator = MagicMock()
     mock_coordinator._strain_library = AsyncMock()
     mock_coordinator.services.config.strain_library = mock_coordinator._strain_library
-    mock_coordinator._strain_library.async_import_seedfinder_lineage_tree.side_effect = (
-        RuntimeError("import failed")
+    mock_coordinator._strain_library.async_import_seedfinder_lineage_tree.side_effect = RuntimeError(
+        "import failed"
     )
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        return_value=mock_coordinator,
-    ):
-        await websocket_import_strain_lineage_tree(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        21, "unknown_error", "import failed"
-    )
+    if True:
+        with pytest.raises(Exception, match=r"import\ failed"):
+            await websocket_import_strain_lineage_tree(hass, mock_coordinator, msg)
 
 
 # ---------------------------------------------------------------------------
@@ -476,14 +239,9 @@ async def test_websocket_query_external_strain_success(
     mock_coordinator.seedfinder_scraper.async_search_strains = AsyncMock(
         return_value=[{"name": "OG Kush", "breeder": "GoodBreeder"}]
     )
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        return_value=mock_coordinator,
-    ):
-        await websocket_query_external_strain(hass, mock_connection, msg)
-    mock_connection.send_result.assert_called_once_with(
-        22, [{"name": "OG Kush", "breeder": "GoodBreeder"}]
-    )
+    if True:
+        result = await websocket_query_external_strain(hass, mock_coordinator, msg)
+    assert result == [{"name": "OG Kush", "breeder": "GoodBreeder"}]
 
 
 @pytest.mark.asyncio
@@ -511,8 +269,8 @@ async def test_websocket_query_external_strain_blacklist_error(
         "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
         side_effect=side_effect_get_any,
     ):
-        await websocket_query_external_strain(hass, mock_connection, msg)
-    mock_connection.send_result.assert_called_once_with(23, [])
+        result = await websocket_query_external_strain(hass, mock_coordinator, msg)
+    assert result == []
 
 
 @pytest.mark.asyncio
@@ -527,14 +285,9 @@ async def test_websocket_query_external_strain_service_validation_error(
     mock_coordinator.seedfinder_scraper.async_search_strains = AsyncMock(
         side_effect=ServiceValidationError("unavailable")
     )
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        return_value=mock_coordinator,
-    ):
-        await websocket_query_external_strain(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        22, "seedfinder_unavailable", "unavailable"
-    )
+    if True:
+        with pytest.raises(ServiceValidationError, match=r"unavailable"):
+            await websocket_query_external_strain(hass, mock_coordinator, msg)
 
 
 # ---------------------------------------------------------------------------
@@ -553,12 +306,11 @@ async def test_websocket_get_external_strain_details_none(
     mock_coordinator.seedfinder_scraper.async_get_strain_details = AsyncMock(
         return_value=None
     )
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        return_value=mock_coordinator,
-    ):
-        await websocket_get_external_strain_details(hass, mock_connection, msg)
-    mock_connection.send_result.assert_called_once_with(24, None)
+    if True:
+        result = await websocket_get_external_strain_details(
+            hass, mock_coordinator, msg
+        )
+    assert result is None
 
 
 @pytest.mark.asyncio
@@ -592,13 +344,11 @@ async def test_websocket_get_external_strain_details_with_data(
     mock_coordinator.seedfinder_scraper.async_get_strain_details = AsyncMock(
         return_value=raw
     )
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        return_value=mock_coordinator,
-    ):
-        await websocket_get_external_strain_details(hass, mock_connection, msg)
+    if True:
+        result = await websocket_get_external_strain_details(
+            hass, mock_coordinator, msg
+        )
 
-    result = mock_connection.send_result.call_args[0][1]
     assert result["name"] == "Gelato #41"
     assert result["flowering_days"] == round((56 + 63) / 2)
     assert result["indica_percentage"] == 60
@@ -636,13 +386,11 @@ async def test_websocket_get_external_strain_details_single_flowering_time(
     mock_coordinator.seedfinder_scraper.async_get_strain_details = AsyncMock(
         return_value=raw
     )
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        return_value=mock_coordinator,
-    ):
-        await websocket_get_external_strain_details(hass, mock_connection, msg)
+    if True:
+        result = await websocket_get_external_strain_details(
+            hass, mock_coordinator, msg
+        )
 
-    result = mock_connection.send_result.call_args[0][1]
     assert result["flowering_days"] == 60
     assert result["parents"] is None
 
@@ -658,14 +406,9 @@ async def test_websocket_get_external_strain_details_service_validation_error(
     mock_coordinator.seedfinder_scraper.async_get_strain_details = AsyncMock(
         side_effect=ServiceValidationError("unavailable")
     )
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        return_value=mock_coordinator,
-    ):
-        await websocket_get_external_strain_details(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        25, "seedfinder_unavailable", "unavailable"
-    )
+    if True:
+        with pytest.raises(ServiceValidationError, match=r"unavailable"):
+            await websocket_get_external_strain_details(hass, mock_coordinator, msg)
 
 
 @pytest.mark.asyncio
@@ -699,13 +442,11 @@ async def test_websocket_get_external_strain_details_no_flowering_time_match(
     mock_coordinator.seedfinder_scraper.async_get_strain_details = AsyncMock(
         return_value=raw
     )
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_any",
-        return_value=mock_coordinator,
-    ):
-        await websocket_get_external_strain_details(hass, mock_connection, msg)
+    if True:
+        result = await websocket_get_external_strain_details(
+            hass, mock_coordinator, msg
+        )
 
-    result = mock_connection.send_result.call_args[0][1]
     assert result["flowering_days"] is None
 
 
@@ -761,7 +502,7 @@ async def test_websocket_download_strain_image_uses_content_type_header(
             return_value=mock_session,
         ),
     ):
-        await websocket_download_strain_image(hass, mock_connection, msg)
+        await websocket_download_strain_image(hass, mock_coordinator, msg)
 
     saved_base64: str = mock_image_manager.save_strain_image.call_args[0][2]
     assert saved_base64.startswith("data:image/png;base64,"), (

--- a/tests/integration/test_websocket_plant.py
+++ b/tests/integration/test_websocket_plant.py
@@ -1,12 +1,17 @@
 """Tests for websocket/plant.py handlers."""
+
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.growspace_manager.exceptions import GrowspaceError
+from custom_components.growspace_manager.exceptions import (
+    EntityNotFoundError,
+    GrowspaceError,
+)
 from custom_components.growspace_manager.websocket.plant import (
     websocket_add_plant,
     websocket_add_plants,
@@ -79,21 +84,10 @@ async def test_water_plant_success(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {"id": 1, "plant_id": "p1", "amount": 500.0}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_water_plant(hass, mock_connection, msg)
+    await websocket_water_plant(hass, mock_coordinator, msg)
     mock_coordinator.services.plants.water_plant.assert_awaited_once_with(
         plant_id="p1", amount=500.0, nutrients=None, preset_id=None
     )
-    mock_connection.send_result.assert_called_once_with(1)
-
-
-async def test_water_plant_validation_error(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    msg = {"id": 1, "plant_id": "p1", "amount": 500.0}
-    with patch(_GET_COORD, side_effect=ServiceValidationError("not loaded")):
-        await websocket_water_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(1, "validation_failed", "not loaded")
 
 
 async def test_water_plant_generic_error(
@@ -101,9 +95,8 @@ async def test_water_plant_generic_error(
 ) -> None:
     mock_coordinator.services.plants.water_plant.side_effect = RuntimeError("boom")
     msg = {"id": 1, "plant_id": "p1", "amount": 500.0}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_water_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(1, "unknown_error", "boom")
+    with pytest.raises(Exception, match=r"boom"):
+        await websocket_water_plant(hass, mock_coordinator, msg)
 
 
 # ---------------------------------------------------------------------------
@@ -116,33 +109,33 @@ async def test_add_plant_success(
 ) -> None:
     mock_coordinator.growspaces = {"tent1": MagicMock()}
     msg = {"id": 2, "growspace_id": "tent1", "row": 0, "col": 0, "strain": "OG Kush"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_add_plant(hass, mock_connection, msg)
+    await websocket_add_plant(hass, mock_coordinator, msg)
     mock_coordinator.services.plants.add_plant.assert_awaited_once()
-    mock_connection.send_result.assert_called_once_with(2)
 
 
 async def test_add_plant_growspace_not_found(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {"id": 3, "growspace_id": "missing", "row": 0, "col": 0, "strain": "OG Kush"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_add_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        3, "validation_failed", "Growspace 'missing' not found"
-    )
+    with pytest.raises(EntityNotFoundError, match=r"Growspace\ 'missing'\ not\ found"):
+        await websocket_add_plant(hass, mock_coordinator, msg)
 
 
 async def test_add_plant_mother_growspace_auto_sets_mother_start(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     mock_coordinator.growspaces = {"mother": MagicMock()}
-    msg = {"id": 4, "growspace_id": "mother", "row": 0, "col": 0, "strain": "Clone Queen"}
+    msg = {
+        "id": 4,
+        "growspace_id": "mother",
+        "row": 0,
+        "col": 0,
+        "strain": "Clone Queen",
+    }
     with (
-        patch(_GET_COORD, return_value=mock_coordinator),
         patch(f"{_PATCH}.dt_util.utcnow", return_value=_FIXED_NOW),
     ):
-        await websocket_add_plant(hass, mock_connection, msg)
+        await websocket_add_plant(hass, mock_coordinator, msg)
     call_kwargs = mock_coordinator.services.plants.add_plant.call_args[1]
     assert call_kwargs["mother_start"] == _FIXED_NOW
 
@@ -155,11 +148,14 @@ async def test_add_plant_seed_batch_passes_generation(
     mock_batch.generation = "F2"
     mock_coordinator.services.genetics.seed_batch_by_id.return_value = mock_batch
     msg = {
-        "id": 5, "growspace_id": "tent1", "row": 0, "col": 0,
-        "strain": "OG Kush", "seed_batch_id": "batch1",
+        "id": 5,
+        "growspace_id": "tent1",
+        "row": 0,
+        "col": 0,
+        "strain": "OG Kush",
+        "seed_batch_id": "batch1",
     }
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_add_plant(hass, mock_connection, msg)
+    await websocket_add_plant(hass, mock_coordinator, msg)
     call_kwargs = mock_coordinator.services.plants.add_plant.call_args[1]
     assert call_kwargs["generation"] == "F2"
     assert call_kwargs["seed_batch_id"] == "batch1"
@@ -171,9 +167,10 @@ async def test_add_plant_growspace_error_becomes_validation_error(
     mock_coordinator.growspaces = {"tent1": MagicMock()}
     mock_coordinator.services.plants.add_plant.side_effect = GrowspaceError("grid full")
     msg = {"id": 6, "growspace_id": "tent1", "row": 0, "col": 0, "strain": "OG Kush"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_add_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(6, "validation_failed", "grid full")
+    with pytest.raises(
+        (ServiceValidationError, GrowspaceError, ValueError), match=r"grid\ full"
+    ):
+        await websocket_add_plant(hass, mock_coordinator, msg)
 
 
 async def test_add_plant_generic_error(
@@ -182,9 +179,8 @@ async def test_add_plant_generic_error(
     mock_coordinator.growspaces = {"tent1": MagicMock()}
     mock_coordinator.services.plants.add_plant.side_effect = RuntimeError("crash")
     msg = {"id": 7, "growspace_id": "tent1", "row": 0, "col": 0, "strain": "OG Kush"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_add_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(7, "unknown_error", "crash")
+    with pytest.raises(Exception, match=r"crash"):
+        await websocket_add_plant(hass, mock_coordinator, msg)
 
 
 # ---------------------------------------------------------------------------
@@ -198,23 +194,21 @@ async def test_add_plants_success(
     mock_coordinator.growspaces = {"tent1": MagicMock()}
     # Initial check + 2 loop iterations
     mock_coordinator.validator.find_first_available_position.side_effect = [
-        (0, 0), (0, 0), (0, 1)
+        (0, 0),
+        (0, 0),
+        (0, 1),
     ]
     msg = {"id": 10, "growspace_id": "tent1", "strain": "OG Kush", "amount": 2}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_add_plants(hass, mock_connection, msg)
-    mock_connection.send_result.assert_called_once_with(10, {"plants_added": 2})
+    result = await websocket_add_plants(hass, mock_coordinator, msg)
+    assert result == {"plants_added": 2}
 
 
 async def test_add_plants_growspace_not_found(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {"id": 11, "growspace_id": "missing", "strain": "OG Kush", "amount": 3}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_add_plants(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        11, "validation_failed", "Growspace 'missing' not found"
-    )
+    with pytest.raises(EntityNotFoundError, match=r"Growspace\ 'missing'\ not\ found"):
+        await websocket_add_plants(hass, mock_coordinator, msg)
 
 
 async def test_add_plants_growspace_full_at_start(
@@ -223,11 +217,11 @@ async def test_add_plants_growspace_full_at_start(
     mock_coordinator.growspaces = {"tent1": MagicMock()}
     mock_coordinator.validator.find_first_available_position.return_value = (None, None)
     msg = {"id": 12, "growspace_id": "tent1", "strain": "OG Kush", "amount": 2}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_add_plants(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        12, "validation_failed", "Growspace 'tent1' is full"
-    )
+    with pytest.raises(
+        (ServiceValidationError, GrowspaceError, ValueError),
+        match=r"Growspace\ 'tent1'\ is\ full",
+    ):
+        await websocket_add_plants(hass, mock_coordinator, msg)
 
 
 async def test_add_plants_stops_when_growspace_fills_mid_batch(
@@ -236,12 +230,13 @@ async def test_add_plants_stops_when_growspace_fills_mid_batch(
     mock_coordinator.growspaces = {"tent1": MagicMock()}
     # Initial check passes; first loop slot exists; second loop finds it full
     mock_coordinator.validator.find_first_available_position.side_effect = [
-        (0, 0), (0, 0), (None, None)
+        (0, 0),
+        (0, 0),
+        (None, None),
     ]
     msg = {"id": 13, "growspace_id": "tent1", "strain": "OG Kush", "amount": 3}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_add_plants(hass, mock_connection, msg)
-    mock_connection.send_result.assert_called_once_with(13, {"plants_added": 1})
+    result = await websocket_add_plants(hass, mock_coordinator, msg)
+    assert result == {"plants_added": 1}
 
 
 async def test_add_plants_growspace_error_stops_batch_with_partial_count(
@@ -249,16 +244,17 @@ async def test_add_plants_growspace_error_stops_batch_with_partial_count(
 ) -> None:
     mock_coordinator.growspaces = {"tent1": MagicMock()}
     mock_coordinator.validator.find_first_available_position.side_effect = [
-        (0, 0), (0, 0), (0, 1)
+        (0, 0),
+        (0, 0),
+        (0, 1),
     ]
     mock_coordinator.services.plants.add_plant.side_effect = [
         None,  # plant 1 succeeds
         GrowspaceError("conflict"),  # plant 2 fails → break
     ]
     msg = {"id": 14, "growspace_id": "tent1", "strain": "OG Kush", "amount": 3}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_add_plants(hass, mock_connection, msg)
-    mock_connection.send_result.assert_called_once_with(14, {"plants_added": 1})
+    result = await websocket_add_plants(hass, mock_coordinator, msg)
+    assert result == {"plants_added": 1}
 
 
 async def test_add_plants_generic_error(
@@ -268,9 +264,8 @@ async def test_add_plants_generic_error(
     mock_coordinator.validator.find_first_available_position.return_value = (0, 0)
     mock_coordinator.services.plants.add_plant.side_effect = RuntimeError("crash")
     msg = {"id": 15, "growspace_id": "tent1", "strain": "OG Kush", "amount": 1}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_add_plants(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(15, "unknown_error", "crash")
+    with pytest.raises(Exception, match=r"crash"):
+        await websocket_add_plants(hass, mock_coordinator, msg)
 
 
 # ---------------------------------------------------------------------------
@@ -282,71 +277,80 @@ async def test_update_plant_success_with_regular_field(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {
-        "id": 20, "type": "growspace_manager/update_plant",
-        "plant_id": "p1", "strain": "New Strain",
+        "id": 20,
+        "type": "growspace_manager/update_plant",
+        "plant_id": "p1",
+        "strain": "New Strain",
     }
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_update_plant(hass, mock_connection, msg)
+    await websocket_update_plant(hass, mock_coordinator, msg)
     mock_coordinator.services.plants.update_plant.assert_awaited_once_with(
         "p1", strain="New Strain"
     )
-    mock_connection.send_result.assert_called_once_with(20)
 
 
 async def test_update_plant_none_non_date_field_is_silently_dropped(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {
-        "id": 21, "type": "growspace_manager/update_plant",
-        "plant_id": "p1", "strain": None,
+        "id": 21,
+        "type": "growspace_manager/update_plant",
+        "plant_id": "p1",
+        "strain": None,
     }
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_update_plant(hass, mock_connection, msg)
+    await websocket_update_plant(hass, mock_coordinator, msg)
     mock_coordinator.services.plants.update_plant.assert_not_awaited()
-    mock_connection.send_result.assert_called_once_with(21)
 
 
 async def test_update_plant_date_field_none_is_passed_through(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {
-        "id": 22, "type": "growspace_manager/update_plant",
-        "plant_id": "p1", "veg_start": None,
+        "id": 22,
+        "type": "growspace_manager/update_plant",
+        "plant_id": "p1",
+        "veg_start": None,
     }
     with (
-        patch(_GET_COORD, return_value=mock_coordinator),
         patch(f"{_PATCH}.parse_date_field", return_value=None),
     ):
-        await websocket_update_plant(hass, mock_connection, msg)
-    mock_coordinator.services.plants.update_plant.assert_awaited_once_with("p1", veg_start=None)
+        await websocket_update_plant(hass, mock_coordinator, msg)
+    mock_coordinator.services.plants.update_plant.assert_awaited_once_with(
+        "p1", veg_start=None
+    )
 
 
 async def test_update_plant_date_field_with_value_is_parsed(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {
-        "id": 23, "type": "growspace_manager/update_plant",
-        "plant_id": "p1", "veg_start": "2026-01-10",
+        "id": 23,
+        "type": "growspace_manager/update_plant",
+        "plant_id": "p1",
+        "veg_start": "2026-01-10",
     }
     with (
-        patch(_GET_COORD, return_value=mock_coordinator),
         patch(f"{_PATCH}.parse_date_field", return_value=_FIXED_DT),
     ):
-        await websocket_update_plant(hass, mock_connection, msg)
-    mock_coordinator.services.plants.update_plant.assert_awaited_once_with("p1", veg_start=_FIXED_DT)
+        await websocket_update_plant(hass, mock_coordinator, msg)
+    mock_coordinator.services.plants.update_plant.assert_awaited_once_with(
+        "p1", veg_start=_FIXED_DT
+    )
 
 
 async def test_update_plant_validation_error(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
-    mock_coordinator.validator.validate_plant_exists.side_effect = ServiceValidationError("not found")
+    mock_coordinator.validator.validate_plant_exists.side_effect = (
+        ServiceValidationError("not found")
+    )
     msg = {
-        "id": 24, "type": "growspace_manager/update_plant",
-        "plant_id": "p1", "strain": "X",
+        "id": 24,
+        "type": "growspace_manager/update_plant",
+        "plant_id": "p1",
+        "strain": "X",
     }
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_update_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(24, "validation_failed", "not found")
+    with pytest.raises(ServiceValidationError, match="not found"):
+        await websocket_update_plant(hass, mock_coordinator, msg)
 
 
 async def test_update_plant_generic_error(
@@ -354,12 +358,13 @@ async def test_update_plant_generic_error(
 ) -> None:
     mock_coordinator.services.plants.update_plant.side_effect = RuntimeError("crash")
     msg = {
-        "id": 25, "type": "growspace_manager/update_plant",
-        "plant_id": "p1", "strain": "X",
+        "id": 25,
+        "type": "growspace_manager/update_plant",
+        "plant_id": "p1",
+        "strain": "X",
     }
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_update_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(25, "unknown_error", "crash")
+    with pytest.raises(Exception, match=r"crash"):
+        await websocket_update_plant(hass, mock_coordinator, msg)
 
 
 # ---------------------------------------------------------------------------
@@ -372,8 +377,7 @@ async def test_harvest_plant_success_no_metrics(
 ) -> None:
     mock_coordinator.plants = {"p1": MagicMock()}
     msg = {"id": 30, "plant_id": "p1"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_harvest_plant(hass, mock_connection, msg)
+    await websocket_harvest_plant(hass, mock_coordinator, msg)
     mock_coordinator.services.plants.transition_plant.assert_awaited_once_with(
         plant_id="p1",
         target_growspace_id=None,
@@ -386,7 +390,6 @@ async def test_harvest_plant_success_no_metrics(
         cbd_percentage=None,
         terpene_profile=None,
     )
-    mock_connection.send_result.assert_called_once_with(30)
 
 
 async def test_harvest_plant_success_with_valid_transition_date(
@@ -395,10 +398,9 @@ async def test_harvest_plant_success_with_valid_transition_date(
     mock_coordinator.plants = {"p1": MagicMock()}
     msg = {"id": 31, "plant_id": "p1", "transition_date": "2026-01-10"}
     with (
-        patch(_GET_COORD, return_value=mock_coordinator),
         patch(f"{_PATCH}.parse_date_field", return_value=_FIXED_DT),
     ):
-        await websocket_harvest_plant(hass, mock_connection, msg)
+        await websocket_harvest_plant(hass, mock_coordinator, msg)
     call_kwargs = mock_coordinator.services.plants.transition_plant.call_args[1]
     assert call_kwargs["transition_date"] == _FIXED_DT.isoformat()
 
@@ -409,35 +411,33 @@ async def test_harvest_plant_invalid_transition_date_sends_error(
     mock_coordinator.plants = {"p1": MagicMock()}
     msg = {"id": 32, "plant_id": "p1", "transition_date": "not-a-date"}
     with (
-        patch(_GET_COORD, return_value=mock_coordinator),
         patch(f"{_PATCH}.parse_date_field", return_value=None),
     ):
-        await websocket_harvest_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        32, "validation_failed", "Invalid transition_date: not-a-date"
-    )
+        with pytest.raises(
+            (ServiceValidationError, GrowspaceError, ValueError),
+            match=r"Invalid\ transition_date:\ not\-a\-date",
+        ):
+            await websocket_harvest_plant(hass, mock_coordinator, msg)
 
 
 async def test_harvest_plant_not_found(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {"id": 33, "plant_id": "missing"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_harvest_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        33, "validation_failed", "Plant 'missing' not found"
-    )
+    with pytest.raises(EntityNotFoundError, match=r"Plant\ 'missing'\ not\ found"):
+        await websocket_harvest_plant(hass, mock_coordinator, msg)
 
 
 async def test_harvest_plant_generic_error(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     mock_coordinator.plants = {"p1": MagicMock()}
-    mock_coordinator.services.plants.transition_plant.side_effect = RuntimeError("crash")
+    mock_coordinator.services.plants.transition_plant.side_effect = RuntimeError(
+        "crash"
+    )
     msg = {"id": 34, "plant_id": "p1"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_harvest_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(34, "unknown_error", "crash")
+    with pytest.raises(Exception, match=r"crash"):
+        await websocket_harvest_plant(hass, mock_coordinator, msg)
 
 
 # ---------------------------------------------------------------------------
@@ -449,20 +449,20 @@ async def test_move_clone_success_with_transition_date(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {
-        "id": 40, "plant_id": "clone1", "target_growspace_id": "veg",
+        "id": 40,
+        "plant_id": "clone1",
+        "target_growspace_id": "veg",
         "transition_date": "2026-01-10",
     }
     with (
-        patch(_GET_COORD, return_value=mock_coordinator),
         patch(f"{_PATCH}.parse_date_field", return_value=_FIXED_DT),
     ):
-        await websocket_move_clone(hass, mock_connection, msg)
+        await websocket_move_clone(hass, mock_coordinator, msg)
     mock_coordinator.services.plants.promote_clone.assert_awaited_once_with(
         clone_id="clone1",
         target_growspace_id="veg",
         transition_date=_FIXED_DT,
     )
-    mock_connection.send_result.assert_called_once_with(40)
 
 
 async def test_move_clone_success_no_transition_date_uses_utcnow(
@@ -470,10 +470,9 @@ async def test_move_clone_success_no_transition_date_uses_utcnow(
 ) -> None:
     msg = {"id": 41, "plant_id": "clone1", "target_growspace_id": "veg"}
     with (
-        patch(_GET_COORD, return_value=mock_coordinator),
         patch(f"{_PATCH}.dt_util.utcnow", return_value=_FIXED_NOW),
     ):
-        await websocket_move_clone(hass, mock_connection, msg)
+        await websocket_move_clone(hass, mock_coordinator, msg)
     call_kwargs = mock_coordinator.services.plants.promote_clone.call_args[1]
     assert call_kwargs["transition_date"] == _FIXED_NOW
 
@@ -482,15 +481,16 @@ async def test_move_clone_unparseable_date_falls_back_to_utcnow(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {
-        "id": 42, "plant_id": "clone1", "target_growspace_id": "veg",
+        "id": 42,
+        "plant_id": "clone1",
+        "target_growspace_id": "veg",
         "transition_date": "bad-date",
     }
     with (
-        patch(_GET_COORD, return_value=mock_coordinator),
         patch(f"{_PATCH}.parse_date_field", return_value=None),
         patch(f"{_PATCH}.dt_util.utcnow", return_value=_FIXED_NOW),
     ):
-        await websocket_move_clone(hass, mock_connection, msg)
+        await websocket_move_clone(hass, mock_coordinator, msg)
     call_kwargs = mock_coordinator.services.plants.promote_clone.call_args[1]
     assert call_kwargs["transition_date"] == _FIXED_NOW
 
@@ -504,9 +504,10 @@ async def test_move_clone_domain_error_is_validation_failed(
 ) -> None:
     mock_coordinator.services.plants.promote_clone.side_effect = error
     msg = {"id": 43, "plant_id": "clone1", "target_growspace_id": "veg"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_move_clone(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(43, "validation_failed", "bad")
+    with pytest.raises(
+        (ServiceValidationError, GrowspaceError, ValueError), match=r"bad"
+    ):
+        await websocket_move_clone(hass, mock_coordinator, msg)
 
 
 async def test_move_clone_generic_error(
@@ -514,9 +515,8 @@ async def test_move_clone_generic_error(
 ) -> None:
     mock_coordinator.services.plants.promote_clone.side_effect = RuntimeError("crash")
     msg = {"id": 44, "plant_id": "clone1", "target_growspace_id": "veg"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_move_clone(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(44, "unknown_error", "crash")
+    with pytest.raises(Exception, match=r"crash"):
+        await websocket_move_clone(hass, mock_coordinator, msg)
 
 
 # ---------------------------------------------------------------------------
@@ -530,31 +530,30 @@ async def test_take_clone_success(
     mock_coordinator.plants = {"mother1": MagicMock()}
     msg = {"id": 50, "mother_plant_id": "mother1"}
     with (
-        patch(_GET_COORD, return_value=mock_coordinator),
         patch(f"{_PATCH}.dt_util.utcnow", return_value=_FIXED_NOW),
     ):
-        await websocket_take_clone(hass, mock_connection, msg)
+        await websocket_take_clone(hass, mock_coordinator, msg)
     mock_coordinator.services.plants.take_clones.assert_awaited_once_with(
         mother_plant_id="mother1",
         num_clones=1,
         target_growspace_id=None,
         transition_date=_FIXED_NOW,
     )
-    mock_connection.send_result.assert_called_once_with(50)
 
 
 async def test_take_clone_mother_not_found(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {"id": 51, "mother_plant_id": "missing"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_take_clone(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        51, "validation_failed", "Mother plant 'missing' not found"
-    )
+    with pytest.raises(
+        EntityNotFoundError, match=r"Mother\ plant\ 'missing'\ not\ found"
+    ):
+        await websocket_take_clone(hass, mock_coordinator, msg)
 
 
-@pytest.mark.parametrize("error", [GrowspaceError("clone limit"), ValueError("bad range")])
+@pytest.mark.parametrize(
+    "error", [GrowspaceError("clone limit"), ValueError("bad range")]
+)
 async def test_take_clone_domain_error_is_validation_failed(
     hass: HomeAssistant,
     mock_connection: MagicMock,
@@ -564,9 +563,8 @@ async def test_take_clone_domain_error_is_validation_failed(
     mock_coordinator.plants = {"mother1": MagicMock()}
     mock_coordinator.services.plants.take_clones.side_effect = error
     msg = {"id": 52, "mother_plant_id": "mother1"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_take_clone(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(52, "validation_failed", str(error))
+    with pytest.raises(type(error), match=re.escape(str(error))):
+        await websocket_take_clone(hass, mock_coordinator, msg)
 
 
 async def test_take_clone_generic_error(
@@ -575,9 +573,8 @@ async def test_take_clone_generic_error(
     mock_coordinator.plants = {"mother1": MagicMock()}
     mock_coordinator.services.plants.take_clones.side_effect = RuntimeError("crash")
     msg = {"id": 53, "mother_plant_id": "mother1"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_take_clone(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(53, "unknown_error", "crash")
+    with pytest.raises(Exception, match=r"crash"):
+        await websocket_take_clone(hass, mock_coordinator, msg)
 
 
 # ---------------------------------------------------------------------------
@@ -590,21 +587,16 @@ async def test_remove_plant_success(
 ) -> None:
     mock_coordinator.plants = {"p1": MagicMock()}
     msg = {"id": 60, "plant_id": "p1"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_remove_plant(hass, mock_connection, msg)
+    await websocket_remove_plant(hass, mock_coordinator, msg)
     mock_coordinator.services.plants.remove_plant.assert_awaited_once_with("p1")
-    mock_connection.send_result.assert_called_once_with(60)
 
 
 async def test_remove_plant_not_found(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {"id": 61, "plant_id": "missing"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_remove_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        61, "validation_failed", "Plant 'missing' not found"
-    )
+    with pytest.raises(EntityNotFoundError, match=r"Plant\ 'missing'\ not\ found"):
+        await websocket_remove_plant(hass, mock_coordinator, msg)
 
 
 async def test_remove_plant_generic_error(
@@ -613,9 +605,8 @@ async def test_remove_plant_generic_error(
     mock_coordinator.plants = {"p1": MagicMock()}
     mock_coordinator.services.plants.remove_plant.side_effect = RuntimeError("crash")
     msg = {"id": 62, "plant_id": "p1"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_remove_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(62, "unknown_error", "crash")
+    with pytest.raises(Exception, match=r"crash"):
+        await websocket_remove_plant(hass, mock_coordinator, msg)
 
 
 async def test_move_plant_delegates_to_transition_plant(
@@ -623,21 +614,16 @@ async def test_move_plant_delegates_to_transition_plant(
 ) -> None:
     mock_coordinator.plants = {"p1": MagicMock()}
     msg = {"id": 63, "plant_id": "p1", "target_growspace_id": "flower"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_move_plant(hass, mock_connection, msg)
+    await websocket_move_plant(hass, mock_coordinator, msg)
     mock_coordinator.services.plants.transition_plant.assert_awaited_once()
-    mock_connection.send_result.assert_called_once_with(63)
 
 
 async def test_move_plant_not_found(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {"id": 64, "plant_id": "missing", "target_growspace_id": "flower"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_move_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        64, "validation_failed", "Plant 'missing' not found"
-    )
+    with pytest.raises(EntityNotFoundError, match=r"Plant\ 'missing'\ not\ found"):
+        await websocket_move_plant(hass, mock_coordinator, msg)
 
 
 async def test_switch_plants_success(
@@ -645,10 +631,8 @@ async def test_switch_plants_success(
 ) -> None:
     mock_coordinator.plants = {"p1": MagicMock(), "p2": MagicMock()}
     msg = {"id": 65, "plant1_id": "p1", "plant2_id": "p2"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_switch_plants(hass, mock_connection, msg)
+    await websocket_switch_plants(hass, mock_coordinator, msg)
     mock_coordinator.services.plants.switch_plants.assert_awaited_once_with("p1", "p2")
-    mock_connection.send_result.assert_called_once_with(65)
 
 
 async def test_switch_plants_plant1_not_found(
@@ -656,11 +640,8 @@ async def test_switch_plants_plant1_not_found(
 ) -> None:
     mock_coordinator.plants = {"p2": MagicMock()}
     msg = {"id": 66, "plant1_id": "missing", "plant2_id": "p2"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_switch_plants(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        66, "validation_failed", "Plant 'missing' not found"
-    )
+    with pytest.raises(EntityNotFoundError, match=r"Plant\ 'missing'\ not\ found"):
+        await websocket_switch_plants(hass, mock_coordinator, msg)
 
 
 async def test_switch_plants_plant2_not_found(
@@ -668,11 +649,8 @@ async def test_switch_plants_plant2_not_found(
 ) -> None:
     mock_coordinator.plants = {"p1": MagicMock()}
     msg = {"id": 67, "plant1_id": "p1", "plant2_id": "missing"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_switch_plants(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        67, "validation_failed", "Plant 'missing' not found"
-    )
+    with pytest.raises(EntityNotFoundError, match=r"Plant\ 'missing'\ not\ found"):
+        await websocket_switch_plants(hass, mock_coordinator, msg)
 
 
 async def test_score_plant_success(
@@ -680,77 +658,68 @@ async def test_score_plant_success(
 ) -> None:
     mock_coordinator.plants = {"p1": MagicMock()}
     msg = {"id": 68, "plant_id": "p1", "vigor": 8, "keeper": True}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_score_plant(hass, mock_connection, msg)
+    await websocket_score_plant(hass, mock_coordinator, msg)
     mock_coordinator.services.plants.score_plant.assert_awaited_once()
-    mock_connection.send_result.assert_called_once_with(68)
 
 
 async def test_score_plant_not_found(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {"id": 69, "plant_id": "missing"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_score_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(
-        69, "validation_failed", "Plant 'missing' not found"
-    )
+    with pytest.raises(EntityNotFoundError, match=r"Plant\ 'missing'\ not\ found"):
+        await websocket_score_plant(hass, mock_coordinator, msg)
 
 
 async def test_log_drying_weight_success(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {"id": 70, "plant_id": "p1", "weight_grams": 85.5}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_log_drying_weight(hass, mock_connection, msg)
+    await websocket_log_drying_weight(hass, mock_coordinator, msg)
     mock_coordinator.services.plants.log_drying_weight.assert_awaited_once_with(
         plant_id="p1", weight_grams=85.5, date=None
     )
-    mock_connection.send_result.assert_called_once_with(70)
 
 
 async def test_log_drying_weight_generic_error(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
-    mock_coordinator.services.plants.log_drying_weight.side_effect = RuntimeError("crash")
+    mock_coordinator.services.plants.log_drying_weight.side_effect = RuntimeError(
+        "crash"
+    )
     msg = {"id": 71, "plant_id": "p1", "weight_grams": 85.5}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_log_drying_weight(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(71, "unknown_error", "crash")
+    with pytest.raises(Exception, match=r"crash"):
+        await websocket_log_drying_weight(hass, mock_coordinator, msg)
 
 
 async def test_log_moisture_reading_success(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {"id": 72, "plant_id": "p1", "moisture_percent": 11.5}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_log_moisture_reading(hass, mock_connection, msg)
+    await websocket_log_moisture_reading(hass, mock_coordinator, msg)
     mock_coordinator.services.plants.log_moisture_reading.assert_awaited_once_with(
         plant_id="p1", moisture_percent=11.5, date=None
     )
-    mock_connection.send_result.assert_called_once_with(72)
 
 
 async def test_log_moisture_reading_generic_error(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
-    mock_coordinator.services.plants.log_moisture_reading.side_effect = RuntimeError("crash")
+    mock_coordinator.services.plants.log_moisture_reading.side_effect = RuntimeError(
+        "crash"
+    )
     msg = {"id": 73, "plant_id": "p1", "moisture_percent": 11.5}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_log_moisture_reading(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(73, "unknown_error", "crash")
+    with pytest.raises(Exception, match=r"crash"):
+        await websocket_log_moisture_reading(hass, mock_coordinator, msg)
 
 
 async def test_set_visual_tag_success(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {"id": 74, "plant_id": "p1", "visual_tag": "red velcro"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_set_visual_tag(hass, mock_connection, msg)
+    await websocket_set_visual_tag(hass, mock_coordinator, msg)
     mock_coordinator.services.plants.set_visual_tag.assert_awaited_once_with(
         plant_id="p1", visual_tag="red velcro"
     )
-    mock_connection.send_result.assert_called_once_with(74)
 
 
 async def test_set_visual_tag_generic_error(
@@ -758,17 +727,15 @@ async def test_set_visual_tag_generic_error(
 ) -> None:
     mock_coordinator.services.plants.set_visual_tag.side_effect = RuntimeError("crash")
     msg = {"id": 75, "plant_id": "p1", "visual_tag": "red velcro"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_set_visual_tag(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(75, "unknown_error", "crash")
+    with pytest.raises(Exception, match=r"crash"):
+        await websocket_set_visual_tag(hass, mock_coordinator, msg)
 
 
 async def test_update_harvest_metrics_success(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     msg = {"id": 76, "plant_id": "p1", "dry_weight": 42.0}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_update_harvest_metrics(hass, mock_connection, msg)
+    await websocket_update_harvest_metrics(hass, mock_coordinator, msg)
     mock_coordinator.services.plants.update_harvest_metrics.assert_awaited_once_with(
         plant_id="p1",
         wet_weight=None,
@@ -778,17 +745,17 @@ async def test_update_harvest_metrics_success(
         cbd_percentage=None,
         terpene_profile=None,
     )
-    mock_connection.send_result.assert_called_once_with(76)
 
 
 async def test_update_harvest_metrics_generic_error(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
-    mock_coordinator.services.plants.update_harvest_metrics.side_effect = RuntimeError("crash")
+    mock_coordinator.services.plants.update_harvest_metrics.side_effect = RuntimeError(
+        "crash"
+    )
     msg = {"id": 77, "plant_id": "p1", "dry_weight": 42.0}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_update_harvest_metrics(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(77, "unknown_error", "crash")
+    with pytest.raises(Exception, match=r"crash"):
+        await websocket_update_harvest_metrics(hass, mock_coordinator, msg)
 
 
 async def test_add_plants_mother_growspace_auto_sets_mother_start(
@@ -796,14 +763,14 @@ async def test_add_plants_mother_growspace_auto_sets_mother_start(
 ) -> None:
     mock_coordinator.growspaces = {"mother": MagicMock()}
     mock_coordinator.validator.find_first_available_position.side_effect = [
-        (0, 0), (0, 0)
+        (0, 0),
+        (0, 0),
     ]
     msg = {"id": 16, "growspace_id": "mother", "strain": "Clone Queen", "amount": 1}
     with (
-        patch(_GET_COORD, return_value=mock_coordinator),
         patch(f"{_PATCH}.dt_util.utcnow", return_value=_FIXED_NOW),
     ):
-        await websocket_add_plants(hass, mock_connection, msg)
+        await websocket_add_plants(hass, mock_coordinator, msg)
     call_kwargs = mock_coordinator.services.plants.add_plant.call_args[1]
     assert call_kwargs["mother_start"] == _FIXED_NOW
 
@@ -812,35 +779,30 @@ async def test_move_plant_with_valid_transition_date(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     mock_coordinator.plants = {"p1": MagicMock()}
-    msg = {"id": 82, "plant_id": "p1", "target_growspace_id": "flower", "transition_date": "2026-01-10"}
+    msg = {
+        "id": 82,
+        "plant_id": "p1",
+        "target_growspace_id": "flower",
+        "transition_date": "2026-01-10",
+    }
     with (
-        patch(_GET_COORD, return_value=mock_coordinator),
         patch(f"{_PATCH}.parse_date_field", return_value=_FIXED_DT),
     ):
-        await websocket_move_plant(hass, mock_connection, msg)
+        await websocket_move_plant(hass, mock_coordinator, msg)
     call_kwargs = mock_coordinator.services.plants.transition_plant.call_args[1]
     assert call_kwargs["transition_date"] == _FIXED_DT.isoformat()
-    mock_connection.send_result.assert_called_once_with(82)
 
 
 async def test_move_plant_generic_error(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     mock_coordinator.plants = {"p1": MagicMock()}
-    mock_coordinator.services.plants.transition_plant.side_effect = RuntimeError("crash")
+    mock_coordinator.services.plants.transition_plant.side_effect = RuntimeError(
+        "crash"
+    )
     msg = {"id": 83, "plant_id": "p1", "target_growspace_id": "flower"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_move_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(83, "unknown_error", "crash")
-
-
-async def test_move_clone_service_validation_error(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    msg = {"id": 45, "plant_id": "clone1", "target_growspace_id": "veg"}
-    with patch(_GET_COORD, side_effect=ServiceValidationError("not loaded")):
-        await websocket_move_clone(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(45, "validation_failed", "not loaded")
+    with pytest.raises(Exception, match=r"crash"):
+        await websocket_move_plant(hass, mock_coordinator, msg)
 
 
 async def test_switch_plants_generic_error(
@@ -849,9 +811,8 @@ async def test_switch_plants_generic_error(
     mock_coordinator.plants = {"p1": MagicMock(), "p2": MagicMock()}
     mock_coordinator.services.plants.switch_plants.side_effect = RuntimeError("crash")
     msg = {"id": 84, "plant1_id": "p1", "plant2_id": "p2"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_switch_plants(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(84, "unknown_error", "crash")
+    with pytest.raises(Exception, match=r"crash"):
+        await websocket_switch_plants(hass, mock_coordinator, msg)
 
 
 async def test_score_plant_generic_error(
@@ -860,49 +821,60 @@ async def test_score_plant_generic_error(
     mock_coordinator.plants = {"p1": MagicMock()}
     mock_coordinator.services.plants.score_plant.side_effect = RuntimeError("crash")
     msg = {"id": 85, "plant_id": "p1"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_score_plant(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(85, "unknown_error", "crash")
+    with pytest.raises(Exception, match=r"crash"):
+        await websocket_score_plant(hass, mock_coordinator, msg)
 
 
 async def test_log_drying_weight_validation_error(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
-    mock_coordinator.services.plants.log_drying_weight.side_effect = ServiceValidationError("invalid")
+    mock_coordinator.services.plants.log_drying_weight.side_effect = (
+        ServiceValidationError("invalid")
+    )
     msg = {"id": 86, "plant_id": "p1", "weight_grams": 50.0}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_log_drying_weight(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(86, "validation_failed", "invalid")
+    with pytest.raises(
+        (ServiceValidationError, GrowspaceError, ValueError), match=r"invalid"
+    ):
+        await websocket_log_drying_weight(hass, mock_coordinator, msg)
 
 
 async def test_log_moisture_reading_validation_error(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
-    mock_coordinator.services.plants.log_moisture_reading.side_effect = ServiceValidationError("invalid")
+    mock_coordinator.services.plants.log_moisture_reading.side_effect = (
+        ServiceValidationError("invalid")
+    )
     msg = {"id": 87, "plant_id": "p1", "moisture_percent": 50.0}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_log_moisture_reading(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(87, "validation_failed", "invalid")
+    with pytest.raises(
+        (ServiceValidationError, GrowspaceError, ValueError), match=r"invalid"
+    ):
+        await websocket_log_moisture_reading(hass, mock_coordinator, msg)
 
 
 async def test_set_visual_tag_validation_error(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
-    mock_coordinator.services.plants.set_visual_tag.side_effect = ServiceValidationError("invalid")
+    mock_coordinator.services.plants.set_visual_tag.side_effect = (
+        ServiceValidationError("invalid")
+    )
     msg = {"id": 88, "plant_id": "p1", "visual_tag": "red"}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_set_visual_tag(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(88, "validation_failed", "invalid")
+    with pytest.raises(
+        (ServiceValidationError, GrowspaceError, ValueError), match=r"invalid"
+    ):
+        await websocket_set_visual_tag(hass, mock_coordinator, msg)
 
 
 async def test_update_harvest_metrics_validation_error(
     hass: HomeAssistant, mock_connection: MagicMock, mock_coordinator: MagicMock
 ) -> None:
-    mock_coordinator.services.plants.update_harvest_metrics.side_effect = ServiceValidationError("invalid")
+    mock_coordinator.services.plants.update_harvest_metrics.side_effect = (
+        ServiceValidationError("invalid")
+    )
     msg = {"id": 89, "plant_id": "p1", "dry_weight": 42.0}
-    with patch(_GET_COORD, return_value=mock_coordinator):
-        await websocket_update_harvest_metrics(hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(89, "validation_failed", "invalid")
+    with pytest.raises(
+        (ServiceValidationError, GrowspaceError, ValueError), match=r"invalid"
+    ):
+        await websocket_update_harvest_metrics(hass, mock_coordinator, msg)
 
 
 async def test_print_label_success(
@@ -916,7 +888,6 @@ async def test_print_label_success(
     mock_hass.services.async_call.assert_awaited_once_with(
         "growspace_manager", "print_label", {"plant_id": "p1"}, blocking=True
     )
-    mock_connection.send_result.assert_called_once_with(78)
 
 
 async def test_print_label_validation_error(
@@ -924,10 +895,12 @@ async def test_print_label_validation_error(
 ) -> None:
     mock_hass = MagicMock()
     mock_hass.services = MagicMock()
-    mock_hass.services.async_call = AsyncMock(side_effect=ServiceValidationError("no printer"))
+    mock_hass.services.async_call = AsyncMock(
+        side_effect=ServiceValidationError("no printer")
+    )
     msg = {"id": 79, "type": "growspace_manager/print_label", "plant_id": "p1"}
-    await websocket_print_label(mock_hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(79, "validation_failed", "no printer")
+    with pytest.raises(ServiceValidationError, match="no printer"):
+        await websocket_print_label(mock_hass, MagicMock(), msg)
 
 
 async def test_print_label_generic_error(
@@ -937,5 +910,5 @@ async def test_print_label_generic_error(
     mock_hass.services = MagicMock()
     mock_hass.services.async_call = AsyncMock(side_effect=RuntimeError("crash"))
     msg = {"id": 80, "type": "growspace_manager/print_label", "plant_id": "p1"}
-    await websocket_print_label(mock_hass, mock_connection, msg)
-    mock_connection.send_error.assert_called_once_with(80, "unknown_error", "crash")
+    with pytest.raises(RuntimeError, match="crash"):
+        await websocket_print_label(mock_hass, MagicMock(), msg)

--- a/tests/integration/test_websocket_tank_water_history.py
+++ b/tests/integration/test_websocket_tank_water_history.py
@@ -1,6 +1,6 @@
 """Tests for get_tank_water_history WebSocket command."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -19,7 +19,14 @@ def mock_connection() -> MagicMock:
 
 
 def _make_buckets(count: int, liters: float = 0.0) -> list[dict]:
-    return [{"bucket_start": f"2024-01-01T00:{i:02d}:00+00:00", "liters_consumed": liters, "liters_refilled": 0.0} for i in range(count)]
+    return [
+        {
+            "bucket_start": f"2024-01-01T00:{i:02d}:00+00:00",
+            "liters_consumed": liters,
+            "liters_refilled": 0.0,
+        }
+        for i in range(count)
+    ]
 
 
 def _make_coordinator(
@@ -36,7 +43,9 @@ def _make_coordinator(
     growspace = MagicMock()
     growspace.environment_config = env
     coord.growspaces = {growspace_id: growspace}
-    coord.services.growspaces.get_all_trackers_for_growspace.return_value = trackers or {}
+    coord.services.growspaces.get_all_trackers_for_growspace.return_value = (
+        trackers or {}
+    )
     return coord
 
 
@@ -50,13 +59,7 @@ async def test_24h_returns_96_buckets(
 
     msg = {"id": 1, "growspace_id": "tent1", "range": "24h"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-        return_value=coord,
-    ):
-        await websocket_get_tank_water_history(hass, mock_connection, msg)
-
-    result = mock_connection.send_result.call_args[0][1]
+    result = await websocket_get_tank_water_history(hass, coord, msg)
     assert result["growspace_id"] == "tent1"
     assert result["range"] == "24h"
     assert len(result["buckets"]) == 96
@@ -72,13 +75,7 @@ async def test_7d_returns_168_buckets(
 
     msg = {"id": 1, "growspace_id": "tent1", "range": "7d"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-        return_value=coord,
-    ):
-        await websocket_get_tank_water_history(hass, mock_connection, msg)
-
-    result = mock_connection.send_result.call_args[0][1]
+    result = await websocket_get_tank_water_history(hass, coord, msg)
     assert len(result["buckets"]) == 168
 
 
@@ -92,13 +89,7 @@ async def test_6h_returns_24_buckets(
 
     msg = {"id": 1, "growspace_id": "tent1", "range": "6h"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-        return_value=coord,
-    ):
-        await websocket_get_tank_water_history(hass, mock_connection, msg)
-
-    result = mock_connection.send_result.call_args[0][1]
+    result = await websocket_get_tank_water_history(hass, coord, msg)
     assert len(result["buckets"]) == 24
 
 
@@ -112,13 +103,7 @@ async def test_1h_returns_4_buckets(
 
     msg = {"id": 1, "growspace_id": "tent1", "range": "1h"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-        return_value=coord,
-    ):
-        await websocket_get_tank_water_history(hass, mock_connection, msg)
-
-    result = mock_connection.send_result.call_args[0][1]
+    result = await websocket_get_tank_water_history(hass, coord, msg)
     assert len(result["buckets"]) == 4
 
 
@@ -134,13 +119,7 @@ async def test_aggregates_liters_across_tanks(
 
     msg = {"id": 1, "growspace_id": "tent1", "range": "24h"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-        return_value=coord,
-    ):
-        await websocket_get_tank_water_history(hass, mock_connection, msg)
-
-    result = mock_connection.send_result.call_args[0][1]
+    result = await websocket_get_tank_water_history(hass, coord, msg)
     assert all(b["liters"] == pytest.approx(1.5) for b in result["buckets"])
 
 
@@ -152,13 +131,7 @@ async def test_returns_empty_buckets_when_flow_sensors_configured(
 
     msg = {"id": 1, "growspace_id": "tent1", "range": "24h"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-        return_value=coord,
-    ):
-        await websocket_get_tank_water_history(hass, mock_connection, msg)
-
-    result = mock_connection.send_result.call_args[0][1]
+    result = await websocket_get_tank_water_history(hass, coord, msg)
     assert result["buckets"] == []
 
 
@@ -170,13 +143,7 @@ async def test_returns_empty_buckets_when_drain_sensors_configured(
 
     msg = {"id": 1, "growspace_id": "tent1", "range": "24h"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-        return_value=coord,
-    ):
-        await websocket_get_tank_water_history(hass, mock_connection, msg)
-
-    result = mock_connection.send_result.call_args[0][1]
+    result = await websocket_get_tank_water_history(hass, coord, msg)
     assert result["buckets"] == []
 
 
@@ -190,13 +157,7 @@ async def test_all_zero_buckets_when_no_consumption(
 
     msg = {"id": 1, "growspace_id": "tent1", "range": "24h"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-        return_value=coord,
-    ):
-        await websocket_get_tank_water_history(hass, mock_connection, msg)
-
-    result = mock_connection.send_result.call_args[0][1]
+    result = await websocket_get_tank_water_history(hass, coord, msg)
     assert len(result["buckets"]) == 96
     assert all(b["liters"] == 0.0 for b in result["buckets"])
 
@@ -210,13 +171,7 @@ async def test_returns_empty_buckets_when_growspace_not_found(
 
     msg = {"id": 1, "growspace_id": "unknown", "range": "24h"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-        return_value=coord,
-    ):
-        await websocket_get_tank_water_history(hass, mock_connection, msg)
-
-    result = mock_connection.send_result.call_args[0][1]
+    result = await websocket_get_tank_water_history(hass, coord, msg)
     assert result["growspace_id"] == "unknown"
     assert result["range"] == "24h"
     assert result["buckets"] == []
@@ -230,28 +185,7 @@ async def test_returns_empty_buckets_when_no_qualifying_trackers(
 
     msg = {"id": 1, "growspace_id": "tent1", "range": "24h"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-        return_value=coord,
-    ):
-        await websocket_get_tank_water_history(hass, mock_connection, msg)
-
-    result = mock_connection.send_result.call_args[0][1]
+    result = await websocket_get_tank_water_history(hass, coord, msg)
     assert result["growspace_id"] == "tent1"
     assert result["range"] == "24h"
     assert result["buckets"] == []
-
-
-async def test_error_sends_error_response(
-    hass: HomeAssistant, mock_connection: MagicMock
-) -> None:
-    """Exceptions are caught and sent as error responses."""
-    msg = {"id": 1, "growspace_id": "tent1", "range": "24h"}
-
-    with patch(
-        "custom_components.growspace_manager.websocket.irrigation.GrowspaceCoordinator.get_for_service_call",
-        side_effect=Exception("boom"),
-    ):
-        await websocket_get_tank_water_history(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once_with(1, "unknown_error", "boom")

--- a/tests/integration/test_websocket_update_sensor_coordinates.py
+++ b/tests/integration/test_websocket_update_sensor_coordinates.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.growspace_manager.exceptions import GrowspaceNotFoundError
 from custom_components.growspace_manager.websocket import (
     _EPOCH_SENTINEL,
     WS_TYPE_GET_HISTORY_STATS,
@@ -54,10 +55,8 @@ async def test_websocket_get_history_stats_invalid_times(
         "start_time": "invalid",
         "interval_minutes": 60,
     }
-    await websocket_get_history_stats(hass, mock_connection, msg_bad_start)
-    mock_connection.send_error.assert_called_with(
-        1, "invalid_args", "Invalid start_time"
-    )
+    with pytest.raises(ServiceValidationError, match="Invalid start_time"):
+        await websocket_get_history_stats(hass, MagicMock(), msg_bad_start)
 
     # Line 617-618 coverage
     msg_bad_end = {
@@ -68,14 +67,14 @@ async def test_websocket_get_history_stats_invalid_times(
         "end_time": "invalid",
         "interval_minutes": 60,
     }
-    with patch(
-        "homeassistant.util.dt.parse_datetime",
-        side_effect=[datetime(2023, 1, 1, tzinfo=dt_util.UTC), None],
+    with (
+        patch(
+            "homeassistant.util.dt.parse_datetime",
+            side_effect=[datetime(2023, 1, 1, tzinfo=dt_util.UTC), None],
+        ),
+        pytest.raises(ServiceValidationError, match="Invalid end_time"),
     ):
-        await websocket_get_history_stats(hass, mock_connection, msg_bad_end)
-        mock_connection.send_error.assert_called_with(
-            2, "invalid_args", "Invalid end_time"
-        )
+        await websocket_get_history_stats(hass, MagicMock(), msg_bad_end)
 
 
 async def test_websocket_update_sensor_coordinates_success(
@@ -100,21 +99,16 @@ async def test_websocket_update_sensor_coordinates_success(
     mock_coord.async_commit = AsyncMock()
     mock_coord.async_request_refresh = AsyncMock()
 
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        return_value=mock_coord,
-    ):
-        await websocket_update_sensor_coordinates(hass, mock_connection, msg)
+    await websocket_update_sensor_coordinates(hass, mock_coord, msg)
 
-        assert mock_growspace.environment_config.sensor_coordinates["sensor.test"] == {
-            "x": 10,
-            "y": 20,
-            "z": 30,
-            "rotation": 90,
-        }
-        mock_coord.async_commit.assert_awaited()
-        mock_coord.async_request_refresh.assert_awaited()
-        mock_connection.send_result.assert_called_with(1)
+    assert mock_growspace.environment_config.sensor_coordinates["sensor.test"] == {
+        "x": 10,
+        "y": 20,
+        "z": 30,
+        "rotation": 90,
+    }
+    mock_coord.async_commit.assert_awaited()
+    mock_coord.async_request_refresh.assert_awaited()
 
 
 async def test_websocket_update_sensor_coordinates_no_rotation(
@@ -140,18 +134,13 @@ async def test_websocket_update_sensor_coordinates_no_rotation(
     mock_coord.async_commit = AsyncMock()
     mock_coord.async_request_refresh = AsyncMock()
 
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        return_value=mock_coord,
-    ):
-        await websocket_update_sensor_coordinates(hass, mock_connection, msg)
+    await websocket_update_sensor_coordinates(hass, mock_coord, msg)
 
-        assert mock_growspace.environment_config.sensor_coordinates["sensor.test"] == {
-            "x": 10,
-            "y": 20,
-            "z": 30,
-        }
-        mock_connection.send_result.assert_called_with(1)
+    assert mock_growspace.environment_config.sensor_coordinates["sensor.test"] == {
+        "x": 10,
+        "y": 20,
+        "z": 30,
+    }
 
 
 async def test_websocket_update_sensor_coordinates_errors(
@@ -169,44 +158,36 @@ async def test_websocket_update_sensor_coordinates_errors(
 
     mock_coord = MagicMock()
 
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        return_value=mock_coord,
-    ):
-        # 1. Growspace not found (Line 673-676)
-        mock_coord.growspaces = {}
-        await websocket_update_sensor_coordinates(hass, mock_connection, msg)
-        mock_connection.send_error.assert_called_with(
-            1, "not_found", "Growspace gs1 not found"
-        )
+    # 1. Growspace not found
+    mock_coord.growspaces = {}
+    with pytest.raises(GrowspaceNotFoundError, match="gs1 not found"):
+        await websocket_update_sensor_coordinates(hass, mock_coord, msg)
 
-        # 2. No environment config (Line 683-688)
-        mock_growspace = MagicMock()
-        mock_growspace.environment_config = None
-        mock_coord.growspaces = {"gs1": mock_growspace}
-        await websocket_update_sensor_coordinates(hass, mock_connection, msg)
-        mock_connection.send_error.assert_called_with(
-            1, "invalid_state", "Grow space has no environment configuration"
-        )
+    # 2. No environment config
+    mock_growspace = MagicMock()
+    mock_growspace.environment_config = None
+    mock_coord.growspaces = {"gs1": mock_growspace}
+    with pytest.raises(ServiceValidationError, match="no environment configuration"):
+        await websocket_update_sensor_coordinates(hass, mock_coord, msg)
 
-        # 3. ServiceValidationError (Line 711)
-        mock_growspace.environment_config = MagicMock()
-        with patch.object(
+    # 3. ServiceValidationError from commit propagates
+    mock_growspace.environment_config = MagicMock()
+    with (
+        patch.object(
             mock_coord,
             "async_commit",
             side_effect=ServiceValidationError("Validation Fail"),
-        ):
-            await websocket_update_sensor_coordinates(hass, mock_connection, msg)
-            mock_connection.send_error.assert_called_with(
-                1, "invalid_args", "Validation Fail"
-            )
+        ),
+        pytest.raises(ServiceValidationError, match="Validation Fail"),
+    ):
+        await websocket_update_sensor_coordinates(hass, mock_coord, msg)
 
-        # 4. Generic Exception (Line 713-714)
-        with patch.object(
-            mock_coord, "async_commit", side_effect=Exception("Unexpected")
-        ):
-            await websocket_update_sensor_coordinates(hass, mock_connection, msg)
-        mock_connection.send_error.assert_called_with(1, "unknown_error", "Unexpected")
+    # 4. Generic Exception propagates
+    with (
+        patch.object(mock_coord, "async_commit", side_effect=Exception("Unexpected")),
+        pytest.raises(Exception, match="Unexpected"),
+    ):
+        await websocket_update_sensor_coordinates(hass, mock_coord, msg)
 
 
 def test_merge_logbook_event_error() -> None:

--- a/tests/services/test_report.py
+++ b/tests/services/test_report.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 
+from custom_components.growspace_manager.exceptions import PlantNotFoundError
 from custom_components.growspace_manager.models import Growspace, Plant
 from custom_components.growspace_manager.services.report import (
     _aggregate_growspace_data,
@@ -17,7 +18,7 @@ from custom_components.growspace_manager.services.report import (
     handle_export_grow_report,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 
 @pytest.fixture
@@ -799,7 +800,7 @@ async def test_websocket_get_grow_report_plant(
     mock_coordinator._data_repository.get_plant.return_value = mock_plant
     mock_coordinator._data_repository.get_growspace.return_value = mock_growspace
 
-    mock_connection = MagicMock()
+    MagicMock()
 
     msg = {
         "id": 1,
@@ -819,12 +820,9 @@ async def test_websocket_get_grow_report_plant(
     ):
         mock_aggregate.return_value = {"plant_info": {"id": "test_plant"}}
 
-        await async_websocket_get_grow_report(hass, mock_connection, msg)
+        result = await async_websocket_get_grow_report(hass, mock_coordinator, msg)
 
-        mock_connection.send_result.assert_called_once()
-        call_args = mock_connection.send_result.call_args
-        assert call_args[0][0] == 1  # Message ID
-        assert call_args[0][1]["plant_info"]["id"] == "test_plant"
+        assert result["plant_info"]["id"] == "test_plant"
 
 
 @pytest.mark.asyncio
@@ -837,7 +835,7 @@ async def test_websocket_get_grow_report_growspace(
     mock_coordinator._data_repository.get_growspace.return_value = mock_growspace
     mock_coordinator.plants = {}
 
-    mock_connection = MagicMock()
+    MagicMock()
 
     msg = {
         "id": 1,
@@ -860,11 +858,9 @@ async def test_websocket_get_grow_report_growspace(
             "summary": {"plant_count": 0},
         }
 
-        await async_websocket_get_grow_report(hass, mock_connection, msg)
+        result = await async_websocket_get_grow_report(hass, mock_coordinator, msg)
 
-        mock_connection.send_result.assert_called_once()
-        call_args = mock_connection.send_result.call_args
-        assert call_args[0][0] == 1
+        assert result["plant_info"]["id"] == "test_growspace"
 
 
 @pytest.mark.asyncio
@@ -876,7 +872,7 @@ async def test_websocket_get_grow_report_plant_not_found(
     mock_coordinator = MagicMock()
     mock_coordinator._data_repository.get_plant.return_value = None
 
-    mock_connection = MagicMock()
+    MagicMock()
 
     msg = {
         "id": 1,
@@ -884,16 +880,8 @@ async def test_websocket_get_grow_report_plant_not_found(
         "config_entry_id": "test_entry",
     }
 
-    with patch(
-        "custom_components.growspace_manager.coordinator.GrowspaceCoordinator",
-    ) as mock_gs_class:
-        mock_gs_class.get_for_service_call.return_value = mock_coordinator
-        await async_websocket_get_grow_report(hass, mock_connection, msg)
-
-        mock_connection.send_error.assert_called_once()
-        call_args = mock_connection.send_error.call_args
-        assert call_args[0][0] == 1
-        assert "not_found" in call_args[0][1]
+    with pytest.raises(PlantNotFoundError, match="missing_plant"):
+        await async_websocket_get_grow_report(hass, mock_coordinator, msg)
 
 
 @pytest.mark.asyncio
@@ -903,23 +891,15 @@ async def test_websocket_get_grow_report_no_ids(
     """Test WebSocket report when neither plant_id nor growspace_id provided."""
 
     mock_coordinator = MagicMock()
-    mock_connection = MagicMock()
+    MagicMock()
 
     msg = {
         "id": 1,
         "config_entry_id": "test_entry",
     }
 
-    with patch(
-        "custom_components.growspace_manager.coordinator.GrowspaceCoordinator",
-    ) as mock_gs_class:
-        mock_gs_class.get_for_service_call.return_value = mock_coordinator
-        await async_websocket_get_grow_report(hass, mock_connection, msg)
-
-        mock_connection.send_error.assert_called_once()
-        call_args = mock_connection.send_error.call_args
-        assert call_args[0][0] == 1
-        assert "invalid_request" in call_args[0][1]
+    with pytest.raises(ServiceValidationError, match="No plant_id or growspace_id"):
+        await async_websocket_get_grow_report(hass, mock_coordinator, msg)
 
 
 @pytest.mark.asyncio
@@ -931,7 +911,7 @@ async def test_websocket_get_grow_report_exception(
     mock_coordinator = MagicMock()
     mock_coordinator._data_repository.get_plant.side_effect = ValueError("DB Error")
 
-    mock_connection = MagicMock()
+    MagicMock()
 
     msg = {
         "id": 1,
@@ -939,16 +919,8 @@ async def test_websocket_get_grow_report_exception(
         "config_entry_id": "test_entry",
     }
 
-    with patch(
-        "custom_components.growspace_manager.coordinator.GrowspaceCoordinator",
-    ) as mock_gs_class:
-        mock_gs_class.get_for_service_call.return_value = mock_coordinator
-        await async_websocket_get_grow_report(hass, mock_connection, msg)
-
-        mock_connection.send_error.assert_called_once()
-        call_args = mock_connection.send_error.call_args
-        assert call_args[0][0] == 1
-        assert "unknown_error" in call_args[0][1]
+    with pytest.raises(ValueError, match="DB Error"):
+        await async_websocket_get_grow_report(hass, mock_coordinator, msg)
 
 
 @pytest.mark.asyncio
@@ -1276,4 +1248,3 @@ async def test_export_as_pdf_import_error(
             match="PDF export requires the 'fpdf2' package",
         ):
             await handle_export_grow_report(hass, mock_coordinator, call)
-

--- a/tests/services/test_strain_library_ws.py
+++ b/tests/services/test_strain_library_ws.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 
 from custom_components.growspace_manager.const import DOMAIN
+from custom_components.growspace_manager.exceptions import GrowspaceError
 from custom_components.growspace_manager.websocket import (
     WS_TYPE_GET_EC_RAMP_CURVES,
     WS_TYPE_GET_IPM_PRESETS,
@@ -19,7 +20,6 @@ from custom_components.growspace_manager.websocket import (
     websocket_upload_strain_image,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 
 
 @dataclass
@@ -47,38 +47,17 @@ async def test_websocket_get_strain_library_success(mock_connection) -> None:
     coordinator._strain_library = mock_library
     coordinator.services.config.strain_library = mock_library
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_any",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {"id": 1, "type": WS_TYPE_GET_STRAIN_LIBRARY}
 
         # Call synchronously as it is now a callback
-        websocket_get_strain_library(hass, mock_connection, msg)
+        result = websocket_get_strain_library(hass, coordinator, msg)
 
         expected_response = {
             "strains": expected_strains,
             "strain_list": ["Strain A"],
         }
-        mock_connection.send_result.assert_called_once_with(1, expected_response)
-
-
-@pytest.mark.asyncio
-async def test_websocket_get_strain_library_not_loaded(mock_connection) -> None:
-    """Test error when strain library is not loaded."""
-    hass = Mock(spec=HomeAssistant)
-
-    msg = {"id": 1, "type": WS_TYPE_GET_STRAIN_LIBRARY}
-
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_any",
-        side_effect=ServiceValidationError("Not loaded"),
-    ):
-        websocket_get_strain_library(hass, mock_connection, msg)
-
-        mock_connection.send_error.assert_called_once_with(
-            1, "not_loaded", "Growspace Manager strain library not loaded"
-        )
+    assert result == expected_response
 
 
 @pytest.mark.asyncio
@@ -93,17 +72,11 @@ async def test_websocket_get_strain_library_exception(mock_connection) -> None:
     coordinator._strain_library = mock_library
     coordinator.services.config.strain_library = mock_library
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_any",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {"id": 1, "type": WS_TYPE_GET_STRAIN_LIBRARY}
 
-        websocket_get_strain_library(hass, mock_connection, msg)
-
-        mock_connection.send_error.assert_called_once_with(
-            1, "unknown_error", "Unexpected error"
-        )
+        with pytest.raises(RuntimeError, match="Unexpected error"):
+            websocket_get_strain_library(hass, coordinator, msg)
 
 
 @pytest.mark.asyncio
@@ -117,13 +90,10 @@ async def test_websocket_get_nutrient_presets_success(mock_connection) -> None:
         "nutrient_presets": expected_data
     }
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {"id": 1, "type": WS_TYPE_GET_NUTRIENT_PRESETS}
-        websocket_get_nutrient_presets(hass, mock_connection, msg)
-        mock_connection.send_result.assert_called_once_with(1, expected_data)
+        result = websocket_get_nutrient_presets(hass, coordinator, msg)
+    assert result == expected_data
 
 
 @pytest.mark.asyncio
@@ -137,13 +107,10 @@ async def test_websocket_get_ipm_presets_success(mock_connection) -> None:
         "ipm_presets": expected_data
     }
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {"id": 1, "type": WS_TYPE_GET_IPM_PRESETS}
-        websocket_get_ipm_presets(hass, mock_connection, msg)
-        mock_connection.send_result.assert_called_once_with(1, expected_data)
+        result = websocket_get_ipm_presets(hass, coordinator, msg)
+    assert result == expected_data
 
 
 @pytest.mark.asyncio
@@ -157,13 +124,10 @@ async def test_websocket_get_ec_ramp_curves_success(mock_connection) -> None:
         "ec_ramp_curves": expected_data
     }
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {"id": 1, "type": WS_TYPE_GET_EC_RAMP_CURVES}
-        websocket_get_ec_ramp_curves(hass, mock_connection, msg)
-        mock_connection.send_result.assert_called_once_with(1, expected_data)
+        result = websocket_get_ec_ramp_curves(hass, coordinator, msg)
+    assert result == expected_data
 
 
 @pytest.mark.asyncio
@@ -180,19 +144,16 @@ async def test_websocket_get_strain_lineage_tree_success(mock_connection) -> Non
     coordinator._strain_library = mock_library
     coordinator.services.config.strain_library = mock_library
 
-    with patch(
-        "custom_components.growspace_manager.GrowspaceCoordinator.get_any",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 1,
             "type": WS_TYPE_GET_STRAIN_LINEAGE_TREE,
             "strain_name": "Strain A",
         }
 
-        await websocket_get_strain_lineage_tree(hass, mock_connection, msg)
+        result = await websocket_get_strain_lineage_tree(hass, coordinator, msg)
 
-        mock_connection.send_result.assert_called_once_with(1, expected_tree)
+    assert result == expected_tree
 
 
 @pytest.mark.asyncio
@@ -208,10 +169,7 @@ async def test_websocket_upload_strain_image_success(mock_connection: Mock) -> N
     coordinator = MagicMock()
     coordinator.services.config.strain_library.image_manager = mock_image_manager
 
-    with patch(
-        "custom_components.growspace_manager.websocket.strain.GrowspaceCoordinator.get_any",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 5,
             "type": f"{DOMAIN}/upload_strain_image",
@@ -219,36 +177,15 @@ async def test_websocket_upload_strain_image_success(mock_connection: Mock) -> N
             "phenotype": "Pheno 1",
             "image_base64": "data:image/jpeg;base64,abc123",
         }
-        await websocket_upload_strain_image(hass, mock_connection, msg)
+        result = await websocket_upload_strain_image(hass, coordinator, msg)
 
-    mock_connection.send_result.assert_called_once_with(
-        5, {"path": "/local/growspace_manager/strains/og_kush__pheno1.jpg"}
-    )
+    assert result == {"path": "/local/growspace_manager/strains/og_kush__pheno1.jpg"}
 
 
 @pytest.mark.asyncio
-async def test_websocket_upload_strain_image_not_loaded(mock_connection: Mock) -> None:
-    """Test upload error when strain library is not loaded."""
-    hass = Mock(spec=HomeAssistant)
-
-    with patch(
-        "custom_components.growspace_manager.websocket.strain.GrowspaceCoordinator.get_any",
-        side_effect=ServiceValidationError("Not loaded"),
-    ):
-        msg = {
-            "id": 6,
-            "type": f"{DOMAIN}/upload_strain_image",
-            "strain": "OG Kush",
-            "phenotype": "Pheno 1",
-            "image_base64": "data:image/jpeg;base64,abc123",
-        }
-        await websocket_upload_strain_image(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once_with(6, "not_loaded", "Strain library not loaded")
-
-
-@pytest.mark.asyncio
-async def test_websocket_upload_strain_image_generic_error(mock_connection: Mock) -> None:
+async def test_websocket_upload_strain_image_generic_error(
+    mock_connection: Mock,
+) -> None:
     """Test upload generic exception handling."""
     hass = Mock(spec=HomeAssistant)
 
@@ -258,10 +195,7 @@ async def test_websocket_upload_strain_image_generic_error(mock_connection: Mock
     coordinator = MagicMock()
     coordinator.services.config.strain_library.image_manager = mock_image_manager
 
-    with patch(
-        "custom_components.growspace_manager.websocket.strain.GrowspaceCoordinator.get_any",
-        return_value=coordinator,
-    ):
+    if True:
         msg = {
             "id": 7,
             "type": f"{DOMAIN}/upload_strain_image",
@@ -269,13 +203,14 @@ async def test_websocket_upload_strain_image_generic_error(mock_connection: Mock
             "phenotype": "Pheno 1",
             "image_base64": "data:image/jpeg;base64,abc123",
         }
-        await websocket_upload_strain_image(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once_with(7, "unknown_error", "disk full")
+        with pytest.raises(OSError, match="disk full"):
+            await websocket_upload_strain_image(hass, coordinator, msg)
 
 
 @pytest.mark.asyncio
-async def test_websocket_download_strain_image_http_error(mock_connection: Mock) -> None:
+async def test_websocket_download_strain_image_http_error(
+    mock_connection: Mock,
+) -> None:
     """Test download returns fetch_failed when HTTP response is non-200."""
     hass = Mock(spec=HomeAssistant)
 
@@ -292,10 +227,6 @@ async def test_websocket_download_strain_image_http_error(mock_connection: Mock)
 
     with (
         patch(
-            "custom_components.growspace_manager.websocket.strain.GrowspaceCoordinator.get_any",
-            return_value=coordinator,
-        ),
-        patch(
             "custom_components.growspace_manager.websocket.strain.async_get_clientsession",
             return_value=mock_session,
         ),
@@ -307,34 +238,14 @@ async def test_websocket_download_strain_image_http_error(mock_connection: Mock)
             "strain": "OG Kush",
             "phenotype": "Pheno 1",
         }
-        await websocket_download_strain_image(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once_with(8, "fetch_failed", "HTTP 404")
-
-
-@pytest.mark.asyncio
-async def test_websocket_download_strain_image_not_loaded(mock_connection: Mock) -> None:
-    """Test download error when strain library is not loaded."""
-    hass = Mock(spec=HomeAssistant)
-
-    with patch(
-        "custom_components.growspace_manager.websocket.strain.GrowspaceCoordinator.get_any",
-        side_effect=ServiceValidationError("Not loaded"),
-    ):
-        msg = {
-            "id": 9,
-            "type": f"{DOMAIN}/download_strain_image",
-            "url": "https://example.com/img.jpg",
-            "strain": "OG Kush",
-            "phenotype": "Pheno 1",
-        }
-        await websocket_download_strain_image(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once_with(9, "not_loaded", "Strain library not loaded")
+        with pytest.raises(GrowspaceError, match="HTTP 404"):
+            await websocket_download_strain_image(hass, coordinator, msg)
 
 
 @pytest.mark.asyncio
-async def test_websocket_download_strain_image_generic_error(mock_connection: Mock) -> None:
+async def test_websocket_download_strain_image_generic_error(
+    mock_connection: Mock,
+) -> None:
     """Test download generic exception handling."""
     hass = Mock(spec=HomeAssistant)
 
@@ -342,10 +253,6 @@ async def test_websocket_download_strain_image_generic_error(mock_connection: Mo
     coordinator.services.config.strain_library.image_manager = MagicMock()
 
     with (
-        patch(
-            "custom_components.growspace_manager.websocket.strain.GrowspaceCoordinator.get_any",
-            return_value=coordinator,
-        ),
         patch(
             "custom_components.growspace_manager.websocket.strain.async_get_clientsession",
             side_effect=RuntimeError("session error"),
@@ -358,6 +265,5 @@ async def test_websocket_download_strain_image_generic_error(mock_connection: Mo
             "strain": "OG Kush",
             "phenotype": "Pheno 1",
         }
-        await websocket_download_strain_image(hass, mock_connection, msg)
-
-    mock_connection.send_error.assert_called_once_with(10, "unknown_error", "session error")
+        with pytest.raises(RuntimeError, match="session error"):
+            await websocket_download_strain_image(hass, coordinator, msg)

--- a/tests/test_lineage_fallback.py
+++ b/tests/test_lineage_fallback.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from custom_components.growspace_manager.const import DOMAIN
+from custom_components.growspace_manager.exceptions import PlantNotFoundError
 from custom_components.growspace_manager.managers.genetics import GeneticsManager
 from custom_components.growspace_manager.models import (
     Plant,
@@ -32,13 +33,16 @@ def manager_empty(save_callback: AsyncMock) -> GeneticsManager:
     from custom_components.growspace_manager.data_access.growspace_repository import (
         GrowspaceRepository,
     )
+
     repo = GrowspaceRepository()
-    repo.add_plant(Plant(
-        plant_id="plant-1",
-        growspace_id="gs-1",
-        genetics=PlantGenetics(strain_name="OG Kush"),
-        stage="flower",
-    ))
+    repo.add_plant(
+        Plant(
+            plant_id="plant-1",
+            growspace_id="gs-1",
+            genetics=PlantGenetics(strain_name="OG Kush"),
+            stage="flower",
+        )
+    )
     return GeneticsManager(repository=repo, save_callback=save_callback)
 
 
@@ -48,19 +52,24 @@ def manager_with_pollination(save_callback: AsyncMock) -> GeneticsManager:
     from custom_components.growspace_manager.data_access.growspace_repository import (
         GrowspaceRepository,
     )
+
     repo = GrowspaceRepository()
-    repo.add_plant(Plant(
-        plant_id="plant-donor",
-        growspace_id="gs-1",
-        genetics=PlantGenetics(strain_name="Durban Poison"),
-        stage="flower",
-    ))
-    repo.add_plant(Plant(
-        plant_id="plant-receiver",
-        growspace_id="gs-1",
-        genetics=PlantGenetics(strain_name="OG Kush"),
-        stage="flower",
-    ))
+    repo.add_plant(
+        Plant(
+            plant_id="plant-donor",
+            growspace_id="gs-1",
+            genetics=PlantGenetics(strain_name="Durban Poison"),
+            stage="flower",
+        )
+    )
+    repo.add_plant(
+        Plant(
+            plant_id="plant-receiver",
+            growspace_id="gs-1",
+            genetics=PlantGenetics(strain_name="OG Kush"),
+            stage="flower",
+        )
+    )
     mgr = GeneticsManager(repository=repo, save_callback=save_callback)
     event = PollinationEvent(
         event_id="evt-1",
@@ -157,20 +166,15 @@ async def test_fallback_uses_strain_library_when_no_pollination_parents() -> Non
     plant.genetics.strain_name = "OG Kush"
 
     pollination_tree = {"name": "OG Kush", "parents": []}
-    coordinator = _make_coordinator({"plant-1": plant}, pollination_tree, strain_library)
+    coordinator = _make_coordinator(
+        {"plant-1": plant}, pollination_tree, strain_library
+    )
 
     hass = _make_hass(DOMAIN)
-    connection = MagicMock()
+    MagicMock()
     msg = {"id": 1, "plant_id": "plant-1"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
-        await websocket_get_lineage_tree(hass, connection, msg)
-
-    connection.send_result.assert_called_once()
-    result_tree = connection.send_result.call_args[0][1]
+    result_tree = await websocket_get_lineage_tree(hass, coordinator, msg)
     assert len(result_tree["parents"]) == 2
     parent_names = [p["name"] for p in result_tree["parents"]]
     assert "Chemdawg" in parent_names
@@ -194,20 +198,15 @@ async def test_no_fallback_when_pollination_tree_has_parents() -> None:
             {"name": "Donor", "parents": []},
         ],
     }
-    coordinator = _make_coordinator({"plant-1": plant}, pollination_tree, strain_library)
+    coordinator = _make_coordinator(
+        {"plant-1": plant}, pollination_tree, strain_library
+    )
 
     hass = _make_hass(DOMAIN)
-    connection = MagicMock()
+    MagicMock()
     msg = {"id": 2, "plant_id": "plant-1"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
-        await websocket_get_lineage_tree(hass, connection, msg)
-
-    connection.send_result.assert_called_once()
-    result_tree = connection.send_result.call_args[0][1]
+    result_tree = await websocket_get_lineage_tree(hass, coordinator, msg)
     # Parents come from pollination, not strain library
     assert result_tree["parents"] == pollination_tree["parents"]
     strain_library.get_strain_lineage_tree.assert_not_called()
@@ -221,20 +220,15 @@ async def test_fallback_skipped_when_strain_library_not_loaded() -> None:
     plant.genetics.strain_name = "OG Kush"
 
     pollination_tree = {"name": "OG Kush", "parents": []}
-    coordinator = _make_coordinator({"plant-1": plant}, pollination_tree, strain_library=None)
+    coordinator = _make_coordinator(
+        {"plant-1": plant}, pollination_tree, strain_library=None
+    )
 
     hass = _make_hass(DOMAIN)
-    connection = MagicMock()
+    MagicMock()
     msg = {"id": 3, "plant_id": "plant-1"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
-        await websocket_get_lineage_tree(hass, connection, msg)
-
-    connection.send_result.assert_called_once()
-    result_tree = connection.send_result.call_args[0][1]
+    result_tree = await websocket_get_lineage_tree(hass, coordinator, msg)
     assert result_tree["parents"] == []
 
 
@@ -253,20 +247,15 @@ async def test_fallback_skipped_when_strain_library_tree_also_empty() -> None:
     plant.genetics.strain_name = "OG Kush"
 
     pollination_tree = {"name": "OG Kush", "parents": []}
-    coordinator = _make_coordinator({"plant-1": plant}, pollination_tree, strain_library)
+    coordinator = _make_coordinator(
+        {"plant-1": plant}, pollination_tree, strain_library
+    )
 
     hass = _make_hass(DOMAIN)
-    connection = MagicMock()
+    MagicMock()
     msg = {"id": 4, "plant_id": "plant-1"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
-        await websocket_get_lineage_tree(hass, connection, msg)
-
-    connection.send_result.assert_called_once()
-    result_tree = connection.send_result.call_args[0][1]
+    result_tree = await websocket_get_lineage_tree(hass, coordinator, msg)
     assert result_tree["parents"] == []
 
 
@@ -278,16 +267,8 @@ async def test_plant_not_found_sends_error() -> None:
 
     hass = MagicMock()
     hass.data = {}
-    connection = MagicMock()
+    MagicMock()
     msg = {"id": 5, "plant_id": "missing-plant"}
 
-    with patch(
-        "custom_components.growspace_manager.websocket.GrowspaceCoordinator.get_for_service_call",
-        return_value=coordinator,
-    ):
-        await websocket_get_lineage_tree(hass, connection, msg)
-
-    connection.send_error.assert_called_once()
-    call_args = connection.send_error.call_args[0]
-    assert call_args[1] == "invalid_args"
-    assert "missing-plant" in call_args[2]
+    with pytest.raises(PlantNotFoundError, match="missing-plant"):
+        await websocket_get_lineage_tree(hass, coordinator, msg)

--- a/tests/test_update_vision_checkup_config.py
+++ b/tests/test_update_vision_checkup_config.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from custom_components.growspace_manager.exceptions import GrowspaceNotFoundError
 from custom_components.growspace_manager.models import EnvironmentConfig, Growspace
+from custom_components.growspace_manager.websocket import (
+    websocket_update_vision_checkup_config,
+)
+from homeassistant.exceptions import ServiceValidationError
 
 
 @pytest.fixture
@@ -32,12 +37,6 @@ def mock_coordinator(mock_growspace):
 
 @pytest.mark.asyncio
 async def test_update_vision_checkup_config_success(mock_coordinator, mock_growspace):
-    from custom_components.growspace_manager.websocket import (
-        websocket_update_vision_checkup_config,
-    )
-
-    connection = MagicMock()
-    connection.send_result = MagicMock()
     msg = {
         "id": 1,
         "growspace_id": "tent1",
@@ -46,11 +45,9 @@ async def test_update_vision_checkup_config_success(mock_coordinator, mock_grows
         "mid_check_hours": 8,
         "late_check_offset_minutes": 45,
     }
-    with patch(
-        "custom_components.growspace_manager.coordinator.GrowspaceCoordinator.get_for_service_call",
-        return_value=mock_coordinator,
-    ):
-        await websocket_update_vision_checkup_config(MagicMock(), connection, msg)
+    result = await websocket_update_vision_checkup_config(
+        MagicMock(), mock_coordinator, msg
+    )
 
     cfg = mock_growspace.environment_config.vision_checkup_config
     assert cfg.enabled is True
@@ -59,98 +56,38 @@ async def test_update_vision_checkup_config_success(mock_coordinator, mock_grows
     assert cfg.late_check_offset_minutes == 45
     mock_coordinator.async_commit.assert_awaited_once()
     mock_coordinator.vision_scheduler.schedule_all_growspaces.assert_called_once()
-    connection.send_result.assert_called_once_with(1, {"success": True})
+    assert result == {"success": True}
 
 
 @pytest.mark.asyncio
 async def test_update_vision_checkup_config_growspace_not_found(mock_coordinator):
-    from custom_components.growspace_manager.websocket import (
-        websocket_update_vision_checkup_config,
-    )
-
-    connection = MagicMock()
-    connection.send_error = MagicMock()
     msg = {"id": 2, "growspace_id": "nonexistent", "enabled": False}
-    with patch(
-        "custom_components.growspace_manager.coordinator.GrowspaceCoordinator.get_for_service_call",
-        return_value=mock_coordinator,
-    ):
-        await websocket_update_vision_checkup_config(MagicMock(), connection, msg)
-
-    connection.send_error.assert_called_once()
-    args = connection.send_error.call_args[0]
-    assert args[0] == 2
-    assert args[1] == "not_found"
+    with pytest.raises(GrowspaceNotFoundError):
+        await websocket_update_vision_checkup_config(MagicMock(), mock_coordinator, msg)
 
 
 @pytest.mark.asyncio
 async def test_update_vision_checkup_config_no_env_config(mock_coordinator):
-    from custom_components.growspace_manager.websocket import (
-        websocket_update_vision_checkup_config,
-    )
-
     gs = MagicMock()
     gs.environment_config = None
     mock_coordinator.growspaces = {"tent1": gs}
-    connection = MagicMock()
-    connection.send_error = MagicMock()
     msg = {"id": 3, "growspace_id": "tent1", "enabled": True}
-    with patch(
-        "custom_components.growspace_manager.coordinator.GrowspaceCoordinator.get_for_service_call",
-        return_value=mock_coordinator,
-    ):
-        await websocket_update_vision_checkup_config(MagicMock(), connection, msg)
-
-    connection.send_error.assert_called_once()
-    args = connection.send_error.call_args[0]
-    assert args[0] == 3
-    assert args[1] == "no_environment"
+    with pytest.raises(ServiceValidationError, match="No environment config"):
+        await websocket_update_vision_checkup_config(MagicMock(), mock_coordinator, msg)
 
 
 @pytest.mark.asyncio
 async def test_update_vision_checkup_config_partial_update(
     mock_coordinator, mock_growspace
 ):
-    from custom_components.growspace_manager.websocket import (
-        websocket_update_vision_checkup_config,
-    )
-
     # Pre-set values
     mock_growspace.environment_config.vision_checkup_config.enabled = False
     mock_growspace.environment_config.vision_checkup_config.early_check_offset_minutes = 999
 
-    connection = MagicMock()
     msg = {"id": 4, "growspace_id": "tent1", "enabled": True}  # Only update enabled
-    with patch(
-        "custom_components.growspace_manager.coordinator.GrowspaceCoordinator.get_for_service_call",
-        return_value=mock_coordinator,
-    ):
-        await websocket_update_vision_checkup_config(MagicMock(), connection, msg)
+    await websocket_update_vision_checkup_config(MagicMock(), mock_coordinator, msg)
 
     cfg = mock_growspace.environment_config.vision_checkup_config
     assert cfg.enabled is True
     # early_check_offset_minutes should remain 999 (not updated)
     assert cfg.early_check_offset_minutes == 999
-
-
-@pytest.mark.asyncio
-async def test_update_vision_checkup_config_coordinator_not_loaded():
-    from custom_components.growspace_manager.websocket import (
-        websocket_update_vision_checkup_config,
-    )
-    from homeassistant.exceptions import ServiceValidationError
-
-    connection = MagicMock()
-    connection.send_error = MagicMock()
-    msg = {"id": 5, "growspace_id": "tent1", "enabled": True}
-
-    with patch(
-        "custom_components.growspace_manager.coordinator.GrowspaceCoordinator.get_for_service_call",
-        side_effect=ServiceValidationError("Integration not loaded"),
-    ):
-        await websocket_update_vision_checkup_config(MagicMock(), connection, msg)
-
-    connection.send_error.assert_called_once()
-    args = connection.send_error.call_args[0]
-    assert args[0] == 5
-    assert args[1] == "not_loaded"


### PR DESCRIPTION
## Summary

Candidate 3 from the architecture review. The WebSocket package was already half-deep (table-driven registration, `handle_ws_errors`, one-line coordinator resolution); this PR finishes the seam and completes ADR-0005's typed error-code contract that the card has been shipping against since the get_data decomposition.

## What changed

**WS Command Lifecycle (`websocket/_common.py`, ADR-0027).** All 66 handlers become payload-returning functions `(hass, coordinator, msg) → payload | None`. One registration wrapper owns resolve → execute → `send_result` → error mapping. Each module declares `WSCommand` rows (`type, handler, schema, resolve="targeted"|"any", sync`). Verified before designing: no handler used the connection beyond send_result/send_error, so nothing needed an escape hatch.

**Typed error codes, backend side completed.** The card's `errors.ts` types `coordinator_not_ready / entity_not_found / validation_failed / internal_error / rate_limited` and silently coerces anything else to `internal_error` — so the backend's `unknown_error` and five ad-hoc codes were self-defeating. Now:

- `EntityNotFoundError` (new parent of the existing `Plant/GrowspaceNotFoundError`) → `entity_not_found` — not-found UX becomes reachable on the card
- `CoordinatorNotReadyError` → `coordinator_not_ready` — the locator now distinguishes "nothing loaded" from "ambiguous instance"
- `RateLimitedError` → `rate_limited` — replaces ai_assistant's hand-rolled four-way branches (collapsed into one `_converse_or_raise` helper)
- validation family → `validation_failed`; everything else → `internal_error` (with traceback)
- Inline `connection.send_error` calls in handlers are gone; an error is a raised typed exception, mapped once. The shared constants in `services/utils.py` (which already had the right names — only `data.py` ever used them) are the single source.

**Zero card changes needed** — codes converge into the set it already types.

## Test surface (the point of the refactor)

- Handler tests assert on returned payloads and raised typed exceptions — no mock connections.
- New `tests/core/test_ws_command_lifecycle.py` covers resolution modes, sync/async wrappers, and the full code vocabulary **once** (14 tests).
- ~46 per-handler resolution-error tests deleted as redundant with the lifecycle tests; ~30 test files migrated to the payload surface.
- e2e WS-client tests (real `hass_ws_client`) keep exercising the full stack; `resolve="any"` commands now require a loaded coordinator (tests stub `get_any`).

## Behaviour notes

- Wire error `code` strings change (`unknown_error` → `internal_error`, ad-hoc codes → typed set). Messages unchanged. The card handles both before/after.
- Commands that never touched a coordinator (logbook, history stats, print_label) now resolve one (`resolve="any"`) — meaningless without the integration loaded anyway, and consistent.
- No commands added/removed; the `test_core_init` registration count (67) is untouched.

Full suite: **4,829 passed**, 46 snapshots, 0 failures. ADR: `docs/adr/0027-ws-command-lifecycle-and-typed-error-codes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)