### PR TITLE
Make Catalogued Strain deletion reference-aware

### DIFF
--- a/custom_components/growspace_manager/exceptions.py
+++ b/custom_components/growspace_manager/exceptions.py
@@ -40,3 +40,29 @@ class GrowspaceNotFoundError(EntityNotFoundError):
 
 class ValidationChangeError(GrowspaceError):
     """Raised when a validation check fails for a state change."""
+
+
+class StrainReferenceError(ValidationChangeError):
+    """Raised when cultivation records prevent removing a strain."""
+
+    def __init__(
+        self, strain: str, *, plant_count: int = 0, has_harvest_history: bool = False
+    ) -> None:
+        """Describe the references that must be resolved before removal."""
+        references = []
+        if plant_count:
+            record = "record" if plant_count == 1 else "records"
+            references.append(f"{plant_count} Plant {record}")
+        if has_harvest_history:
+            references.append("harvest history")
+        reference_summary = " and ".join(references)
+        verb = (
+            "references"
+            if (plant_count == 1 and not has_harvest_history)
+            or (not plant_count and has_harvest_history)
+            else "reference"
+        )
+        super().__init__(
+            f"Cannot remove strain '{strain}': {reference_summary} still {verb} it. "
+            "Resolve the cultivation references first."
+        )

--- a/custom_components/growspace_manager/strain_library.py
+++ b/custom_components/growspace_manager/strain_library.py
@@ -14,10 +14,12 @@ from typing import Any
 
 import aiosqlite
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util, slugify
 
-from .const import DB_FILE_STRAIN_LIBRARY
+from .const import DB_FILE_STRAIN_LIBRARY, DOMAIN
+from .exceptions import StrainReferenceError
 from .image_manager import ImageManager
 from .import_export_manager import ImportExportManager
 from .managers.lineage import StrainLineageManager
@@ -1162,7 +1164,7 @@ class StrainLibrary:
         _LOGGER.info("Removed phenotype %s from strain %s", phenotype, strain)
 
     async def remove_strain(self, strain: str) -> None:
-        """Remove an entire strain and all related data."""
+        """Remove, demote, or reject removal according to strain references."""
         if self._db is None:
             _LOGGER.warning("Database not connected, cannot remove strain")
             return
@@ -1178,20 +1180,116 @@ class StrainLibrary:
                 )
                 return
             strain_id = row[0]
-        # Delete harvests, phenotypes, strain
-        await self._db.execute(
-            "DELETE FROM harvests WHERE phenotype_id IN (SELECT phenotype_id FROM phenotypes WHERE strain_id = ?)",
+
+        plant_count = self._count_plant_references(strain_id, strain)
+        async with self._db.execute(
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM harvests h
+                JOIN phenotypes p ON p.phenotype_id = h.phenotype_id
+                WHERE p.strain_id = ?
+            )
+            """,
             (strain_id,),
-        )
+        ) as cur:
+            reference_row = await cur.fetchone()
+            has_harvest_history = bool(reference_row and reference_row[0])
+        if plant_count or has_harvest_history:
+            raise StrainReferenceError(
+                strain,
+                plant_count=plant_count,
+                has_harvest_history=has_harvest_history,
+            )
+
+        async with self._db.execute(
+            "SELECT phenotype_name FROM phenotypes WHERE strain_id = ?", (strain_id,)
+        ) as cur:
+            phenotype_names = [row[0] for row in await cur.fetchall()]
+        async with self._db.execute(
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM strain_ancestry
+                WHERE ancestor_name = ? AND descendant_strain_id != ?
+            )
+            """,
+            (strain, strain_id),
+        ) as cur:
+            reference_row = await cur.fetchone()
+            has_lineage_references = bool(reference_row and reference_row[0])
+
         await self._db.execute(
             "DELETE FROM phenotypes WHERE strain_id = ?", (strain_id,)
         )
