### PR TITLE
Fix prerelease publishing

### DIFF
--- a/.github/scripts/__init__.py
+++ b/.github/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Helpers used by GitHub Actions workflows."""

--- a/.github/scripts/prerelease_version.py
+++ b/.github/scripts/prerelease_version.py
@@ -1,0 +1,34 @@
+"""Generate the next monotonic prerelease version for the active GSM channel."""
+
+import argparse
+import re
+import sys
+
+STABLE_VERSION = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$")
+
+
+def prerelease_version(stable_version: str, run_number: int) -> str:
+    """Return a beta of the patch following stable_version."""
+    match = STABLE_VERSION.fullmatch(stable_version)
+    if match is None:
+        raise ValueError(f"Expected a stable X.Y.Z version, got {stable_version!r}")
+    if run_number < 1:
+        raise ValueError("GitHub workflow run number must be positive")
+
+    major = int(match["major"])
+    minor = int(match["minor"])
+    patch = int(match["patch"]) + 1
+    return f"{major}.{minor}.{patch}b{run_number}"
+
+
+def main() -> None:
+    """Print the prerelease version for the workflow."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("stable_version")
+    parser.add_argument("run_number", type=int)
+    args = parser.parse_args()
+    sys.stdout.write(f"{prerelease_version(args.stable_version, args.run_number)}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,9 +1,13 @@
 name: Pre-release
 
-on:
+"on":
   push:
     branches:
       - prerelease
+
+concurrency:
+  group: prerelease-publish
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -17,17 +21,16 @@ jobs:
       - name: Update version
         id: version_step
         run: |
-          VERSION="0.2.$(date +%Y%m%d%H%M%S)"
+          STABLE_VERSION="$(jq -r .version custom_components/growspace_manager/manifest.json)"
+          VERSION="$(python3 .github/scripts/prerelease_version.py "$STABLE_VERSION" "$GITHUB_RUN_NUMBER")"
           echo "New version: $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          cd custom_components/growspace_manager
-          # Use jq to reliably update the version
-          if ! jq --arg v "$VERSION" '.version = $v' manifest.json > manifest.json.tmp; then
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          manifest="custom_components/growspace_manager/manifest.json"
+          if ! jq --arg v "$VERSION" '.version = $v' "$manifest" > "$manifest.tmp"; then
             echo "jq command failed"
             exit 1
           fi
-          mv manifest.json.tmp manifest.json
-          cd ../..
+          mv "$manifest.tmp" "$manifest"
 
       # 2. Creates the ZIP file
       - name: ZIP Release
@@ -42,20 +45,34 @@ jobs:
 
       # 3. Creates the GitHub Pre-release and attaches the new zip file
       - name: Create Pre-release
-        uses: softprops/action-gh-release@v3.0.0
+        uses: softprops/action-gh-release@v3.0.2
         with:
           prerelease: true
-          tag_name: v${{ steps.version_step.outputs.version }}-beta
+          tag_name: v${{ steps.version_step.outputs.version }}
+          target_commitish: ${{ github.sha }}
           name: Pre-release-${{ github.ref_name }}-${{ github.sha }}
           generate_release_notes: true
           files: growspace_manager.zip
+          fail_on_unmatched_files: true
+
+      - name: Verify release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: v${{ steps.version_step.outputs.version }}
+        run: |
+          tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG_NAME" --jq .object.sha)"
+          if [ "$tag_sha" != "$GITHUB_SHA" ]; then
+            echo "Release tag $TAG_NAME points to $tag_sha instead of $GITHUB_SHA" >&2
+            exit 1
+          fi
 
       # 4. Delete Older Pre-releases
       - name: Delete Older Pre-releases
-        uses: dev-drprasad/delete-older-releases@v0.3.2
+        uses: dev-drprasad/delete-older-releases@v0.3.4
         with:
           keep_latest: 5 # Number of most recent pre-releases to keep
-          delete_tag_pattern: "^prerelease-" # Regex pattern to match your tags
+          delete_prerelease_only: true
+          delete_tag_pattern: "(b[0-9]+|-beta)$"
           delete_tags: true # Also delete the tags associated with the releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/test_prerelease_publishing.py
+++ b/tests/test_prerelease_publishing.py
@@ -1,0 +1,56 @@
+"""Regression tests for the active prerelease publishing channel."""
+
+from pathlib import Path
+import re
+import runpy
+
+from awesomeversion import AwesomeVersion
+import yaml
+
+REPO_ROOT = Path(__file__).parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/prerelease.yaml"
+VERSION_SCRIPT = REPO_ROOT / ".github/scripts/prerelease_version.py"
+
+
+def _workflow_steps() -> list[dict]:
+    workflow = _workflow()
+    return workflow["jobs"]["build"]["steps"]
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW_PATH.read_text())
+
+
+def _step(name: str) -> dict:
+    return next(step for step in _workflow_steps() if step.get("name") == name)
+
+
+def test_prerelease_publishing_contract() -> None:
+    """The active release must be monotonic, correctly tagged, and cleaned up."""
+    version_module = runpy.run_path(VERSION_SCRIPT)
+
+    prerelease = version_module["prerelease_version"]("1.2.1", 123)
+    assert prerelease == "1.2.2b123"
+    assert AwesomeVersion(prerelease) > AwesomeVersion("1.2.1")
+    assert AwesomeVersion(prerelease) > AwesomeVersion("1.0.0")
+
+    assert _workflow()["concurrency"] == {
+        "group": "prerelease-publish",
+        "cancel-in-progress": False,
+    }
+
+    release = _step("Create Pre-release")
+    assert release["with"]["target_commitish"] == "${{ github.sha }}"
+    assert release["with"]["fail_on_unmatched_files"] is True
+
+    verification = _step("Verify release tag")
+    assert "GITHUB_SHA" in verification["run"]
+    assert "git/ref/tags" in verification["run"]
+
+    cleanup = _step("Delete Older Pre-releases")
+    pattern = re.compile(cleanup["with"]["delete_tag_pattern"])
+
+    assert cleanup["with"]["delete_prerelease_only"] is True
+    assert pattern.search("v1.2.2b123")
+    assert pattern.search("v0.2.20260811164742-beta")
+    assert not pattern.search("v1.2.1")


### PR DESCRIPTION
## Summary

- derive each prerelease as a monotonic beta of the next stable patch (for example, `1.2.2b123`)
- bind and verify the release tag against the exact `prerelease` workflow commit
- serialize publishing, require the ZIP asset, and clean up both current and legacy beta tags

## Root cause

The workflow did not set `target_commitish`, so GitHub created prerelease tags from the default branch instead of the commit that triggered the workflow. Its timestamp version stream (`0.2.*`) also compared below both the branch manifest (`1.2.1`) and the stale full release (`1.0.0`), while the cleanup regex did not match the generated `*-beta` tags.

## Impact

Consumers can select a prerelease that is newer than the stable manifest and know its tag resolves to the published source commit. The first successful run will retain the five newest prereleases and delete older prerelease releases and their tags, including legacy `*-beta` tags; stable releases are protected.

## Validation

- publishing contract regression test passes when invoked directly
- Ruff check and format pass
- codespell, yamllint, and Prettier pass
- `git diff --check` passes

The repository pytest process completes this new assertion but hangs during local session teardown, so the remaining CI run is intentionally left to GitHub Actions.
