### PR TITLE
docs: point test commands at the repo-local venv, not the HA core one

### DIFF
--- a/.agent/workflows/run_tests.md
+++ b/.agent/workflows/run_tests.md
@@ -6,33 +6,42 @@ description: How to run pytest for the Growspace Manager backend
 
 ## Running Backend Tests
 
-1. Run pytest with the project venv (Python 3.13+):
+Run from the checkout root, through the repo-local venv (Python 3.14+). One venv lives in the main checkout and every worktree shares it; if it does not exist yet, see "Creating or refreshing the venv" in `CLAUDE.md`.
+
+1. Run pytest:
 
 ```bash
 cd /home/maxi/core/core/vendor/growspace_manager
-/home/maxi/core/core/.venv/bin/pytest tests/ -q
+.venv/bin/pytest tests/ -q
+```
+
+From a `.worktrees/<branch>` worktree, reach the same venv the pre-commit hooks use:
+
+```bash
+../../.venv/bin/pytest tests/ -q
 ```
 
 2. Run with coverage:
 
 ```bash
-/home/maxi/core/core/.venv/bin/pytest tests/ --cov=custom_components.growspace_manager --cov-report=term-missing -q
+.venv/bin/pytest tests/ --cov=custom_components.growspace_manager --cov-report=term-missing -q
 ```
 
 3. Run a specific test file:
 
 ```bash
-/home/maxi/core/core/.venv/bin/pytest tests/test_<module>.py -v
+.venv/bin/pytest tests/test_<module>.py -v
 ```
 
 4. Run tests matching a pattern:
 
 ```bash
-/home/maxi/core/core/.venv/bin/pytest tests/ -k "test_pattern" -v
+.venv/bin/pytest tests/ -k "test_pattern" -v
 ```
 
 ## Notes
 
-- The venv at `/home/maxi/core/core/.venv` contains Python 3.13+ with all required dependencies
-- Always use the full path to pytest to ensure correct Python version and dependencies
-- The `-q` flag provides quiet output, use `-v` for verbose
+- **Never use the Home Assistant core venv at `/home/maxi/core/core/.venv`.** It is HA core's own test environment, so it carries HA core's syrupy rather than the version `pytest-homeassistant-custom-component` pins; every test import then dies inside `pytest_homeassistant_custom_component/syrupy.py`. It surfaces as a collection error, which reads like a broken test rather than a wrong interpreter.
+- Always call pytest through the venv path rather than a bare `pytest` — the system `python3` is not 3.14.
+- `pytest.ini` sets `pythonpath = .`, so run from the checkout root and no `PYTHONPATH` export is needed.
+- The `-q` flag provides quiet output, use `-v` for verbose.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,16 @@ cd .worktrees/<branch-name>
   `origin`, not the checkout — another session may have moved HEAD.
 - Clean up with `git worktree remove` once the PR is open.
 
+## Test environment
+
+One repo-local `.venv` (Python 3.14) lives in the main checkout and every
+worktree shares it: `.venv/bin/pytest` from the main checkout,
+`../../.venv/bin/pytest` from a worktree — the path the pre-commit hooks
+already use. **Never the HA core venv at `/home/maxi/core/core/.venv`**: its
+syrupy is newer than the one `pytest-homeassistant-custom-component` pins, so
+every test import dies at collection. Building or refreshing the venv is
+documented in `CLAUDE.md`.
+
 ## Base branches
 
 - Architecture/refactor work integrates on **`prerelease`**, not `dev`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,25 +19,49 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Testing
 
-All tests should be run using the parent project's virtual environment at `/home/maxi/core/core/.venv` (Python 3.14+):
+Tests run against the **repo-local** venv at `.venv` in the main checkout (Python 3.14+, built from `requirements.txt`). Worktrees share that one venv — they do not get their own:
+
+| Running from | Path |
+| --- | --- |
+| the main checkout | `.venv/bin/pytest` |
+| a `.worktrees/<branch>` worktree | `../../.venv/bin/pytest` — the same path the pre-commit hooks use |
+
+**Never use the Home Assistant core venv at `/home/maxi/core/core/.venv`.** It is HA core's own test environment, so it carries HA core's syrupy rather than the version `pytest-homeassistant-custom-component` pins, and every test import then dies inside `pytest_homeassistant_custom_component/syrupy.py` on a symbol newer syrupy removed. It surfaces as a collection error, which reads like a broken test rather than a wrong interpreter.
 
 ```bash
 # Run all tests
-/home/maxi/core/core/.venv/bin/pytest tests/ -q
+.venv/bin/pytest tests/ -q
 
 # Run tests with coverage
-/home/maxi/core/core/.venv/bin/pytest tests/ --cov=custom_components.growspace_manager --cov-report=term-missing -q
+.venv/bin/pytest tests/ --cov=custom_components.growspace_manager --cov-report=term-missing -q
 
 # Run specific test file
-/home/maxi/core/core/.venv/bin/pytest tests/test_<module>.py -v
+.venv/bin/pytest tests/test_<module>.py -v
 
 # Run tests matching a pattern
-/home/maxi/core/core/.venv/bin/pytest tests/ -k "test_pattern" -v
+.venv/bin/pytest tests/ -k "test_pattern" -v
 
 # Update test snapshots (if used)
-/home/maxi/core/core/.venv/bin/pytest tests/ --snapshot-update
+.venv/bin/pytest tests/ --snapshot-update
 # Always run tests again without --snapshot-update to verify
 ```
