### PR TITLE
docs: amend ADR-0024 with card-side Port Pre-fill pointer

### DIFF
--- a/docs/adr/0024-ac-infinity-growlight-explicit-entity-bundle.md
+++ b/docs/adr/0024-ac-infinity-growlight-explicit-entity-bundle.md
@@ -11,3 +11,14 @@ The AC Infinity grow-light configurator (ADR-0023) needs to write ~6 entities on
 - The user picks each AC Infinity entity explicitly (~6 pickers per grow light) — more setup friction than a single device picker, accepted for convention-consistency and zero upstream coupling.
 - No dependency on `ac_infinity`'s internal entity keys: an upstream rename breaks nothing in GSM (the user's stored entity IDs are HA-registry-stable, and renames surface as normal missing-entity errors).
 - This is **not** the first AC Infinity config surface — `configure_environment` + `AC_INFINITY_DEVICE_SCHEMA` + the card payload (the `feat-ac-infinity-configure-env` line of work) established that for the fan/humidifier roles first. The grow-light bundle extends that surface rather than founding it, and should reuse the same schema/validation/preservation plumbing (note the "configure_environment is a full replace" behavior — the growlight bundle must be preserved on unrelated env edits like every other field).
+
+## Amendment (2026-07-07)
+
+The ergonomics half of this decision was revisited: the card now offers a **device-picker
+pre-fill** (card repo ADR-0028) on all AC Infinity editors — the user picks the `ac_infinity`
+port device and the card resolves the member entities via `translation_key` at edit time,
+pre-filling (and on re-pick, overwriting) the existing entity pickers. This is UI sugar only:
+the **stored config remains the explicit entity bundle decided here**, no backend or runtime
+resolution was introduced, and an upstream key rename degrades the pre-fill back to the manual
+flow without breaking anything stored. The rejection above stands for storage and backend; it
+no longer implies the *pickers themselves* must be filled by hand.


### PR DESCRIPTION
Appends an amendment note to ADR-0024: the card now offers a device-picker **pre-fill** (card repo ADR-0028) that resolves member entities via `translation_key` at edit time only. The explicit-entity-bundle storage decision stands unchanged — no backend or runtime resolution introduced.

Companion PR in the card repo adds ADR-0028 + glossary terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)