### PR TITLE
Stop registering Plants as Home Assistant devices

### DIFF
--- a/custom_components/growspace_manager/__init__.py
+++ b/custom_components/growspace_manager/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.components.frontend import (
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
@@ -33,6 +33,9 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
 
+_LEGACY_PLANT_MANUFACTURER = "Growspace Manager"
+_LEGACY_PLANT_MODEL_PREFIX = "Plant ("
+
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import TypeAlias
@@ -51,6 +54,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: GrowspaceConfigEntry) ->
     _LOGGER.debug(
         "Setting up Growspace Manager integration for entry %s", entry.entry_id
     )
+
+    _async_remove_legacy_plant_devices(hass, entry)
 
     # Initialize Storage and Coordinator
     store = Store[dict[str, Any]](hass, STORAGE_VERSION, STORAGE_KEY)
@@ -183,6 +188,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: GrowspaceConfigEntry) ->
     entry.async_on_unload(lambda: _async_cancel_coordinators(entry.runtime_data))
 
     return True
+
+
+@callback
+def _async_remove_legacy_plant_devices(hass: HomeAssistant, entry: ConfigEntry) -> int:
+    """Remove obsolete per-plant devices owned by this config entry."""
+    device_registry = dr.async_get(hass)
+    legacy_devices = [
+        device
+        for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+        if device.manufacturer == _LEGACY_PLANT_MANUFACTURER
+        and (
+            device.model == "Plant"
+            or (
+                device.model is not None
+                and device.model.startswith(_LEGACY_PLANT_MODEL_PREFIX)
+            )
+        )
+    ]
+    for device in legacy_devices:
+        device_registry.async_update_device(
+            device.id, remove_config_entry_id=entry.entry_id
+        )
+
+    if legacy_devices:
+        _LOGGER.info(
+            "Cleaned up %d legacy Plant device(s) for config entry %s",
+            len(legacy_devices),
+            entry.entry_id,
+        )
+    return len(legacy_devices)
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/growspace_manager/services/plant_facade.py
+++ b/custom_components/growspace_manager/services/plant_facade.py
@@ -27,8 +27,6 @@ from custom_components.growspace_manager.const import (
     ATTR_TRANSITION_DATE,
     CANONICAL_ID_MOTHER,
     DATE_FIELDS,
-    DOMAIN,
-    VERSION,
     GrowspaceService,
     NotificationTier,
     PlantStage,
@@ -56,7 +54,7 @@ from custom_components.growspace_manager.strain_library import StrainLibrary
 from custom_components.growspace_manager.utils import parse_date_field
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from ._definition import ServiceDefinition
@@ -93,19 +91,9 @@ class PlantFacade:
         return self._coordinator._nutrient_manager.get_applicable_presets(plant_id)
 
     async def add_plant(self, **kwargs: Any) -> Plant:
-        """Add a new plant and register its HA device."""
+        """Add a new plant."""
         plant = await self._coordinator._plant_manager.add_plant(**kwargs)
-        device_registry = dr.async_get(self._coordinator.hass)
         strain_name = plant.genetics.strain_name if plant.genetics else "Unknown"
-        device_registry.async_get_or_create(
-            config_entry_id=self._coordinator.config_entry.entry_id,
-            identifiers={(DOMAIN, plant.plant_id)},
-            name=strain_name,
-            model=f"Plant ({strain_name})" if strain_name else "Plant",
-            manufacturer="Growspace Manager",
-            sw_version=VERSION,
-            suggested_area=plant.growspace_id,
-        )
         _LOGGER.info(
             "Added plant %s (%s) to %s",
             strain_name,
@@ -115,14 +103,8 @@ class PlantFacade:
         return plant
 
     async def update_plant(self, plant_id: str, **kwargs: Any) -> Plant:
-        """Update an existing plant and sync its HA device name if changed."""
+        """Update an existing plant."""
         plant = await self._coordinator._plant_manager.update_plant(plant_id, **kwargs)
-        if "name" in kwargs:
-            device_registry = dr.async_get(self._coordinator.hass)
-            if device := device_registry.async_get_device(
-                identifiers={(DOMAIN, plant_id)}
-            ):
-                device_registry.async_update_device(device.id, name=kwargs["name"])
         _LOGGER.info("Updated plant %s", plant_id)
         return plant
 
@@ -446,7 +428,9 @@ class PlantFacade:
             ps.keeper = keeper
         if notes is not None:
             ps.notes = notes
-        await self._coordinator._plant_manager.update_plant(plant_id, phenotype_score=ps)
+        await self._coordinator._plant_manager.update_plant(
+            plant_id, phenotype_score=ps
+        )
         _LOGGER.info("Plant %s phenotype scored", plant_id)
 
     async def update_harvest_metrics(

--- a/tests/integration/test_facade_comprehensive.py
+++ b/tests/integration/test_facade_comprehensive.py
@@ -142,8 +142,8 @@ async def test_update_growspace_with_name_change(mock_coordinator) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_plant_registers_device(mock_coordinator) -> None:
-    """add_plant should create a device entry for the plant."""
+async def test_add_plant_does_not_register_device(mock_coordinator) -> None:
+    """add_plant should not create a device entry for the plant."""
     facade = ServiceFacade(mock_coordinator)
     plant = MagicMock()
     plant.plant_id = "p1"
@@ -152,12 +152,11 @@ async def test_add_plant_registers_device(mock_coordinator) -> None:
     plant.genetics.strain_name = "OG Kush"
     mock_coordinator._plant_manager.add_plant = AsyncMock(return_value=plant)
 
-    mock_dr = MagicMock()
-    with patch("homeassistant.helpers.device_registry.async_get", return_value=mock_dr):
+    with patch("homeassistant.helpers.device_registry.async_get") as async_get_registry:
         result = await facade.plants.add_plant(growspace_id="gs1", strain="OG Kush")
 
     assert result is plant
-    mock_dr.async_get_or_create.assert_called_once()
+    async_get_registry.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -170,13 +169,11 @@ async def test_add_plant_no_genetics(mock_coordinator) -> None:
     plant.genetics = None
     mock_coordinator._plant_manager.add_plant = AsyncMock(return_value=plant)
 
-    mock_dr = MagicMock()
-    with patch("homeassistant.helpers.device_registry.async_get", return_value=mock_dr):
+    with patch("homeassistant.helpers.device_registry.async_get") as async_get_registry:
         result = await facade.plants.add_plant(growspace_id="gs1", strain="")
 
     assert result is plant
-    call_kwargs = mock_dr.async_get_or_create.call_args.kwargs
-    assert call_kwargs["name"] == "Unknown"
+    async_get_registry.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_facade_coverage.py
+++ b/tests/integration/test_facade_coverage.py
@@ -11,24 +11,14 @@ from homeassistant.exceptions import ServiceValidationError
 
 @pytest.mark.asyncio
 async def test_update_plant_name_change(mock_coordinator, mock_plant) -> None:
-    """Test updating plant name updates the device name."""
+    """Test updating a Plant name does not access the device registry."""
     facade = ServiceFacade(mock_coordinator)
-    mock_coordinator._plant_manager.async_update_plant = AsyncMock(
-        return_value=mock_plant
-    )
+    mock_coordinator._plant_manager.update_plant = AsyncMock(return_value=mock_plant)
 
-    # Mock device registry
-    mock_dr = MagicMock()
-    mock_device = MagicMock()
-    mock_device.id = "device_1"
-    mock_dr.async_get_device.return_value = mock_device
-
-    with patch("homeassistant.helpers.device_registry.async_get", return_value=mock_dr):
+    with patch("homeassistant.helpers.device_registry.async_get") as async_get_registry:
         await facade.plants.update_plant("plant_1", name="New Plant Name")
 
-    mock_dr.async_update_device.assert_called_once_with(
-        "device_1", name="New Plant Name"
-    )
+    async_get_registry.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -160,4 +150,3 @@ async def test_growspace_lifecycle_services(mock_coordinator) -> None:
 
     await facade.growspaces.async_set_lighting_schedule("gs1", 12, 12, 12)
     assert gs.environment_config.veg_day_hours == 12
-

--- a/tests/integration/test_init_coverage.py
+++ b/tests/integration/test_init_coverage.py
@@ -195,6 +195,9 @@ async def test_async_setup_entry_pending_growspace_failure(hass: HomeAssistant) 
             new_callable=AsyncMock,
         ),
         patch(
+            "custom_components.growspace_manager._async_remove_legacy_plant_devices"
+        ) as mock_plant_device_cleanup,
+        patch(
             "custom_components.growspace_manager.async_create_issue"
         ) as mock_create_issue,
         patch.object(
@@ -203,6 +206,7 @@ async def test_async_setup_entry_pending_growspace_failure(hass: HomeAssistant) 
     ):
         assert await async_setup_entry(hass, entry) is True
 
+        mock_plant_device_cleanup.assert_called_once_with(hass, entry)
         mock_create_issue.assert_called_once()
 
 

--- a/tests/integration/test_plant_device_registry.py
+++ b/tests/integration/test_plant_device_registry.py
@@ -1,0 +1,159 @@
+"""Tests for the Plant device-registry boundary."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.growspace_manager import _async_remove_legacy_plant_devices
+from custom_components.growspace_manager.models import Plant
+from custom_components.growspace_manager.services.plant_facade import PlantFacade
+from homeassistant.core import ServiceCall
+
+
+async def test_adding_single_plant_leaves_device_count_unchanged() -> None:
+    """Adding one Plant must not create a Home Assistant device."""
+    coordinator = MagicMock()
+    coordinator._plant_manager.add_plant = AsyncMock(
+        return_value=Plant(plant_id="plant-1", growspace_id="growspace-1")
+    )
+    facade = PlantFacade(coordinator)
+    device_registry = MagicMock()
+    device_registry.devices = {"growspace-device": MagicMock()}
+    initial_device_count = len(device_registry.devices)
+
+    with patch(
+        "homeassistant.helpers.device_registry.async_get",
+        return_value=device_registry,
+    ) as async_get_registry:
+        await facade.add_plant(growspace_id="growspace-1", strain="OG Kush")
+
+    assert len(device_registry.devices) == initial_device_count
+    async_get_registry.assert_not_called()
+
+
+async def test_adding_plant_batch_leaves_device_count_unchanged() -> None:
+    """Adding a Plant batch must not create Home Assistant devices."""
+    coordinator = MagicMock()
+    coordinator.growspaces = {"growspace-1": MagicMock()}
+    coordinator.validator.find_first_available_position.return_value = (1, 1)
+    coordinator._plant_manager.add_plant = AsyncMock(
+        side_effect=[
+            Plant(plant_id="plant-1", growspace_id="growspace-1"),
+            Plant(plant_id="plant-2", growspace_id="growspace-1"),
+        ]
+    )
+    facade = PlantFacade(coordinator)
+    call = MagicMock(spec=ServiceCall)
+    call.data = {
+        "growspace_id": "growspace-1",
+        "strain": "OG Kush",
+        "amount": 2,
+    }
+    device_registry = MagicMock()
+    device_registry.devices = {"growspace-device": MagicMock()}
+    initial_device_count = len(device_registry.devices)
+
+    with patch(
+        "homeassistant.helpers.device_registry.async_get",
+        return_value=device_registry,
+    ) as async_get_registry:
+        await facade.add_plants_from_call(MagicMock(), MagicMock(), call)
+
+    assert len(device_registry.devices) == initial_device_count
+    async_get_registry.assert_not_called()
+
+
+def test_cleanup_removes_only_legacy_plant_devices_for_entry() -> None:
+    """Cleanup removes active and stale legacy devices without false positives."""
+    entry = SimpleNamespace(entry_id="target-entry")
+    devices = {
+        "active": SimpleNamespace(
+            id="active",
+            manufacturer="Growspace Manager",
+            model="Plant (OG Kush)",
+        ),
+        "stale": SimpleNamespace(
+            id="stale",
+            manufacturer="Growspace Manager",
+            model="Plant",
+        ),
+        "other-entry": SimpleNamespace(
+            id="other-entry",
+            manufacturer="Growspace Manager",
+            model="Plant (OG Kush)",
+        ),
+        "wrong-manufacturer": SimpleNamespace(
+            id="wrong-manufacturer",
+            manufacturer="Another Manufacturer",
+            model="Plant (OG Kush)",
+        ),
+        "similar-model": SimpleNamespace(
+            id="similar-model",
+            manufacturer="Growspace Manager",
+            model="Plant Sensor",
+        ),
+        "growspace": SimpleNamespace(
+            id="growspace",
+            manufacturer="Growspace Manager",
+            model="Growspace",
+        ),
+        "strain-library": SimpleNamespace(
+            id="strain-library",
+            manufacturer="Growspace Manager",
+            model="Strain Library",
+        ),
+        "service": SimpleNamespace(
+            id="service",
+            manufacturer="Growspace Manager",
+            model="Service",
+        ),
+    }
+    target_entry_device_ids = {
+        "active",
+        "stale",
+        "wrong-manufacturer",
+        "similar-model",
+        "growspace",
+        "strain-library",
+        "service",
+    }
+    device_registry = MagicMock()
+
+    def remove_entry_device(device_id: str, *, remove_config_entry_id: str) -> None:
+        assert remove_config_entry_id == entry.entry_id
+        devices.pop(device_id)
+
+    device_registry.async_update_device.side_effect = remove_entry_device
+
+    def devices_for_entry(
+        _device_registry: MagicMock, config_entry_id: str
+    ) -> list[SimpleNamespace]:
+        assert config_entry_id == entry.entry_id
+        return [
+            device
+            for device_id, device in devices.items()
+            if device_id in target_entry_device_ids
+        ]
+
+    with (
+        patch(
+            "custom_components.growspace_manager.dr.async_get",
+            return_value=device_registry,
+        ),
+        patch(
+            "custom_components.growspace_manager.dr.async_entries_for_config_entry",
+            side_effect=devices_for_entry,
+        ),
+    ):
+        assert _async_remove_legacy_plant_devices(MagicMock(), entry) == 2
+        assert set(devices) == {
+            "other-entry",
+            "wrong-manufacturer",
+            "similar-model",
+            "growspace",
+            "strain-library",
+            "service",
+        }
+
+        preserved_device_ids = set(devices)
+        assert _async_remove_legacy_plant_devices(MagicMock(), entry) == 0
+        assert set(devices) == preserved_device_ids

--- a/tests/integration/test_plant_facade_coverage.py
+++ b/tests/integration/test_plant_facade_coverage.py
@@ -5,12 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.growspace_manager.const import (
-    DOMAIN,
-    VERSION,
-    NotificationTier,
-    PlantStage,
-)
+from custom_components.growspace_manager.const import NotificationTier, PlantStage
 from custom_components.growspace_manager.models import Plant, PlantGenetics
 from custom_components.growspace_manager.services.plant_facade import PlantFacade
 from homeassistant.exceptions import ServiceValidationError
@@ -41,98 +36,53 @@ async def test_get_applicable_presets(mock_coordinator: MagicMock) -> None:
     facade = PlantFacade(mock_coordinator)
     mock_coordinator._nutrient_manager.get_applicable_presets.return_value = ["preset1"]
     assert facade.get_applicable_presets("plant_1") == ["preset1"]
-    mock_coordinator._nutrient_manager.get_applicable_presets.assert_called_once_with("plant_1")
+    mock_coordinator._nutrient_manager.get_applicable_presets.assert_called_once_with(
+        "plant_1"
+    )
 
 
 @pytest.mark.asyncio
 async def test_add_plant_success(mock_coordinator: MagicMock) -> None:
-    """Test add_plant successfully registers HA device."""
+    """Test add_plant delegates without registering an HA device."""
     facade = PlantFacade(mock_coordinator)
     plant = Plant(plant_id="plant_1", growspace_id="gs1")
     plant.genetics = PlantGenetics(strain_name="OG Kush", phenotype_name="Pheno 1")
     mock_coordinator._plant_manager.add_plant = AsyncMock(return_value=plant)
 
-    mock_dr = MagicMock()
-    mock_dr.async_get_or_create = MagicMock()
-
-    with patch("homeassistant.helpers.device_registry.async_get", return_value=mock_dr):
+    with patch("homeassistant.helpers.device_registry.async_get") as async_get_registry:
         result = await facade.add_plant(strain="OG Kush")
 
     assert result == plant
-    mock_dr.async_get_or_create.assert_called_once_with(
-        config_entry_id=mock_coordinator.config_entry.entry_id,
-        identifiers={(DOMAIN, "plant_1")},
-        name="OG Kush",
-        model="Plant (OG Kush)",
-        manufacturer="Growspace Manager",
-        sw_version=VERSION,
-        suggested_area="gs1",
-    )
+    async_get_registry.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_add_plant_success_no_genetics(mock_coordinator: MagicMock) -> None:
-    """Test add_plant successfully registers HA device with no genetics."""
+    """Test add_plant supports missing genetics without registering a device."""
     facade = PlantFacade(mock_coordinator)
     plant = Plant(plant_id="plant_1", growspace_id="gs1")
     plant.genetics = None
     mock_coordinator._plant_manager.add_plant = AsyncMock(return_value=plant)
 
-    mock_dr = MagicMock()
-    mock_dr.async_get_or_create = MagicMock()
-
-    with patch("homeassistant.helpers.device_registry.async_get", return_value=mock_dr):
+    with patch("homeassistant.helpers.device_registry.async_get") as async_get_registry:
         result = await facade.add_plant()
 
     assert result == plant
-    mock_dr.async_get_or_create.assert_called_once_with(
-        config_entry_id=mock_coordinator.config_entry.entry_id,
-        identifiers={(DOMAIN, "plant_1")},
-        name="Unknown",
-        model="Plant (Unknown)",
-        manufacturer="Growspace Manager",
-        sw_version=VERSION,
-        suggested_area="gs1",
-    )
+    async_get_registry.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_update_plant_name_no_device(mock_coordinator: MagicMock) -> None:
-    """Test update_plant when device is not found in the device registry."""
+    """Test update_plant does not access the device registry."""
     facade = PlantFacade(mock_coordinator)
     plant = Plant(plant_id="plant_123", growspace_id="gs1")
     mock_coordinator._plant_manager.update_plant = AsyncMock(return_value=plant)
 
-    # Mock device registry to return None (device not found)
-    mock_dr = MagicMock()
-    mock_dr.async_get_device.return_value = None
-
-    with patch("homeassistant.helpers.device_registry.async_get", return_value=mock_dr):
+    with patch("homeassistant.helpers.device_registry.async_get") as async_get_registry:
         result = await facade.update_plant("plant_123", name="New Name")
 
     assert result == plant
-    mock_dr.async_get_device.assert_called_once_with(identifiers={(DOMAIN, "plant_123")})
-    mock_dr.async_update_device.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_update_plant_device_success(mock_coordinator: MagicMock) -> None:
-    """Test update_plant when device is found and its name is updated in HA."""
-    facade = PlantFacade(mock_coordinator)
-    plant = Plant(plant_id="plant_123", growspace_id="gs1")
-    mock_coordinator._plant_manager.update_plant = AsyncMock(return_value=plant)
-
-    mock_dr = MagicMock()
-    mock_device = MagicMock()
-    mock_device.id = "dev_123"
-    mock_dr.async_get_device.return_value = mock_device
-
-    with patch("homeassistant.helpers.device_registry.async_get", return_value=mock_dr):
-        result = await facade.update_plant("plant_123", name="New Name")
-
-    assert result == plant
-    mock_dr.async_get_device.assert_called_once_with(identifiers={(DOMAIN, "plant_123")})
-    mock_dr.async_update_device.assert_called_once_with("dev_123", name="New Name")
+    async_get_registry.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -142,7 +92,9 @@ async def test_remove_plant_not_removed(mock_coordinator: MagicMock) -> None:
     mock_coordinator._plant_manager.remove_plant = AsyncMock(return_value=False)
 
     # We patch remove_plant_entities to verify it is not called
-    with patch.object(facade, "remove_plant_entities", new_callable=AsyncMock) as mock_remove_entities:
+    with patch.object(
+        facade, "remove_plant_entities", new_callable=AsyncMock
+    ) as mock_remove_entities:
         result = await facade.remove_plant("plant_123")
 
     assert result is False
@@ -155,7 +107,9 @@ async def test_remove_plant_success(mock_coordinator: MagicMock) -> None:
     facade = PlantFacade(mock_coordinator)
     mock_coordinator._plant_manager.remove_plant = AsyncMock(return_value=True)
 
-    with patch.object(facade, "remove_plant_entities", new_callable=AsyncMock) as mock_remove_entities:
+    with patch.object(
+        facade, "remove_plant_entities", new_callable=AsyncMock
+    ) as mock_remove_entities:
         result = await facade.remove_plant("plant_123")
 
     assert result is True
@@ -169,7 +123,9 @@ async def test_async_remove_plant(mock_coordinator: MagicMock) -> None:
     mock_coordinator._plant_manager.remove_plant = AsyncMock(return_value=True)
 
     # Patch remove_plant_entities to avoid HA registry calls
-    with patch.object(facade, "remove_plant_entities", new_callable=AsyncMock) as mock_remove_entities:
+    with patch.object(
+        facade, "remove_plant_entities", new_callable=AsyncMock
+    ) as mock_remove_entities:
         result = await facade.async_remove_plant("plant_123")
 
     assert result is True
@@ -271,7 +227,9 @@ async def test_switch_plants(mock_coordinator: MagicMock) -> None:
 
     await facade.switch_plants("plant1", "plant2")
 
-    mock_coordinator._plant_manager.switch_plants.assert_called_once_with("plant1", "plant2")
+    mock_coordinator._plant_manager.switch_plants.assert_called_once_with(
+        "plant1", "plant2"
+    )
 
 
 @pytest.mark.asyncio
@@ -544,11 +502,15 @@ async def test_score_plant_success_full(mock_coordinator: MagicMock) -> None:
     assert ps.keeper is True
     assert ps.notes == "Amazing vigor and resin"
 
-    mock_coordinator._plant_manager.update_plant.assert_called_once_with("plant_123", phenotype_score=ps)
+    mock_coordinator._plant_manager.update_plant.assert_called_once_with(
+        "plant_123", phenotype_score=ps
+    )
 
 
 @pytest.mark.asyncio
-async def test_score_plant_success_alternative_names(mock_coordinator: MagicMock) -> None:
+async def test_score_plant_success_alternative_names(
+    mock_coordinator: MagicMock,
+) -> None:
     """Test score_plant success path covering non-legacy names (e.g. internodal_spacing, terpene_intensity, mold_resistance)."""
     facade = MagicMock()
     facade = PlantFacade(mock_coordinator)
@@ -568,7 +530,9 @@ async def test_score_plant_success_alternative_names(mock_coordinator: MagicMock
     assert ps.terpene_intensity == 8
     assert ps.mold_resistance == 7
 
-    mock_coordinator._plant_manager.update_plant.assert_called_once_with("plant_123", phenotype_score=ps)
+    mock_coordinator._plant_manager.update_plant.assert_called_once_with(
+        "plant_123", phenotype_score=ps
+    )
 
 
 @pytest.mark.asyncio
@@ -607,7 +571,9 @@ async def test_update_harvest_metrics_success(mock_coordinator: MagicMock) -> No
     assert metrics.cbd_percentage == 0.8
     assert metrics.terpene_profile == "Myrcene, Limonene"
 
-    mock_coordinator._plant_manager.update_plant.assert_called_once_with("plant_123", harvest_metrics=metrics)
+    mock_coordinator._plant_manager.update_plant.assert_called_once_with(
+        "plant_123", harvest_metrics=metrics
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- stop creating Home Assistant device-registry entries when adding individual Plants or Plant batches
- stop synchronizing Plant names to obsolete per-Plant devices
- remove legacy Plant devices during every config-entry setup when the config entry, `Growspace Manager` manufacturer, and `Plant` model fingerprint match
- preserve Growspace, Strain Library, service, near-match, and other-config-entry devices
- keep Plant entities attached to their existing Growspace devices

## Why

Plants are Growspace Manager records rather than physical Home Assistant devices. Registering every Plant produced empty strain-named devices and made device counts grow with crop records.

The setup cleanup also removes obsolete devices for active and already-deleted Plants. It detaches only the current config entry, so shared devices remain available to other entries. Repeated cleanup is idempotent.

## Validation

- `4905 passed in 119.05s`
- focused Plant device/facade/setup tests: 165 passed
- real integration setup and Growspace device tests: 13 passed
- ruff check and format passed
- codespell and prettier passed
- mypy remains non-blocking and reports the repository's existing baseline errors; no errors occur on the modified lines

Closes #555
