### PR TITLE
Create dedicated Strain Library device

### DIFF
--- a/custom_components/growspace_manager/managers/lineage.py
+++ b/custom_components/growspace_manager/managers/lineage.py
@@ -264,7 +264,7 @@ class StrainLineageManager:
             if ancestor_name == root_strain_name:
                 continue
             await self._db.execute(
-                "INSERT OR IGNORE INTO strains (strain_name) VALUES (?)",
+                "INSERT OR IGNORE INTO strains (strain_name, is_stub) VALUES (?, 1)",
                 (ancestor_name,),
             )
             await self._db.execute(
@@ -281,14 +281,6 @@ class StrainLineageManager:
             await self._db.execute(
                 "UPDATE strains SET lineage_tree = ?, lineage = ? WHERE strain_name = ?",
                 (json.dumps(library_parents), flat_lineage, name),
-            )
-
-        for ancestor_name in all_names:
-            if ancestor_name == root_strain_name:
-                continue
-            await self._db.execute(
-                "UPDATE strains SET is_stub = 1 WHERE strain_name = ? AND breeder IS NULL",
-                (ancestor_name,),
             )
 
         await self._db.commit()

--- a/custom_components/growspace_manager/sensor/strain.py
+++ b/custom_components/growspace_manager/sensor/strain.py
@@ -13,6 +13,13 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
+STRAIN_LIBRARY_DEVICE_INFO = DeviceInfo(
+    identifiers={(DOMAIN, "strain_library")},
+    name="Strain Library",
+    model="Strain Library",
+    manufacturer="Growspace Manager",
+)
+
 
 class StrainLibrarySensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type: ignore[misc]
     """A sensor that provides analytics from the user's strain library."""
@@ -29,28 +36,48 @@ class StrainLibrarySensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity)
         self._attr_unique_id = f"{DOMAIN}_strain_library"
         self._attr_translation_key = "strain_library"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, "service")},
-            name="Growspace Manager Service",
-            model="Service",
-            manufacturer="Growspace Manager",
+        self._attr_device_info = STRAIN_LIBRARY_DEVICE_INFO
+
+    @staticmethod
+    def _strain_counts(strains: dict[str, dict[str, Any]]) -> tuple[int, int, int]:
+        """Return catalogued, ancestor, and total strain counts."""
+        ancestor_count = sum(
+            bool(data.get("meta", {}).get("is_stub", False))
+            for data in strains.values()
         )
+        total_count = len(strains)
+        return total_count - ancestor_count, ancestor_count, total_count
 
     @property
     @override  # type: ignore[misc]
     def native_value(self) -> int:
-        """Return the number of unique strains in the library."""
-        return len(self.coordinator.services.config.strain_library.get_all())
+        """Return the number of catalogued strains in the library."""
+        strains = self.coordinator.services.config.strain_library.get_all()
+        catalogued_count, _, _ = self._strain_counts(strains)
+        return catalogued_count
 
     @property
     @override  # type: ignore[misc]
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return strain analytics as state attributes."""
         analytics = self.coordinator.services.config.strain_library.get_analytics()
+        strains = self.coordinator.services.config.strain_library.get_all()
+        catalogued_count, ancestor_count, total_count = self._strain_counts(strains)
+        catalogued_strains = {
+            name
+            for name, data in strains.items()
+            if not data.get("meta", {}).get("is_stub", False)
+        }
 
         return {
-            "strain_count": len(analytics.get("strains", {})),
-            "strain_list": analytics.get("strain_list", []),
+            "strain_count": catalogued_count,
+            "ancestor_strain_count": ancestor_count,
+            "total_strain_count": total_count,
+            "strain_list": [
+                name
+                for name in analytics.get("strain_list", [])
+                if name in catalogued_strains
+            ],
             "last_updated": dt_util.utcnow().isoformat(),
             "note": "Full analytics available via WebSocket API: growspace_manager/get_strain_library",
         }
@@ -68,12 +95,7 @@ class SeedInventorySensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity)
         """Initialize the seed inventory sensor."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{DOMAIN}_seed_inventory"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, "service")},
