### PR TITLE
chore: make the CI dependency install reproducible

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,10 +35,14 @@ jobs:
         with:
           python-version: "3.14"
           cache: "pip"
+      # Two-phase constrained install, matching tests.yaml — see the comment there.
       - name: install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade -r requirements.txt
+          pip install "$(grep '^homeassistant==' requirements.txt)"
+          pip install -r requirements.txt -c "$(
+            python -c 'import homeassistant, pathlib; print(pathlib.Path(homeassistant.__file__).parent / "package_constraints.txt")'
+          )"
           pip install "mypy==1.20.2"
       # Non-blocking until the inherited HA-core-strict baseline (~460 errors) is
       # burned down in a dedicated effort; see ADR 0020.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,8 +24,21 @@ jobs:
             ${{ runner.os }}-pip-
       - name: update pip
         run: python -m pip install --upgrade pip setuptools wheel
+      # Two-phase install so every Home-Assistant-owned dependency resolves to the
+      # version this HA release actually supports. Installing requirements.txt in one
+      # unconstrained pass let hassil float past HA 2026.5.4 and zeroed out collection
+      # on a commit that had passed a month earlier (ADR-0020, 2026-08-07 amendment).
       - name: install dependencies
-        run: pip install --upgrade -r requirements.txt
+        run: |
+          # Phase 1: HA alone, so its package_constraints.txt is on disk to constrain phase 2.
+          pip install "$(grep '^homeassistant==' requirements.txt)"
+          pip install -r requirements.txt -c "$(
+            python -c 'import homeassistant, pathlib; print(pathlib.Path(homeassistant.__file__).parent / "package_constraints.txt")'
+          )"
+      # Makes the resolved set visible in the log, so a future "it passed last month"
+      # can be diffed against what actually got installed.
+      - name: record resolved dependency set
+        run: pip freeze
       - name: Run Unit Tests
         env:
           PYTHONPATH: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,38 +1,62 @@
+# This file is the CI test environment, not what HACS users install — the shipped
+# dependency ranges live in custom_components/growspace_manager/manifest.json.
+#
+# Pinning policy (ADR-0020, 2026-08-07 amendment): CI must resolve the same set on
+# any given commit regardless of when it runs. Three mechanisms cover that, in order
+# of precedence:
+#
+#   1. HA's own homeassistant/package_constraints.txt, applied as a `-c` constraints
+#      file by the two-phase install in tests.yaml. This governs every dependency
+#      Home Assistant itself pins (Pillow, voluptuous, aiodhcpwatcher, PyTurboJPEG,
+#      pydantic, hassil, home-assistant-intents...) — do not restate those here.
+#   2. pytest-homeassistant-custom-component, which pins homeassistant plus the
+#      pytest stack exactly (pytest, pytest-asyncio, pytest-cov, pytest-xdist,
+#      coverage, freezegun, requests-mock, syrupy, pipdeptree).
+#   3. Explicit `==` pins below, for the remainder that neither of the above covers.
+#
+# Anything left bare would float under a fresh resolve, which is how hassil reached
+# 3.10 (no hassil.fuzzy) and zeroed out test collection on an unchanged commit.
+
 # Home Assistant Core (Minimal)
-# Kept in lockstep with pytest-homeassistant-custom-component (which pins an exact
-# homeassistant version) and the hassil/home-assistant-intents pair below; a fresh
-# CI install otherwise floats them past what this homeassistant version supports
-# and breaks collection (intents lost FuzzyConfig, hassil >=3.10 dropped hassil.fuzzy).
+# Kept in lockstep with pytest-homeassistant-custom-component, which pins this exact
+# homeassistant version; bumping one requires bumping the other.
 homeassistant==2026.5.4
-aiosqlite
+aiosqlite==0.22.1
 Pillow
-python-dateutil
+python-dateutil==2.9.0.post0
 voluptuous
 
 # Integration dependencies
