### PR TITLE
Fix prerelease cleanup filter

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -72,7 +72,6 @@ jobs:
         with:
           keep_latest: 5 # Number of most recent pre-releases to keep
           delete_prerelease_only: true
-          delete_tag_pattern: "(b[0-9]+|-beta)$"
           delete_tags: true # Also delete the tags associated with the releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/test_prerelease_publishing.py
+++ b/tests/test_prerelease_publishing.py
@@ -1,7 +1,6 @@
 """Regression tests for the active prerelease publishing channel."""
 
 from pathlib import Path
-import re
 import runpy
 
 from awesomeversion import AwesomeVersion
@@ -48,9 +47,6 @@ def test_prerelease_publishing_contract() -> None:
     assert "git/ref/tags" in verification["run"]
 
     cleanup = _step("Delete Older Pre-releases")
-    pattern = re.compile(cleanup["with"]["delete_tag_pattern"])
 
     assert cleanup["with"]["delete_prerelease_only"] is True
-    assert pattern.search("v1.2.2b123")
-    assert pattern.search("v0.2.20260811164742-beta")
-    assert not pattern.search("v1.2.1")
+    assert "delete_tag_pattern" not in cleanup["with"]


### PR DESCRIPTION
## Summary

- remove the ineffective `delete_tag_pattern` from prerelease cleanup
- assert that cleanup relies on `delete_prerelease_only` instead

## Root cause

The cleanup action documents `delete_tag_pattern` as a literal substring filter, not a regular expression. The regex-like value merged in #563 therefore matches neither the new `v1.2.2b*` tags nor the legacy `*-beta` tags.

## Impact

The next prerelease publish will retain the five newest prereleases and delete older prerelease releases and their tags. Stable releases remain protected by `delete_prerelease_only: true`.

## Validation

- publishing contract regression test passes
- Ruff, formatting, codespell, yamllint, Prettier, and `git diff --check` pass

Follow-up to #563, which merged while this action-input audit was in progress.