-            name="Growspace Manager Service",
-            model="Service",
-            manufacturer="Growspace Manager",
-        )
+        self._attr_device_info = STRAIN_LIBRARY_DEVICE_INFO
 
     @property
     @override  # type: ignore[misc]

--- a/tests/integration/test_strain_library_device_registry.py
+++ b/tests/integration/test_strain_library_device_registry.py
@@ -1,0 +1,36 @@
+"""Tests for the Strain Library device-registry boundary."""
+
+from unittest.mock import MagicMock
+
+from custom_components.growspace_manager.sensor import (
+    GrowspaceListSensor,
+    SeedInventorySensor,
+    StrainLibrarySensor,
+    VpdSensor,
+)
+
+
+def test_genetics_entities_share_one_dedicated_device() -> None:
+    """Strain Library and Seed Inventory resolve to one dedicated device."""
+    coordinator = MagicMock()
+
+    strain_library = StrainLibrarySensor(coordinator)
+    seed_inventory = SeedInventorySensor(coordinator)
+
+    assert strain_library.device_info == seed_inventory.device_info
+    assert strain_library.device_info["identifiers"] == {
+        ("growspace_manager", "strain_library")
+    }
+
+
+def test_general_overview_and_vpd_remain_on_service_device() -> None:
+    """General overview and global VPD retain service-device ownership."""
+    coordinator = MagicMock()
+    coordinator.plants = {}
+    coordinator.growspaces = {}
+
+    overview = GrowspaceListSensor(coordinator)
+    vpd = VpdSensor(coordinator, "outside", "Outside VPD", None, None, None)
+
+    assert overview.device_info["identifiers"] == {("growspace_manager", "service")}
+    assert vpd.device_info["identifiers"] == {("growspace_manager", "service")}

--- a/tests/test_seed_inventory_sensor.py
+++ b/tests/test_seed_inventory_sensor.py
@@ -61,10 +61,12 @@ class TestSeedInventorySensor:
         assert batches[0]["strain_name"] == "OG Kush"
         assert batches[0]["quantity"] == 10
 
-    def test_device_info_uses_service_device(self, coordinator):
-        """Sensor attaches to the service device (not a growspace)."""
+    def test_device_info_uses_strain_library_device(self, coordinator):
+        """Sensor attaches to the dedicated Strain Library device."""
         sensor = SeedInventorySensor(coordinator)
         assert sensor.device_info is not None
         identifiers = dict(sensor.device_info.get("identifiers", set()))
         assert "growspace_manager" in identifiers
-        assert identifiers["growspace_manager"] == "service"
+        assert identifiers["growspace_manager"] == "strain_library"
+        assert sensor.device_info["name"] == "Strain Library"
+        assert sensor.device_info["model"] == "Strain Library"