-fpdf2>=2.7.9
-mashumaro>=3.10
-beautifulsoup4>=4.12.0
+# manifest.json ships these as ranges (mashumaro>=3.10, beautifulsoup4>=4.12.0);
+# the pins here fix what CI tests against, they do not narrow what users get.
+fpdf2==2.8.7
+mashumaro==3.22
+beautifulsoup4==4.15.0
 
 # Test Dependencies
 aiodhcpwatcher
-pycares>=5.0.0
-ruff
+pycares==5.0.1
 coverage
-pre-commit
 pydantic
-pylint
 pipdeptree
 pytest-asyncio
 pytest-homeassistant-custom-component==0.13.333
 pytest-cov
 pytest
 PyTurboJPEG
-yamllint
-codespell
 pytest-xdist
 freezegun
 requests-mock
 hassil==3.5.0
 home-assistant-intents==2026.5.5
 syrupy>=5.0.0
+
+# Local dev tooling — NOT what the gate runs. CI pins its own copies: ruff and mypy
+# in lint.yaml, and the hook versions in .pre-commit-config.yaml. ruff is pinned to
+# lint.yaml's version so a local `ruff check` agrees with the gate; lint.yaml is the
+# source of truth, so bump it there first.
+ruff==0.15.12
+pre-commit
+pylint
+yamllint
+codespell


### PR DESCRIPTION
Follow-up to #528, implementing the mechanism that ADR-0020's 2026-08-07 amendment recorded as intent.

## Why

#528 pinned `hassil` and stopped the outage, but ~20 dependencies stayed bare under `pip install --upgrade`. The same commit could still resolve differently on different days — which is exactly the property that made the gate's verdict uninformative.

## What

**Two-phase constrained install** in `tests.yaml` and `lint.yaml`'s mypy job:

```bash
pip install "$(grep '^homeassistant==' requirements.txt)"
pip install -r requirements.txt -c <site-packages>/homeassistant/package_constraints.txt
```

Every HA-owned dependency now resolves to what this HA release supports — automatically, and for dependencies added later, instead of being mirrored by hand.

**Three mechanisms, stated in the file** so the next reader knows which owns what:

1. HA's `package_constraints.txt` via `-c` — Pillow, voluptuous, aiodhcpwatcher, PyTurboJPEG, pydantic, hassil, intents
2. `pytest-homeassistant-custom-component` — pins the pytest stack exactly (pytest, pytest-asyncio, pytest-cov, pytest-xdist, coverage, freezegun, requests-mock, syrupy, pipdeptree)
3. Explicit `==` pins for the remainder

**Explicit pins** set to what a clean `--upgrade` resolve picks *today*, so CI keeps running what it already runs rather than being silently downgraded to a maintainer's local versions:

```
aiosqlite==0.22.1   python-dateutil==2.9.0.post0   fpdf2==2.8.7
mashumaro==3.22     beautifulsoup4==4.15.0         pycares==5.0.1
```

**`ruff==0.15.12`** — matching `lint.yaml`, so a local `ruff check` agrees with the gate. It was floating to 0.16.1, meaning devs and CI ran different linters. `lint.yaml` remains the source of truth; the other dev-tooling entries are marked as not gate-relevant.

**`pip freeze` step** so a future "but it passed last month" can be diffed against what was actually installed.

## Two downgrades, both verified safe

The constraints file moves `PyTurboJPEG` 2.5.0 → 1.8.3 and `aiodhcpwatcher` 1.2.7 → 1.2.1. `turbojpeg` is replaced by a `MagicMock` in `tests/conftest.py:19` and never really imported; `aiodhcpwatcher` appears nowhere in the code.

## Verification

Built a bare venv, ran the two-phase install, ran the suite against it — **4853 passed**, `ruff check` clean. Confirmed the resolved set matches every intended pin. Not verified from the pre-populated dev venv, which is what hid the original bug.

## Scope

`manifest.json` is untouched — it ships ranges to HACS users; this pins only the CI test environment. No other workflow installs `requirements.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)