-        await self._db.execute("DELETE FROM strains WHERE strain_id = ?", (strain_id,))
+        if has_lineage_references:
+            await self._db.execute(
+                """
+                UPDATE strains SET
+                    breeder = NULL,
+                    breeder_logo = NULL,
+                    type = NULL,
+                    sex = NULL,
+                    generation = NULL,
+                    sativa_percentage = NULL,
+                    indica_percentage = NULL,
+                    yield_potential = NULL,
+                    height = NULL,
+                    thc = NULL,
+                    awards = NULL,
+                    cbd = NULL,
+                    cbg = NULL,
+                    effects = NULL,
+                    aroma = NULL,
+                    taste = NULL,
+                    description = NULL,
+                    is_indoor = NULL,
+                    is_outdoor = NULL,
+                    is_greenhouse = NULL,
+                    is_stub = 1
+                WHERE strain_id = ?
+                """,
+                (strain_id,),
+            )
+        else:
+            await self._db.execute(
+                "DELETE FROM strain_ancestry WHERE descendant_strain_id = ?",
+                (strain_id,),
+            )
+            await self._db.execute(
+                "DELETE FROM strains WHERE strain_id = ?", (strain_id,)
+            )
         await self._db.commit()
+
+        safe_strain = slugify(strain)
+        for phenotype_name in phenotype_names:
+            self.image_manager.delete_image(
+                safe_strain, slugify(phenotype_name or "default")
+            )
+
         # Invalidate cache and reload
         self._analytics.invalidate()
         await self.load()
-        _LOGGER.info("Removed strain %s from library", strain)
+        if has_lineage_references:
+            _LOGGER.info("Demoted strain %s to an ancestor strain", strain)
+        else:
+            _LOGGER.info("Removed strain %s from library", strain)
+
+    def _count_plant_references(self, strain_id: int, strain_name: str) -> int:
+        """Count plants across loaded config entries that reference a strain."""
+        plant_ids: set[str] = set()
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if entry.state != ConfigEntryState.LOADED:
+                continue
+            coordinator = getattr(entry, "runtime_data", None)
+            plants = getattr(coordinator, "plants", {}) if coordinator else {}
+            for plant in plants.values():
+                genetics = getattr(plant, "genetics", None)
+                if genetics is None:
+                    continue
+                referenced_id = getattr(genetics, "strain_id", None)
+                referenced_name = getattr(genetics, "strain_name", "").strip()
+                if referenced_id == strain_id or referenced_name == strain_name:
+                    plant_ids.add(plant.plant_id)
+        return len(plant_ids)
 
     def get_all(self) -> dict[str, dict[str, Any]]:
         """Return the raw in‑memory strain dictionary."""

--- a/tests/services/test_strain_library.py
+++ b/tests/services/test_strain_library.py
@@ -1,13 +1,18 @@
 """Tests for the StrainLibrary class."""
 
+from copy import deepcopy
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiosqlite
 import pytest
 
+from custom_components.growspace_manager.exceptions import StrainReferenceError
 from custom_components.growspace_manager.image_manager import ImageManager
+from custom_components.growspace_manager.models import Plant, PlantGenetics
 from custom_components.growspace_manager.strain_library import StrainLibrary
+from homeassistant.config_entries import ConfigEntryState
 
 
 @pytest.fixture
@@ -183,6 +188,188 @@ async def test_remove_strain(strain_library: StrainLibrary) -> None:
 
     await strain_library.remove_strain("Sour Diesel")
     assert "Sour Diesel" not in strain_library.strains