+
+`pytest.ini` sets `pythonpath = .`, so no `PYTHONPATH` export is needed as long as pytest runs from the checkout root (which is what makes the shared venv work from a worktree).
+
+#### Creating or refreshing the venv
+
+A fresh clone has no `.venv`; rebuild it whenever `requirements.txt` changes. Use the same **two-phase install CI uses** (`.github/workflows/tests.yaml`) so a local run resolves the dependency set the gate resolves. Installing `requirements.txt` in one unconstrained pass is what let hassil float past the pinned HA release and zero out collection (ADR-0020, 2026-08-07 amendment):
+
+```bash
+uv venv --python 3.14 .venv
+# Phase 1: HA alone, so its package_constraints.txt is on disk to constrain phase 2.
+uv pip install --python .venv/bin/python "$(grep '^homeassistant==' requirements.txt)"
+uv pip install --python .venv/bin/python -r requirements.txt -c "$(
+  .venv/bin/python -c 'import homeassistant, pathlib; print(pathlib.Path(homeassistant.__file__).parent / "package_constraints.txt")'
+)"
+```
+
+Plain `pip install` works too — CI uses it — but the system `python3` is not 3.14, so create the venv with an explicit interpreter either way.
 
 **CRITICAL:** After completing any task involving code changes, ALWAYS run the relevant tests to ensure no regressions. For bug fixes, run the related test file. For features, run all affected test files. Before marking work complete, run the full test suite.
 
@@ -306,7 +330,7 @@ Optional:
 2. **Never make polling intervals user-configurable** - integration determines intervals
 3. **Don't allow user-configurable config entry names** (except for helper integrations)
 4. **Always validate config entry is loaded before service execution**
-5. **Use the parent venv at `/home/maxi/core/core/.venv`**, not a local one
+5. **Use the repo-local `.venv`**, never the HA core venv at `/home/maxi/core/core/.venv` — its syrupy breaks every test import (see [Testing](#testing))
 6. **Run tests after every code change** - don't wait until the end
 
 ## Refactoring Quick Reference


### PR DESCRIPTION
`CLAUDE.md` and `.agent/workflows/run_tests.md` both told agents to run pytest through `/home/maxi/core/core/.venv`, including a "Common Pitfalls" entry stating it explicitly. That interpreter **cannot collect this suite**:

```
ImportError: cannot import name 'is_xdist_controller' from 'syrupy.utils'
  .../pytest_homeassistant_custom_component/syrupy.py:27
```

It is HA core's own test environment, so it carries HA core's syrupy (5.5.3) rather than the version `pytest-homeassistant-custom-component==0.13.333` pins (5.1.0). It surfaces as a collection error, so the wrong interpreter reads like a broken test suite — a trap worth an explicit warning rather than a silent path change.

## What the docs now say

- One repo-local `.venv` in the main checkout, shared by every worktree: `.venv/bin/pytest` from the main checkout, `../../.venv/bin/pytest` from a `.worktrees/` worktree — the path `.pre-commit-config.yaml` already uses, which is why worktrees need no venv of their own.
- A "Creating or refreshing the venv" recipe mirroring the **two-phase constrained install** from `tests.yaml`, so a local resolve matches the gate's (ADR-0020's 2026-08-07 amendment, the hassil incident).
- `pytest.ini` already sets `pythonpath = .`, so no `PYTHONPATH` export — just run from the checkout root.
- A pointer in `AGENTS.md`, which agents read before `CLAUDE.md`.

`.agent/workflows/coverage.md` already used the relative `.venv/bin/pytest` and needed no change.

## Verification

Built a venv from scratch with the documented recipe on a clean worktree and ran the full suite through it: **4875 passed**, syrupy resolving to 5.1.0. Also confirmed `../../.venv/bin/pytest` works from inside a worktree. Docs-only — no code, config, or CI change.