### PR TITLE
fix(history): preserve fan percentages when downsampling

### DIFF
--- a/custom_components/growspace_manager/websocket/environment.py
+++ b/custom_components/growspace_manager/websocket/environment.py
@@ -141,6 +141,8 @@ def _downsample_entity_binary_search(
     start_time: datetime,
     end_time: datetime,
     interval_delta: timedelta,
+    *,
+    include_fan_attrs: bool = False,
 ) -> list[dict[str, Any]]:
     """Downsample states using binary search with finger optimization."""
     downsampled = []
@@ -166,12 +168,15 @@ def _downsample_entity_binary_search(
                 state_val = s.state
 
             if state_val and state_val not in ("unknown", "unavailable"):
-                downsampled.append(
-                    {
-                        "s": state_val,
-                        "lu": current_time.isoformat(),
-                    }
-                )
+                point: dict[str, Any] = {
+                    "s": state_val,
+                    "lu": current_time.isoformat(),
+                }
+                if include_fan_attrs:
+                    attrs = _extract_fan_attrs(s)
+                    if attrs:
+                        point["a"] = attrs
+                downsampled.append(point)
         else:
             last_idx = 0
 
@@ -257,7 +262,11 @@ async def _get_history_with_binary_search_downsample(
                 result[entity_id] = passthrough
             else:
                 result[entity_id] = _downsample_entity_binary_search(
-                    states, start_time, end_time, interval_delta
+                    states,
+                    start_time,
+                    end_time,
+                    interval_delta,
+                    include_fan_attrs=is_fan,
                 )
 
         return result

--- a/tests/core/test_core_init.py
+++ b/tests/core/test_core_init.py
@@ -1029,6 +1029,48 @@ async def test_websocket_get_history_stats(
 
 
 @pytest.mark.asyncio
+async def test_websocket_history_stats_preserves_dense_fan_percentage(
+    hass: HomeAssistant,
+) -> None:
+    """Test dense fan history retains percentage attributes when downsampled."""
+    start = dt_util.utcnow().replace(minute=0, second=0, microsecond=0)
+
+    class MockState:
+        def __init__(self, index: int) -> None:
+            self.state = "on"
+            self.attributes = {"percentage": index % 100}
+            self.last_updated = start + timedelta(minutes=index)
+
+    states = [MockState(index) for index in range(201)]
+
+    with (
+        patch(
+            "homeassistant.components.recorder.history.get_significant_states",
+            return_value={"fan.circulation": states},
+        ),
+        patch(
+            "custom_components.growspace_manager.websocket.environment.get_instance"
+        ) as mock_get_rec,
+    ):
+        mock_get_rec.return_value.async_add_executor_job = hass.async_add_executor_job
+        result = await websocket_get_history_stats(
+            hass,
+            MagicMock(),
+            {
+                "id": 1,
+                "type": f"{DOMAIN}/get_history_stats",
+                "entity_ids": ["fan.circulation"],
+                "start_time": start.isoformat(),
+                "end_time": (start + timedelta(minutes=200)).isoformat(),
+                "interval_minutes": 5,
+                "significant_changes_only": True,
+            },
+        )
+
+    assert result["fan.circulation"][1]["a"]["percentage"] == 5
+
+
+@pytest.mark.asyncio
 async def test_websocket_history_empty_and_unavailable(hass: HomeAssistant) -> None:
     """Test history stats with empty data or unavailable states."""
     MagicMock()


### PR DESCRIPTION
## What changed

Preserve the `percentage` attribute when dense `fan.*` history is downsampled by the optimized WebSocket history path.

## Why

The sparse-history path already returned fan percentage attributes, but histories with more than 200 records went through `_downsample_entity_binary_search`, which retained only the entity state (`on`/`off`). The card therefore had no speed information and rendered circulation fan history as a binary value instead of the actual percentage.

## User impact

Circulation and exhaust fan graphs can now display their recorded speed percentages even for dense histories.

## Related frontend PR

- https://github.com/Venosta-web/lovelace-growspace-manager-card/pull/483

## Validation

- Added a regression test with 201 fan records and changing percentage attributes.
- `uv run --no-sync pytest tests/core/test_core_init.py -k 'websocket_get_history_stats or websocket_history_stats or websocket_history_empty' -q` — 9 passed.
- Ruff, Ruff format, Codespell, JSON checks, YAML checks, and Prettier passed on the modified files.

The repository-wide pre-commit pytest hook remains blocked by the existing Syrupy/plugin version mismatch, and repository-wide mypy reports existing errors outside this change.