--- a/tests/test_strain_library_sensor.py
+++ b/tests/test_strain_library_sensor.py
@@ -1,4 +1,5 @@
 """Tests for StrainLibrarySensor — performance optimization."""
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock
@@ -11,6 +12,7 @@ def _make_sensor() -> StrainLibrarySensor:
     coordinator = MagicMock()
     coordinator.services.config.strain_library.get_all.return_value = {
         "OG Kush": {"meta": {}, "phenotypes": {}},
+        "Hindu Kush": {"meta": {"is_stub": True}, "phenotypes": {}},
     }
     coordinator.services.config.strain_library.get_analytics.return_value = {
         "strains": {"OG Kush": {}},
@@ -39,4 +41,22 @@ def test_strain_library_sensor_analytics_basics() -> None:
     sensor = _make_sensor()
     attrs = sensor.extra_state_attributes
     assert attrs["strain_count"] == 1
+    assert attrs["ancestor_strain_count"] == 1
+    assert attrs["total_strain_count"] == 2
     assert attrs["strain_list"] == ["OG Kush"]
+
+
+def test_strain_library_sensor_state_counts_only_catalogued_strains() -> None:
+    """The state excludes lineage-only ancestor strains."""
+    sensor = _make_sensor()
+    assert sensor.native_value == 1
+
+
+def test_strain_library_sensor_uses_dedicated_device() -> None:
+    """The Strain Library sensor uses the same dedicated device identifier."""
+    coordinator = MagicMock()
+    sensor = StrainLibrarySensor(coordinator)
+    assert sensor.device_info is not None
+    assert sensor.device_info["identifiers"] == {
+        ("growspace_manager", "strain_library")
+    }

--- a/tests/test_stub_flag.py
+++ b/tests/test_stub_flag.py
@@ -34,19 +34,16 @@ async def test_import_lineage_marks_ancestors_as_stubs():
 
     await lib.async_import_seedfinder_lineage_tree(root, tree)
 
-    stub_update_sqls = [
+    stub_insert_sqls = [
         (sql, params)
         for sql, params in execute_calls
-        if "is_stub" in sql and "UPDATE" in sql
+        if "is_stub" in sql and "INSERT OR IGNORE INTO strains" in sql
     ]
-    marked = {params[0] for _, params in stub_update_sqls if params}
+    marked = {params[0] for _, params in stub_insert_sqls if params}
     assert "Blueberry" in marked
     assert "Haze" in marked
     assert "Blue Dream" not in marked
-    for sql, _ in stub_update_sqls:
-        assert "breeder IS NULL" in sql, (
-            "Stub UPDATE must guard against overwriting real entries"
-        )
+    assert not any("UPDATE strains SET is_stub = 1" in sql for sql, _ in execute_calls)
 
 
 @pytest.mark.asyncio
@@ -93,6 +90,7 @@ async def test_add_strain_clears_stub_flag():
     lib._db.executemany = AsyncMock()
     lib._db.commit = AsyncMock()
     lib._analytics_cache = None
+    lib.load = AsyncMock()
     lib.image_manager = MagicMock()
     lib.image_manager.save_strain_image = AsyncMock(return_value="/tmp/img.webp")
 
@@ -103,14 +101,72 @@ async def test_add_strain_clears_stub_flag():
         None,
     )
     assert upsert_sql is not None, "Expected INSERT OR REPLACE INTO strains"
-    assert "is_stub" in upsert_sql, "ON CONFLICT clause must set is_stub = 0"
+    assert "is_stub=0" in upsert_sql
+    assert "lineage=COALESCE(excluded.lineage, lineage)" in upsert_sql
+    assert "lineage_tree=COALESCE(excluded.lineage_tree, lineage_tree)" in upsert_sql
+
+
+@pytest.mark.asyncio
+async def test_editing_ancestor_uses_promoting_add_path() -> None:
+    """Editing an ancestor uses add_strain, which clears the ancestor flag."""
+    from custom_components.growspace_manager.strain_library import StrainLibrary
+
+    lib = StrainLibrary(MagicMock())
+    lib.add_strain = AsyncMock()
+
+    await lib.set_strain_meta(strain="Haze", strain_description="Managed")
+
+    lib.add_strain.assert_awaited_once_with(
+        strain="Haze",
+        phenotype=None,
+        breeder=None,
+        breeder_logo=None,
+        strain_type=None,
+        lineage=None,
+        sex=None,
+        flower_days_min=None,
+        flower_days_max=None,
+        description=None,
+        image_base64=None,
+        image_path=None,
+        image_crop_meta=None,
+        images=None,
+        sativa_percentage=None,
+        indica_percentage=None,
+        yield_potential=None,
+        height=None,
+        thc=None,
+        cbd=None,
+        cbg=None,
+        effects=None,
+        aroma=None,
+        taste=None,
+        strain_description="Managed",
+        awards=None,
+        lineage_tree=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_importing_ancestor_uses_promoting_add_path() -> None:
+    """Explicitly importing an ancestor uses add_strain to promote it."""
+    from custom_components.growspace_manager.strain_library import StrainLibrary
+
+    lib = StrainLibrary(MagicMock())
+    lib.add_strain = AsyncMock()
+    lib.load = AsyncMock()
+
+    await lib.import_strains(["Haze"])
+
+    lib.add_strain.assert_awaited_once_with("Haze")
 
 
 @pytest.mark.asyncio
 async def test_load_populates_is_stub_from_db():
-    """load() must read is_stub from the DB row and store it as a bool in meta."""
+    """A managed ancestor is promoted while retaining its lineage."""
     import aiosqlite
 
+    from custom_components.growspace_manager.sensor import StrainLibrarySensor
     from custom_components.growspace_manager.strain_library import (
         STRAIN_LIBRARY_SCHEMA,
         StrainLibrary,
@@ -130,9 +186,17 @@ async def test_load_populates_is_stub_from_db():
         await db.execute("ALTER TABLE phenotypes ADD COLUMN images TEXT")
         await db.commit()
 
-        # Insert one stub (no breeder) and one real entry
         await db.execute(
-            "INSERT INTO strains (strain_name, is_stub) VALUES (?, ?)", ("Haze", 1)
+            """
+            INSERT INTO strains (strain_name, lineage, lineage_tree, is_stub)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                "Haze",
+                "Thai",
+                '[{"name": "Thai", "source": "library"}]',
+                1,
+            ),
         )
         await db.execute(
             "INSERT INTO strains (strain_name, breeder, is_stub) VALUES (?, ?, ?)",
@@ -149,8 +213,24 @@ async def test_load_populates_is_stub_from_db():
         lib._db = db
         await lib.load()
 
-    assert "Haze" in lib.strains
-    assert lib.strains["Haze"]["meta"]["is_stub"] is True
+        coordinator = MagicMock()
+        coordinator.services.config.strain_library = lib
+        sensor = StrainLibrarySensor(coordinator)
 
+        assert sensor.native_value == 1
+        assert sensor.extra_state_attributes["ancestor_strain_count"] == 1
+        assert sensor.extra_state_attributes["total_strain_count"] == 2
+
+        await lib.add_strain("Haze", breeder="Explicitly managed")
+
+        assert sensor.native_value == 2
+        assert sensor.extra_state_attributes["ancestor_strain_count"] == 0
+        assert sensor.extra_state_attributes["total_strain_count"] == 2
+
+    assert lib.strains["Haze"]["meta"]["is_stub"] is False
+    assert lib.strains["Haze"]["meta"]["lineage"] == "Thai"
+    assert lib.strains["Haze"]["meta"]["lineage_tree"] == [
+        {"name": "Thai", "source": "library"}
+    ]
     assert "OG Kush" in lib.strains
     assert lib.strains["OG Kush"]["meta"]["is_stub"] is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Create a dedicated Strain Library device as the Home Assistant boundary for genetics diagnostics. The Strain Library and Seed Inventory entities now share that device, while the general overview and global VPD entities remain on the Growspace Manager Service device.

The Strain Library sensor state now counts only catalogued strains and exposes separate ancestor and total counts. Explicitly adding, editing, or importing a lineage-only ancestor promotes it without changing its lineage. Seedfinder lineage imports mark only newly created ancestors, avoiding accidental demotion of existing catalogued strains and avoiding per-strain devices.

Validation:
- 52 focused tests passed.
- The repository pytest pre-commit hook passed.
- Scoped Ruff, formatting, codespell, JSON, YAML, and Prettier checks passed.
- Repository-wide mypy still reports pre-existing errors outside this change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #556
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