+
+
+async def _add_catalogued_strain(
+    strain_library: StrainLibrary, *, descendants: tuple[str, ...] = ()
+) -> None:
+    """Add a fully managed strain and optionally a descendant that references it."""
+    await strain_library.add_strain(
+        "Target Strain",
+        "Keeper",
+        breeder="Breeder",
+        breeder_logo="/local/breeder.webp",
+        strain_type="Hybrid",
+        lineage="Parent Strain",
+        sex="Feminized",
+        description="Phenotype notes",
+        image_path="/local/target-strain_keeper.webp",
+        images=[{"path": "/local/target-strain_keeper_2.webp"}],
+        sativa_percentage=60,
+        yield_potential="High",
+        thc=24,
+        effects=["Happy"],
+        strain_description="Catalogue notes",
+        awards=["Cup"],
+        lineage_tree={
+            "name": "Target Strain",
+            "parents": [{"name": "Parent Strain", "source": "library"}],
+        },
+    )
+    for descendant in descendants:
+        await strain_library.add_strain(
+            descendant,
+            lineage_tree={
+                "name": descendant,
+                "parents": [{"name": "Target Strain", "source": "library"}],
+            },
+        )
+
+
+def _set_plant_references(strain_library: StrainLibrary, count: int) -> None:
+    """Expose loaded coordinators containing plants that reference the target."""
+    plants = {
+        f"plant-{index}": Plant(
+            plant_id=f"plant-{index}",
+            growspace_id="veg",
+            genetics=PlantGenetics(strain_name="Target Strain"),
+        )
+        for index in range(count)
+    }
+    coordinator = SimpleNamespace(plants=plants)
+    entry = SimpleNamespace(
+        state=ConfigEntryState.LOADED,
+        runtime_data=coordinator,
+    )
+    strain_library.hass.config_entries.async_entries.return_value = [entry]
+
+
+async def _database_snapshot(strain_library: StrainLibrary) -> dict[str, list[tuple]]:
+    """Return all deletion-relevant rows for atomicity assertions."""
+    assert strain_library._db is not None
+    snapshot = {}
+    for table in ("strains", "phenotypes", "harvests", "strain_ancestry"):
+        async with strain_library._db.execute(
+            f"SELECT * FROM {table} ORDER BY 1"  # noqa: S608
+        ) as cursor:
+            snapshot[table] = [tuple(row) for row in await cursor.fetchall()]
+    return snapshot
+
+
+@pytest.mark.parametrize(
+    ("plant_count", "harvest_count", "descendants", "reference_message"),
+    [
+        pytest.param(1, 0, (), "1 Plant record", id="plant"),
+        pytest.param(0, 1, (), "harvest history", id="harvest"),
+        pytest.param(2, 1, (), "2 Plant records and harvest history", id="both"),
+        pytest.param(1, 0, ("Child",), "1 Plant record", id="plant-and-lineage"),
+        pytest.param(0, 1, ("Child",), "harvest history", id="harvest-and-lineage"),
+        pytest.param(
+            2,
+            1,
+            ("Child",),
+            "2 Plant records and harvest history",
+            id="all-references",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_remove_strain_rejects_cultivation_references_without_changes(
+    strain_library: StrainLibrary,
+    plant_count: int,
+    harvest_count: int,
+    descendants: tuple[str, ...],
+    reference_message: str,
+) -> None:
+    """Cultivation references block deletion before catalogue data is changed."""
+    await _add_catalogued_strain(strain_library, descendants=descendants)
+    _set_plant_references(strain_library, plant_count)
+    for _ in range(harvest_count):
+        await strain_library.record_harvest("Target Strain", "Keeper", 28, 63)
+    database_before = await _database_snapshot(strain_library)
+    cache_before = deepcopy(strain_library.strains)
+
+    with pytest.raises(StrainReferenceError, match=reference_message):
+        await strain_library.remove_strain("Target Strain")
+
+    assert await _database_snapshot(strain_library) == database_before
+    assert strain_library.strains == cache_before
+
+
+@pytest.mark.asyncio
+async def test_remove_lineage_referenced_strain_demotes_to_ancestor(
+    strain_library: StrainLibrary, mock_image_manager: ImageManager
+) -> None:
+    """A lineage-only reference retains identity and parents but clears catalogue data."""
+    await _add_catalogued_strain(strain_library, descendants=("Child Strain",))
+    _set_plant_references(strain_library, 0)
+
+    await strain_library.remove_strain("Target Strain")
+
+    assert strain_library._db is not None
+    async with strain_library._db.execute(
+        "SELECT * FROM strains WHERE strain_name = ?", ("Target Strain",)
+    ) as cursor:
+        row = dict(await cursor.fetchone())
+    assert row == {
+        "strain_id": row["strain_id"],
+        "strain_name": "Target Strain",
+        "breeder": None,
+        "breeder_logo": None,
+        "type": None,
+        "lineage": "Parent Strain",
+        "sex": None,
+        "sativa_percentage": None,
+        "indica_percentage": None,
+        "yield_potential": None,
+        "height": None,
+        "thc": None,
+        "awards": None,
+        "lineage_tree": '[{"name": "Parent Strain", "source": "library"}]',
+        "cbd": None,
+        "cbg": None,
+        "effects": None,
+        "aroma": None,
+        "taste": None,
+        "description": None,
+        "is_indoor": None,
+        "is_outdoor": None,
+        "is_greenhouse": None,
+        "is_stub": 1,
+        "generation": None,
+    }
+    async with strain_library._db.execute(
+        "SELECT COUNT(*) FROM phenotypes WHERE strain_id = ?", (row["strain_id"],)
+    ) as cursor:
+        assert (await cursor.fetchone())[0] == 0
+    async with strain_library._db.execute(
+        "SELECT ancestor_name FROM strain_ancestry WHERE descendant_strain_id = ?",
+        (row["strain_id"],),
+    ) as cursor:
+        assert [item[0] for item in await cursor.fetchall()] == ["Parent Strain"]
+    assert strain_library.strains["Target Strain"]["meta"]["is_stub"] is True
+    assert strain_library.strains["Target Strain"]["phenotypes"] == {}
+    mock_image_manager.delete_image.assert_called_once_with("target_strain", "keeper")
+
+
+@pytest.mark.asyncio
+async def test_remove_unreferenced_strain_deletes_everything(
+    strain_library: StrainLibrary, mock_image_manager: ImageManager
+) -> None:
+    """An entirely unreferenced strain is removed rather than demoted."""
+    await _add_catalogued_strain(strain_library)
+    _set_plant_references(strain_library, 0)
+
+    await strain_library.remove_strain("Target Strain")
+
+    assert "Target Strain" not in strain_library.strains
+    assert strain_library._db is not None
+    for table in ("strains", "phenotypes", "strain_ancestry"):
+        async with strain_library._db.execute(
+            f"SELECT COUNT(*) FROM {table}"  # noqa: S608
+        ) as cursor:
+            assert (await cursor.fetchone())[0] == 0
+    mock_image_manager.delete_image.assert_called_once_with("target_strain", "keeper")
 
 
 @pytest.mark.asyncio
@@ -1048,4 +1235,3 @@ async def test_resolve_thumbnail_none_exists(strain_library: StrainLibrary) -> N
 
     thumbnail = strain_library.resolve_thumbnail("OG Kush", "Pheno A")
     assert thumbnail is None
-


### PR DESCRIPTION
## Summary

- reject Catalogued Strain removal while Plant records or harvest history still reference it
- demote lineage-only strains to minimal Ancestor Strains while retaining their canonical name and parent relationships
- fully delete strains with no cultivation or lineage references
- remove catalogue metadata, phenotypes, and associated strain images during demotion or deletion
- cover every Plant, harvest, and lineage reference combination and assert rejected removal is atomic

## Why

Strain removal previously deleted harvests, phenotypes, and the strain row without checking whether active cultivation records or descendant lineages still depended on that strain. This could erase historical data and leave dangling domain references.

## User impact

Users now receive a clear error identifying Plant and/or harvest-history blockers. Strains needed only for lineage remain visible as minimal ancestors instead of disappearing.

## Validation

- [x] `tests/services/test_strain_library.py` — 68 passed
- [x] deletion-focused tests — 13 passed
- [x] Ruff checks for all changed files
- [x] `git diff --check`
- [ ] repository-wide pre-commit gate (currently blocked by pre-existing unrelated Ruff, codespell, YAML, and formatting failures)
- [ ] manual UI validation

Fixes #557
