### PR TITLE
Surface strain-removal reference errors in the options flow

### DIFF
--- a/custom_components/growspace_manager/config_handlers/strain_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/strain_config_handler.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 import voluptuous as vol
 
 from custom_components.growspace_manager.const import CONF_BLACKLIST_BREEDERS
+from custom_components.growspace_manager.exceptions import StrainReferenceError
 from custom_components.growspace_manager.schemas import ADD_STRAIN_SCHEMA
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.helpers import selector
@@ -43,6 +44,16 @@ class StrainConfigHandler(BaseConfigHandler[dict[str, Any]]):
                 try:
                     await coordinator.services.config.strain_library.remove_strain(
                         user_input.get("strain_id")
+                    )
+                except StrainReferenceError as err:
+                    return self.flow.async_show_form(
+                        step_id="manage_strain_library",
+                        data_schema=self._get_strain_library_menu_schema(coordinator),
+                        errors={"base": "strain_delete_blocked"},
+                        description_placeholders={
+                            "strain": err.strain,
+                            "detail": err.detail,
+                        },
                     )
                 except Exception:
                     _LOGGER.exception("Error deleting strain")
@@ -126,8 +137,10 @@ class StrainConfigHandler(BaseConfigHandler[dict[str, Any]]):
         export_dir = self.flow.hass.config.path("exports")
 
         try:
-            zip_path = await coordinator.services.config.strain_library.export_library_to_zip(
-                export_dir
+            zip_path = (
+                await coordinator.services.config.strain_library.export_library_to_zip(
+                    export_dir
+                )
             )
             return self.flow.async_show_form(
                 step_id="export_strain_library",

--- a/custom_components/growspace_manager/exceptions.py
+++ b/custom_components/growspace_manager/exceptions.py
@@ -62,7 +62,13 @@ class StrainReferenceError(ValidationChangeError):
             or (not plant_count and has_harvest_history)
             else "reference"
         )
+        self.strain = strain
+        self.plant_count = plant_count
+        self.has_harvest_history = has_harvest_history
+        # Rendered separately from the message so UI surfaces can place the phrase
+        # into their own translated sentence instead of re-deriving the wording.
+        self.detail = f"{reference_summary} still {verb} it"
         super().__init__(
-            f"Cannot remove strain '{strain}': {reference_summary} still {verb} it. "
+            f"Cannot remove strain '{strain}': {self.detail}. "
             "Resolve the cultivation references first."
         )

--- a/custom_components/growspace_manager/strings.json
+++ b/custom_components/growspace_manager/strings.json
@@ -239,7 +239,9 @@
       "growspace_not_found": "The selected growspace could not be found",
       "position_occupied": "The selected position is already occupied by another plant",
       "invalid_position": "The selected position is outside the growspace boundaries",
-      "assistant_required": "An AI assistant entity must be selected when AI features are enabled"
+      "assistant_required": "An AI assistant entity must be selected when AI features are enabled",
+      "strain_delete_blocked": "Cannot delete {strain}: {detail}. Resolve those references first, then try again.",
+      "delete_failed": "The strain could not be deleted because of an unexpected error. Check the logs for details."
     }
   },
   "services": {

--- a/custom_components/growspace_manager/translations/en.json
+++ b/custom_components/growspace_manager/translations/en.json
@@ -224,7 +224,235 @@
     }
   },
   "options": {
+    "step": {
+      "init": {
+        "title": "Growspace Manager Options",
+        "description": "Manage your growspaces and plants"
+      },
+      "main_menu": {
+        "title": "Growspace Manager",
+        "description": "Choose what you would like to manage",
+        "menu_options": {
+          "manage_growspaces": "Manage Growspaces",
+          "manage_plants": "Manage Plants",
+          "configure_environment": "Configure Growspace Environment",
+          "configure_global": "Configure Global Sensors",
+          "configure_irrigation": "Configure Irrigation",
+          "configure_general": "General Settings"
+        }
+      },
+      "select_growspace_for_irrigation": {
+        "title": "Select Growspace for Irrigation",
+        "description": "Choose which growspace to configure the irrigation controller for.",
+        "data": {
+          "growspace_id": "Growspace"
+        }
+      },
+      "configure_irrigation": {
+        "title": "Configure Irrigation for {growspace_name}",
+        "description": "Manage the irrigation and drain controller for this growspace.",
+        "menu_options": {
+          "edit_pump_settings": "Edit Pump Settings",
+          "add_irrigation_time": "Add Irrigation Time",
+          "remove_irrigation_time": "Remove Irrigation Time",
+          "add_drain_time": "Add Drain Time",
+          "remove_drain_time": "Remove Drain Time"
+        }
+      },
+      "edit_pump_settings": {
+        "title": "Edit Pump Settings for {growspace_name}",
+        "description": "Configure the switch entities and default run durations.",
+        "data": {
+          "irrigation_pump_entity": "Irrigation Pump Switch",
+          "drain_pump_entity": "Drain Pump Switch",
+          "irrigation_duration": "Default Irrigation Duration (seconds)",
+          "drain_duration": "Default Drain Duration (seconds)"
+        }
+      },
+      "add_irrigation_time": {
+        "title": "Add Irrigation Time for {growspace_name}",
+        "description": "Add a new time slot for an irrigation event. You can optionally set a custom duration.",
+        "data": {
+          "time": "Time",
+          "duration": "Custom Duration (seconds)"
+        },
+        "data_description": {
+          "duration": "Optional: a custom duration for this specific event."
+        }
+      },
+      "remove_irrigation_time": {
+        "title": "Remove Irrigation Time for {growspace_name}",
+        "description": "Select an irrigation time to remove.",
+        "data": {
+          "time": "Irrigation Time"
+        }
+      },
+      "add_drain_time": {
+        "title": "Add Drain Time for {growspace_name}",
+        "description": "Add a new time slot for a drain event. You can optionally set a custom duration.",
+        "data": {
+          "time": "Time",
+          "duration": "Custom Duration (seconds)"
+        },
+        "data_description": {
+          "duration": "Optional: a custom duration for this specific event."
+        }
+      },
+      "remove_drain_time": {
+        "title": "Remove Drain Time for {growspace_name}",
+        "description": "Select a drain time to remove.",
+        "data": {
+          "time": "Drain Time"
+        }
+      },
+      "configure_global": {
+        "title": "Configure Global Sensors",
+        "description": "Set up optional sensors for outside and lung room environments.",
+        "data": {
+          "weather_entity": "Outside Weather Entity",
+          "lung_room_temp_sensor": "Lung Room Temperature Sensor",
+          "lung_room_humidity_sensor": "Lung Room Humidity Sensor"
+        }
+      },
+      "configure_general": {
+        "title": "General Settings",
+        "description": "Configure general integration behavior",
+        "data": {
+          "show_sidebar": "Show Growspace Manager in sidebar"
+        }
+      },
+      "configure_environment": {
+        "title": "Configure Environment for {growspace_name}",
+        "description": "Set up and fine-tune the environmental sensors and thresholds for this growspace.",
+        "data": {
+          "minimum_source_air_temperature": "Minimum Source Air Temperature (°C)",
+          "temperature_sensor": "Temperature Sensor",
+          "humidity_sensor": "Humidity Sensor",
+          "vpd_sensor": "VPD Sensor (Optional)",
+          "lst_offset": "Leaf Surface Temp Offset (°C)",
+          "configure_light": "Enable Light Monitoring",
+          "light_sensor": "Light Status Sensor",
+          "configure_fan": "Enable Circulation Fan",
+          "circulation_fan": "Circulation Fan Device",
+          "configure_co2": "Enable CO2 Monitoring",
+          "co2_sensor": "CO2 Sensor",
+          "exhaust_fan_entity": "Exhaust Fan Device (Control)",
+          "configure_exhaust": "Enable Exhaust Monitoring",
+          "exhaust_sensor": "Exhaust Airflow/Speed Sensor",
+          "humidifier_entity": "Humidifier Device (Control)",
+          "configure_humidifier": "Enable Humidifier Monitoring",
+          "humidifier_sensor": "Humidifier Power/Status Sensor",
+          "configure_dehumidifier": "Enable Dehumidifier",
+          "dehumidifier_entity": "Dehumidifier Device",
+          "control_dehumidifier": "Enable Dehumidifier Automation",
+          "ph_sensors": "PH Sensors",
+          "feed_ec_sensors": "Feed EC Sensors",
+          "substrate_ec_sensors": "Substrate EC Sensors",
+          "runoff_ec_sensors": "Runoff EC Sensors",
+          "drain_volume_sensors": "Drain Volume Sensors",
+          "irrigation_flow_sensors": "Irrigation Flow Sensors",
+          "camera_entities": "Camera Entities",
+          "snapshot_interval_hours": "Snapshot Interval (Hours)",
+          "power_sensors": "Power Sensors",
+          "energy_sensors": "Energy Sensors",
+          "irrigation_tank_sensors": "Irrigation Tank Sensors",
+          "irrigation_tank_warning_level": "Tank Warning Level (%)",
+          "irrigation_tank_volume": "Tank volume (litres)"
+        },
+        "data_description": {
+          "irrigation_tank_volume": "Total capacity of the tank in litres. Used for tank-based water consumption tracking when no flow sensors are configured. Leave empty to disable."
+        }
+      },
+      "manage_growspaces": {
+        "title": "Manage Growspaces",
+        "description": "Add, remove, or view your growspaces",
+        "data": {
+          "action": "Action",
+          "growspace_id": "Select Growspace"
+        }
+      },
+      "add_growspace": {
+        "title": "Add New Growspace",
+        "description": "Create a new growspace for your plants",
+        "data": {
+          "name": "Growspace Name",
+          "rows": "Number of Rows",
+          "plants_per_row": "Plants per Row",
+          "notification_target": "Notification Target"
+        },
+        "data_description": {
+          "notification_target": "Optional: notification service (e.g., mobile_app_your_phone)"
+        }
+      },
+      "manage_plants": {
+        "title": "Manage Plants",
+        "description": "Add, update, or remove plants from your growspaces",
+        "data": {
+          "action": "Action",
+          "plant_id": "Select Plant"
+        }
+      },
+      "select_growspace_for_plant": {
+        "title": "Select Growspace",
+        "description": "Choose which growspace to add the plant to",
+        "data": {
+          "growspace_id": "Growspace"
+        }
+      },
+      "add_plant": {
+        "title": "Add New Plant",
+        "description": "Add a plant to the selected growspace",
+        "data": {
+          "strain": "Strain Name",
+          "phenotype": "Phenotype",
+          "row": "Row Position",
+          "col": "Column Position",
+          "veg_start": "Vegetative Start Date",
+          "flower_start": "Flowering Start Date"
+        },
+        "data_description": {
+          "phenotype": "Optional: specific phenotype identifier",
+          "veg_start": "Optional: when vegetative stage started",
+          "flower_start": "Optional: when flowering stage started"
+        }
+      },
+      "update_plant": {
+        "title": "Update Plant",
+        "description": "Modify plant information",
+        "data": {
+          "strain": "Strain Name",
+          "phenotype": "Phenotype",
+          "row": "Row Position",
+          "col": "Column Position",
+          "veg_start": "Vegetative Start Date",
+          "flower_start": "Flowering Start Date"
+        },
+        "data_description": {
+          "phenotype": "Optional: specific phenotype identifier",
+          "veg_start": "Optional: when vegetative stage started",
+          "flower_start": "Optional: when flowering stage started"
+        }
+      },
+      "configure_ai": {
+        "title": "Configure AI Settings",
+        "description": "Set up the AI assistant for grow advice, notifications, and vision checkups.",
+        "data": {
+          "ai_enabled": "Enable AI features",
+          "assistant_id": "AI assistant entity",
+          "notification_personality": "Notification personality",
+          "ai_auto_alerts": "Enable automatic AI alerts",
+          "max_response_length": "Maximum response length (characters)",
+          "vision_checkup_enabled": "Enable AI vision checkups",
+          "ai_task_entity_id": "AI task entity (for vision analysis)"
+        }
+      }
+    },
     "error": {
+      "plant_not_found": "The selected plant could not be found",
+      "growspace_not_found": "The selected growspace could not be found",
+      "position_occupied": "The selected position is already occupied by another plant",
+      "invalid_position": "The selected position is outside the growspace boundaries",
+      "assistant_required": "An AI assistant entity must be selected when AI features are enabled",
       "strain_delete_blocked": "Cannot delete {strain}: {detail}. Resolve those references first, then try again.",
       "delete_failed": "The strain could not be deleted because of an unexpected error. Check the logs for details."
     }

--- a/custom_components/growspace_manager/translations/en.json
+++ b/custom_components/growspace_manager/translations/en.json
@@ -222,5 +222,11 @@
     "phi_not_cleared": {
       "message": "Cannot harvest {plant_id}: pre-harvest interval not cleared until {clearance_date} ({days_remaining} days remaining)."
     }
+  },
+  "options": {
+    "error": {
+      "strain_delete_blocked": "Cannot delete {strain}: {detail}. Resolve those references first, then try again.",
+      "delete_failed": "The strain could not be deleted because of an unexpected error. Check the logs for details."
+    }
   }
 }

--- a/tests/integration/test_strain_config_handler_coverage.py
+++ b/tests/integration/test_strain_config_handler_coverage.py
@@ -9,6 +9,7 @@ from custom_components.growspace_manager.config_handlers.strain_config_handler i
     StrainConfigHandler,
 )
 from custom_components.growspace_manager.const import CONF_BLACKLIST_BREEDERS, DOMAIN
+from custom_components.growspace_manager.exceptions import StrainReferenceError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -131,7 +132,11 @@ async def test_async_step_manage_strain_library_post_edit(
 async def test_async_step_manage_strain_library_post_delete_success(
     handler: StrainConfigHandler,
 ) -> None:
-    """Test deleting a strain successfully."""
+    """Deletion and demotion alike return to the menu without an error.
+
+    remove_strain returns plainly whether the strain was deleted outright or
+    demoted to an ancestor, so one assertion covers both success outcomes.
+    """
     # Access the deeply nested mock through the facade
     strain_service = handler.config_entry.runtime_data.services.config.strain_library
     handler.flow.async_show_form = MagicMock(return_value={"type": "form"})
@@ -141,6 +146,56 @@ async def test_async_step_manage_strain_library_post_delete_success(
     )
     assert result["type"] == "form"
     strain_service.remove_strain.assert_awaited_once_with("test_strain")
+    handler.flow.async_show_form.assert_called_once_with(
+        step_id="manage_strain_library",
+        data_schema=ANY,
+    )
+
+
+@pytest.mark.parametrize(
+    ("plant_count", "has_harvest_history", "expected_detail"),
+    [
+        pytest.param(1, False, "1 Plant record still references it", id="plant"),
+        pytest.param(0, True, "harvest history still references it", id="harvest"),
+        pytest.param(
+            2,
+            True,
+            "2 Plant records and harvest history still reference it",
+            id="both",
+        ),
+    ],
+)
+async def test_async_step_manage_strain_library_post_delete_blocked_by_references(
+    handler: StrainConfigHandler,
+    plant_count: int,
+    has_harvest_history: bool,
+    expected_detail: str,
+) -> None:
+    """A blocked removal reports which references must be resolved."""
+    strain_service = handler.config_entry.runtime_data.services.config.strain_library
+    strain_service.remove_strain = AsyncMock(
+        side_effect=StrainReferenceError(
+            "test_strain",
+            plant_count=plant_count,
+            has_harvest_history=has_harvest_history,
+        )
+    )
+    handler.flow.async_show_form = MagicMock(return_value={"type": "form"})
+
+    result = await handler.async_step_manage_strain_library(
+        {"action": "delete_strain", "strain_id": "test_strain"}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    handler.flow.async_show_form.assert_called_with(
+        step_id="manage_strain_library",
+        data_schema=ANY,
+        errors={"base": "strain_delete_blocked"},
+        description_placeholders={
+            "strain": "test_strain",
+            "detail": expected_detail,
+        },
+    )
 
 
 async def test_async_step_manage_strain_library_post_delete_fail(
@@ -148,7 +203,9 @@ async def test_async_step_manage_strain_library_post_delete_fail(
 ) -> None:
     """Test deleting a strain failure."""
     coordinator = handler.config_entry.runtime_data
-    coordinator._strain_library.remove_strain = AsyncMock(side_effect=Exception("Error"))
+    coordinator._strain_library.remove_strain = AsyncMock(
+        side_effect=Exception("Error")
+    )
     handler.flow.async_show_form = MagicMock(return_value={"type": "form"})
 
     result = await handler.async_step_manage_strain_library(
@@ -441,9 +498,7 @@ async def test_async_step_manage_breeder_blacklist_post(
     handler.config_entry.options = {"existing_option": "value"}
     handler.hass.config_entries = MagicMock()
     handler.hass.config_entries.async_update_entry = MagicMock()
-    handler.async_step_manage_strain_library = AsyncMock(
-        return_value={"type": "form"}
-    )
+    handler.async_step_manage_strain_library = AsyncMock(return_value={"type": "form"})
 
     user_input = {CONF_BLACKLIST_BREEDERS: ["Breeder B"]}
     result = await handler.async_step_manage_breeder_blacklist(user_input)
@@ -454,4 +509,3 @@ async def test_async_step_manage_breeder_blacklist_post(
         options={"existing_option": "value", CONF_BLACKLIST_BREEDERS: ["Breeder B"]},
     )
     handler.async_step_manage_strain_library.assert_called_once()
-


### PR DESCRIPTION
Closes #566.

## What changed

`#557` made `remove_strain` reference-aware, but the options flow wrapped it in a bare `except Exception` and showed a generic `delete_failed` — so the reason a deletion was blocked only ever reached users of the `remove_strain` service, never users configuring through the UI. `delete_failed` also had no translation entry, so it rendered as a raw key.

- `StrainReferenceError` now exposes `strain`, `plant_count`, `has_harvest_history` and a rendered `detail` phrase ("2 Plant records and harvest history still reference it"). **The message it raises is byte-identical** — the `#557` tests that match on it are untouched.
- The handler catches `StrainReferenceError` specifically and passes `strain` + `detail` via `description_placeholders`. Unexpected errors keep `delete_failed` and the `_LOGGER.exception` call.
- Added `strain_delete_blocked` and `delete_failed` to `strings.json` **and** `translations/en.json`.

Placeholders in error strings are a supported pattern — 34 core integrations do it (`enphase_envoy`, `nut`, `onvif`, …); HA passes `description_placeholders` into the error localization.

Demotion needs no special handling: `remove_strain` returns plainly whether the strain was deleted or demoted, so both are already success paths. The test asserts the menu comes back with no `errors` kwarg, which is the substantive check.

## Tests

New in `tests/integration/test_strain_config_handler_coverage.py`:
- blocked path, parametrized over plants / harvests / both, asserting the error key **and** that the placeholder carries the right detail
- success path, asserting no `errors` kwarg (covers deletion and demotion)
- the existing unexpected-error test already pins `delete_failed` with no placeholders

Full suite: 4924 passed.

## Deliberately out of scope

Two adjacent gaps found while working, **not** fixed here — filed separately so this PR stays reviewable:

1. `translations/en.json` is missing the entire `options` section (19 steps). Every options-flow step title, description, and field label is unrendered today. `config` is fully in sync, so this is drift in one section, and syncing 19 steps of previously-invisible UI text does not belong in this PR.
2. `async_step_import_strain_library` emits `setup_error`, `file_not_found`, `invalid_zip`, `import_failed` — none of which have translation entries either. Different step, same root cause as (1).