### PR TITLE
Translate every options-flow step and guard the strings/en.json parity

### DIFF
--- a/custom_components/growspace_manager/strings.json
+++ b/custom_components/growspace_manager/strings.json
@@ -165,7 +165,10 @@
           "name": "Growspace Name",
           "rows": "Number of Rows",
           "plants_per_row": "Plants per Row",
-          "notification_target": "Notification Target"
+          "notification_target": "Notification Target",
+          "length": "Length (cm)",
+          "width": "Width (cm)",
+          "height": "Height (cm)"
         },
         "data_description": {
           "notification_target": "Optional: notification service (e.g., mobile_app_your_phone)"
@@ -232,6 +235,306 @@
           "vision_checkup_enabled": "Enable AI vision checkups",
           "ai_task_entity_id": "AI task entity (for vision analysis)"
         }
+      },
+      "select_growspace_for_env": {
+        "title": "Select Growspace",
+        "description": "Choose which growspace to configure the environment for.",
+        "data": {
+          "growspace_id": "Growspace"
+        }
+      },
+      "irrigation_overview": {
+        "title": "Irrigation for {growspace_name}",
+        "description": "Configure the pump, schedule, and VWC crop-steering strategy for this growspace.",
+        "data": {
+          "growspace_id_read_only": "Growspace",
+          "irrigation_pump_entity": "Irrigation Pump",
+          "irrigation_duration": "Irrigation Duration (seconds)",
+          "current_irrigation_times": "Irrigation Times",
+          "drain_pump_entity": "Drain Pump",
+          "drain_duration": "Drain Duration (seconds)",
+          "current_drain_times": "Drain Times",
+          "soil_trigger_percent": "Soil Moisture Trigger (%)",
+          "max_cycles_per_day": "Maximum Cycles per Day",
+          "daily_volume_cap_liters": "Daily Volume Cap (L)",
+          "pause_on_low_tank": "Pause When Tank Is Low",
+          "skip_during_dark": "Skip During Dark Period",
+          "log_to_logbook": "Log Waterings to the Logbook",
+          "use_vwc_steering": "Enable VWC Crop Steering",
+          "substrate_media_type": "Substrate Media Type",
+          "substrate_liters_per_pot": "Substrate Volume per Pot (L)",
+          "target_vwc_percent": "Target VWC (%)",
+          "maintenance_dryback_percent": "Maintenance Dryback (%)",
+          "shot_sizing_mode": "Shot Sizing Mode",
+          "pump_flow_rate_ml_per_sec": "Pump Flow Rate (ml/s)",
+          "lights_on_time": "Lights-On Time",
+          "p0_duration_minutes": "P0 Duration (minutes)",
+          "p1_shot_volume_percent": "P1 Shot Volume (%)",
+          "p1_shot_duration_seconds": "P1 Shot Duration (seconds)",
+          "p1_shot_interval_minutes": "P1 Shot Interval (minutes)",
+          "auto_advance_p1_to_p2": "Auto-Advance P1 to P2",
+          "p2_shot_volume_percent": "P2 Shot Volume (%)",
+          "p2_shot_duration_seconds": "P2 Shot Duration (seconds)",
+          "p2_shot_interval_minutes": "P2 Shot Interval (minutes)",
+          "p2_stop_before_lights_off_minutes": "Stop P2 Before Lights Off (minutes)",
+          "auto_advance_p2_to_p3": "Auto-Advance P2 to P3",
+          "ec_modulation_enabled": "Enable EC Modulation",
+          "pore_ec_target_min": "Minimum Pore EC Target",
+          "pore_ec_target_max": "Maximum Pore EC Target",
+          "halt_on_runoff_ec_threshold": "Halt on Runoff EC Above"
+        },
+        "data_description": {
+          "shot_sizing_mode": "Duration Mode uses fixed shot durations; Volume Mode derives them from the pump flow rate and substrate volume.",
+          "growspace_id_read_only": "The growspace these settings apply to. Read-only."
+        }
+      },
+      "update_growspace": {
+        "title": "Update Growspace",
+        "description": "Change the name, dimensions, or notification target of this growspace.",
+        "data": {
+          "name": "Growspace Name",
+          "length": "Length (cm)",
+          "width": "Width (cm)",
+          "height": "Height (cm)",
+          "rows": "Number of Rows",
+          "plants_per_row": "Plants per Row",
+          "notification_target": "Notification Target"
+        },
+        "data_description": {
+          "notification_target": "Optional: notification service (e.g., mobile_app_your_phone)"
+        }
+      },
+      "confirm_remove_growspace": {
+        "title": "Remove Growspace",
+        "description": "Remove {growspace_name} and every plant in it? This cannot be undone."
+      },
+      "configure_humidifier": {
+        "title": "Humidifier Thresholds for {growspace_name}",
+        "description": "Set the VPD band that turns the humidifier on and off, per growth stage and day/night cycle.",
+        "data": {
+          "seedling_day_on": "Seedling — Day turn on (kPa)",
+          "seedling_day_off": "Seedling — Day turn off (kPa)",
+          "seedling_night_on": "Seedling — Night turn on (kPa)",
+          "seedling_night_off": "Seedling — Night turn off (kPa)",
+          "veg_day_on": "Vegetative — Day turn on (kPa)",
+          "veg_day_off": "Vegetative — Day turn off (kPa)",
+          "veg_night_on": "Vegetative — Night turn on (kPa)",
+          "veg_night_off": "Vegetative — Night turn off (kPa)",
+          "flower_early_day_on": "Early Flower — Day turn on (kPa)",
+          "flower_early_day_off": "Early Flower — Day turn off (kPa)",
+          "flower_early_night_on": "Early Flower — Night turn on (kPa)",
+          "flower_early_night_off": "Early Flower — Night turn off (kPa)",
+          "flower_mid_day_on": "Mid Flower — Day turn on (kPa)",
+          "flower_mid_day_off": "Mid Flower — Day turn off (kPa)",
+          "flower_mid_night_on": "Mid Flower — Night turn on (kPa)",
+          "flower_mid_night_off": "Mid Flower — Night turn off (kPa)",
+          "flower_late_day_on": "Late Flower — Day turn on (kPa)",
+          "flower_late_day_off": "Late Flower — Day turn off (kPa)",
+          "flower_late_night_on": "Late Flower — Night turn on (kPa)",
+          "flower_late_night_off": "Late Flower — Night turn off (kPa)",
+          "dry_day_on": "Drying — Day turn on (kPa)",
+          "dry_day_off": "Drying — Day turn off (kPa)",
+          "dry_night_on": "Drying — Night turn on (kPa)",
+          "dry_night_off": "Drying — Night turn off (kPa)",
+          "cure_day_on": "Curing — Day turn on (kPa)",
+          "cure_day_off": "Curing — Day turn off (kPa)",
+          "cure_night_on": "Curing — Night turn on (kPa)",
+          "cure_night_off": "Curing — Night turn off (kPa)"
+        }
+      },
+      "configure_dehumidifier": {
+        "title": "Dehumidifier Thresholds for {growspace_name}",
+        "description": "Set the VPD band that turns the dehumidifier on and off, per growth stage and day/night cycle.",
+        "data": {
+          "seedling_day_on": "Seedling — Day turn on (kPa)",
+          "seedling_day_off": "Seedling — Day turn off (kPa)",
+          "seedling_night_on": "Seedling — Night turn on (kPa)",
+          "seedling_night_off": "Seedling — Night turn off (kPa)",
+          "veg_day_on": "Vegetative — Day turn on (kPa)",
+          "veg_day_off": "Vegetative — Day turn off (kPa)",
+          "veg_night_on": "Vegetative — Night turn on (kPa)",
+          "veg_night_off": "Vegetative — Night turn off (kPa)",
+          "flower_early_day_on": "Early Flower — Day turn on (kPa)",
+          "flower_early_day_off": "Early Flower — Day turn off (kPa)",
+          "flower_early_night_on": "Early Flower — Night turn on (kPa)",
+          "flower_early_night_off": "Early Flower — Night turn off (kPa)",
+          "flower_mid_day_on": "Mid Flower — Day turn on (kPa)",
+          "flower_mid_day_off": "Mid Flower — Day turn off (kPa)",
+          "flower_mid_night_on": "Mid Flower — Night turn on (kPa)",
+          "flower_mid_night_off": "Mid Flower — Night turn off (kPa)",
+          "flower_late_day_on": "Late Flower — Day turn on (kPa)",
+          "flower_late_day_off": "Late Flower — Day turn off (kPa)",
+          "flower_late_night_on": "Late Flower — Night turn on (kPa)",
+          "flower_late_night_off": "Late Flower — Night turn off (kPa)",
+          "dry_day_on": "Drying — Day turn on (kPa)",
+          "dry_day_off": "Drying — Day turn off (kPa)",
+          "dry_night_on": "Drying — Night turn on (kPa)",
+          "dry_night_off": "Drying — Night turn off (kPa)",
+          "cure_day_on": "Curing — Day turn on (kPa)",
+          "cure_day_off": "Curing — Day turn off (kPa)",
+          "cure_night_on": "Curing — Night turn on (kPa)",
+          "cure_night_off": "Curing — Night turn off (kPa)"
+        }
+      },
+      "configure_advanced_bayesian": {
+        "title": "Advanced Bayesian Settings for {growspace_name}",
+        "description": "Tune the Bayesian probabilities behind the environment sensors. Field names are derived from your configured sensors and are shown untranslated."
+      },
+      "configure_sensor_placement": {
+        "title": "Sensor Placement for {growspace_name}",
+        "description": "Give each sensor its X/Y/Z position inside the growspace. Field names are derived from your configured sensors and are shown untranslated."
+      },
+      "configure_fan_controller": {
+        "title": "Circulation Fan for {growspace_name}",
+        "description": "Choose how the circulation fan is regulated and the speed range it may use.",
+        "data": {
+          "enabled": "Enable Fan Controller",
+          "regulation_mode": "Regulation Mode",
+          "min_speed": "Minimum Speed (%)",
+          "max_speed": "Maximum Speed (%)",
+          "wind_enabled": "Enable Wind Simulation"
+        }
+      },
+      "configure_fan_vpd": {
+        "title": "VPD Fan Regulation for {growspace_name}",
+        "description": "Set the VPD target the fan regulates towards and the critical temperatures that override it.",
+        "data": {
+          "vpd_target": "VPD Target (kPa)",
+          "vpd_tolerance": "VPD Tolerance (kPa)",
+          "stage_vpd_enabled": "Use Per-Stage VPD Targets",
+          "critical_temp_high": "Critical High Temperature (°C)",
+          "critical_temp_low": "Critical Low Temperature (°C)",
+          "critical_temp_hysteresis": "Critical Temperature Hysteresis (°C)"
+        }
+      },
+      "configure_fan_humidity": {
+        "title": "Humidity Fan Regulation for {growspace_name}",
+        "description": "Set the humidity target the fan regulates towards.",
+        "data": {
+          "humidity_target": "Humidity Target (%)",
+          "humidity_tolerance": "Humidity Tolerance (%)"
+        }
+      },
+      "configure_fan_temperature": {
+        "title": "Temperature Fan Regulation for {growspace_name}",
+        "description": "Set the temperature target the fan regulates towards.",
+        "data": {
+          "temperature_target": "Temperature Target (°C)",
+          "temperature_tolerance": "Temperature Tolerance (°C)"
+        }
+      },
+      "configure_fan_wind": {
+        "title": "Wind Simulation for {growspace_name}",
+        "description": "Vary the fan speed over time to simulate natural wind.",
+        "data": {
+          "wind_amplitude_pct": "Wind Amplitude (%)",
+          "wind_period_seconds": "Wind Period (seconds)"
+        }
+      },
+      "manage_strain_library": {
+        "title": "Manage Strain Library",
+        "description": "Add, edit, import, or export the strains available to your plants.",
+        "data": {
+          "action": "Action",
+          "strain_id": "Select Strain"
+        }
+      },
+      "add_strain": {
+        "title": "Add Strain",
+        "description": "Add a new strain to the library.",
+        "data": {
+          "strain": "Strain Name",
+          "phenotype": "Phenotype",
+          "breeder": "Breeder",
+          "breeder_logo": "Breeder Logo URL",
+          "type": "Type",
+          "lineage": "Lineage",
+          "sex": "Sex",
+          "flower_days_min": "Minimum Flowering Days",
+          "flower_days_max": "Maximum Flowering Days",
+          "description": "Description",
+          "sativa_percentage": "Sativa (%)",
+          "indica_percentage": "Indica (%)",
+          "yield_potential": "Yield Potential"
+        }
+      },
+      "edit_strain": {
+        "title": "Edit Strain",
+        "description": "Change the details of an existing strain.",
+        "data": {
+          "strain": "Strain Name",
+          "phenotype": "Phenotype",
+          "breeder": "Breeder",
+          "breeder_logo": "Breeder Logo URL",
+          "type": "Type",
+          "lineage": "Lineage",
+          "sex": "Sex",
+          "flower_days_min": "Minimum Flowering Days",
+          "flower_days_max": "Maximum Flowering Days",
+          "description": "Description",
+          "sativa_percentage": "Sativa (%)",
+          "indica_percentage": "Indica (%)",
+          "yield_potential": "Yield Potential"
+        }
+      },
+      "import_strain_library": {
+        "title": "Import Strain Library",
+        "description": "Import strains from a ZIP archive. Imported strains are merged into the existing library.",
+        "data": {
+          "file_path": "ZIP File Path"
+        },
+        "data_description": {
+          "file_path": "Full path to the archive, e.g. {default_path}"
+        }
+      },
+      "export_strain_library": {
+        "title": "Export Strain Library",
+        "description": "The strain library was exported to {path}."
+      },
+      "manage_breeder_blacklist": {
+        "title": "Breeder Blacklist",
+        "description": "Breeders listed here are hidden from strain suggestions.",
+        "data": {
+          "blacklist_breeders": "Blacklisted Breeders"
+        }
+      },
+      "manage_timed_notifications": {
+        "title": "Timed Notifications",
+        "description": "Add, edit, or delete notifications that fire on a given day of a grow.",
+        "data": {
+          "action": "Action",
+          "notification_id": "Select Notification"
+        }
+      },
+      "add_timed_notification": {
+        "title": "Add Timed Notification",
+        "description": "Send a message once a grow reaches the given day.",
+        "data": {
+          "message": "Message",
+          "trigger_type": "Count Days From",
+          "day": "Day",
+          "growspace_ids": "Growspaces"
+        },
+        "data_description": {
+          "growspace_ids": "Leave empty to apply to every growspace"
+        }
+      },
+      "edit_timed_notification": {
+        "title": "Edit Timed Notification",
+        "description": "Change when this notification fires and what it says.",
+        "data": {
+          "message": "Message",
+          "trigger_type": "Count Days From",
+          "day": "Day",
+          "growspace_ids": "Growspaces"
+        },
+        "data_description": {
+          "growspace_ids": "Leave empty to apply to every growspace"
+        }
+      },
+      "delete_timed_notification": {
+        "title": "Delete Timed Notification",
+        "description": "Delete notification {notification_id}? This cannot be undone."
       }
     },
     "error": {
@@ -241,7 +544,25 @@
       "invalid_position": "The selected position is outside the growspace boundaries",
       "assistant_required": "An AI assistant entity must be selected when AI features are enabled",
       "strain_delete_blocked": "Cannot delete {strain}: {detail}. Resolve those references first, then try again.",
-      "delete_failed": "The strain could not be deleted because of an unexpected error. Check the logs for details."
+      "delete_failed": "The strain could not be deleted because of an unexpected error. Check the logs for details.",
+      "setup_error": "The integration is not set up yet. Try again once it has finished loading.",
+      "file_not_found": "No file was found at that path. Check the path and try again.",
+      "invalid_zip": "That file is not a valid strain library archive.",
+      "import_failed": "The strain library could not be imported. Check the logs for details.",
+      "add_failed": "The item could not be added because of an unexpected error. Check the logs for details.",
+      "update_failed": "The item could not be updated because of an unexpected error. Check the logs for details.",
+      "remove_failed": "The item could not be removed because of an unexpected error. Check the logs for details.",
+      "select_growspace": "Select a growspace to continue",
+      "fan_speed_invalid": "The minimum fan speed must be lower than the maximum fan speed",
+      "invalid_tuple_format": "The advanced Bayesian values must be entered as number pairs, for example (0.1, 0.9)"
+    },
+    "abort": {
+      "setup_error": "The integration is not set up yet. Try again once it has finished loading.",
+      "export_failed": "The strain library could not be exported. Check the logs for details.",
+      "growspace_not_found": "The selected growspace could not be found.",
+      "plant_not_found": "The selected plant could not be found.",
+      "notification_not_found": "The selected notification could not be found.",
+      "no_growspaces": "No growspaces are configured yet. Add one first."
     }
   },
   "services": {
@@ -422,6 +743,15 @@
       },
       "drying_moisture": {
         "name": "Drying moisture"
+      },
+      "air_exchange": {
+        "name": "Air Exchange"
+      },
+      "overview": {
+        "name": "Overview"
+      },
+      "power_usage": {
+        "name": "Power Usage"
       }
     },
     "binary_sensor": {
@@ -430,6 +760,26 @@
       },
       "drying_ready_for_cure": {
         "name": "Ready for cure"
+      },
+      "stress": {
+        "name": "Stress"
+      },
+      "mold": {
+        "name": "Mold Risk"
+      },
+      "optimal": {
+        "name": "Optimal Conditions"
+      },
+      "drying": {
+        "name": "Drying"
+      },
+      "curing": {
+        "name": "Curing"
+      }
+    },
+    "switch": {
+      "notifications": {
+        "name": "Notifications"
       }
     }
   },

--- a/custom_components/growspace_manager/strings.json
+++ b/custom_components/growspace_manager/strings.json
@@ -479,12 +479,9 @@
       },
       "import_strain_library": {
         "title": "Import Strain Library",
-        "description": "Import strains from a ZIP archive. Imported strains are merged into the existing library.",
+        "description": "Import strains from a ZIP archive, for example {default_path}. Imported strains are merged into the existing library.",
         "data": {
           "file_path": "ZIP File Path"
-        },
-        "data_description": {
-          "file_path": "Full path to the archive, e.g. {default_path}"
         }
       },
       "export_strain_library": {

--- a/custom_components/growspace_manager/translations/en.json
+++ b/custom_components/growspace_manager/translations/en.json
@@ -10,219 +10,6 @@
       }
     }
   },
-  "entity": {
-    "binary_sensor": {
-      "stress": {
-        "name": "Stress"
-      },
-      "mold": {
-        "name": "Mold Risk"
-      },
-      "optimal": {
-        "name": "Optimal Conditions"
-      },
-      "drying": {
-        "name": "Drying"
-      },
-      "curing": {
-        "name": "Curing"
-      },
-      "light_verification": {
-        "name": "Light cycle verification"
-      },
-      "drying_ready_for_cure": {
-        "name": "Ready for cure"
-      }
-    },
-    "switch": {
-      "notifications": {
-        "name": "Notifications"
-      }
-    },
-    "sensor": {
-      "vpd": {
-        "name": "VPD"
-      },
-      "air_exchange": {
-        "name": "Air Exchange"
-      },
-      "overview": {
-        "name": "Overview"
-      },
-      "growspaces_list": {
-        "name": "Growspaces List"
-      },
-      "strain_library": {
-        "name": "Strain Library"
-      },
-      "dli": {
-        "name": "Daily Light Integral"
-      },
-      "crop_steering": {
-        "name": "Crop Steering Score"
-      },
-      "energy_usage": {
-        "name": "Energy Usage"
-      },
-      "power_usage": {
-        "name": "Power Usage"
-      },
-      "water_usage": {
-        "name": "Water Usage"
-      },
-      "ec_target": {
-        "name": "EC Target"
-      },
-      "vision_checkup": {
-        "name": "Vision checkup"
-      },
-      "tank_derived_water": {
-        "name": "Tank water consumption"
-      },
-      "calculated_vpd": {
-        "name": "Calculated VPD"
-      },
-      "plant": {
-        "name": "Plant"
-      },
-      "seed_inventory": {
-        "name": "Seed inventory"
-      },
-      "drying_weight": {
-        "name": "Drying weight"
-      },
-      "drying_moisture": {
-        "name": "Drying moisture"
-      }
-    }
-  },
-  "services": {
-    "add_growspace": {
-      "name": "Add Growspace",
-      "description": "Create a new growspace for managing plants",
-      "fields": {
-        "name": {
-          "name": "Name",
-          "description": "Name of the growspace"
-        },
-        "rows": {
-          "name": "Rows",
-          "description": "Number of rows in the growspace"
-        },
-        "plants_per_row": {
-          "name": "Plants per Row",
-          "description": "Number of plants per row"
-        },
-        "notification_target": {
-          "name": "Notification Target",
-          "description": "Notification service target (e.g., mobile_app_your_phone)"
-        }
-      }
-    },
-    "remove_growspace": {
-      "name": "Remove Growspace",
-      "description": "Remove a growspace and all its plants",
-      "fields": {
-        "growspace_id": {
-          "name": "Growspace ID",
-          "description": "ID of the growspace to remove"
-        }
-      }
-    },
-    "add_plant": {
-      "name": "Add Plant",
-      "description": "Add a plant to a growspace",
-      "fields": {
-        "growspace_id": {
-          "name": "Growspace ID",
-          "description": "ID of the target growspace"
-        },
-        "strain": {
-          "name": "Strain",
-          "description": "Plant strain name"
-        },
-        "row": {
-          "name": "Row",
-          "description": "Row position in the growspace"
-        },
-        "col": {
-          "name": "Column",
-          "description": "Column position in the growspace"
-        },
-        "phenotype": {
-          "name": "Phenotype",
-          "description": "Plant phenotype (optional)"
-        },
-        "veg_start": {
-          "name": "Vegetative Start",
-          "description": "When vegetative stage started"
-        },
-        "flower_start": {
-          "name": "Flowering Start",
-          "description": "When flowering stage started"
-        }
-      }
-    },
-    "update_plant": {
-      "name": "Update Plant",
-      "description": "Update plant information",
-      "fields": {
-        "plant_id": {
-          "name": "Plant ID",
-          "description": "ID of the plant to update"
-        },
-        "strain": {
-          "name": "Strain",
-          "description": "Plant strain name"
-        },
-        "phenotype": {
-          "name": "Phenotype",
-          "description": "Plant phenotype"
-        },
-        "row": {
-          "name": "Row",
-          "description": "Row position in the growspace"
-        },
-        "col": {
-          "name": "Column",
-          "description": "Column position in the growspace"
-        },
-        "veg_start": {
-          "name": "Vegetative Start",
-          "description": "When vegetative stage started"
-        },
-        "flower_start": {
-          "name": "Flowering Start",
-          "description": "When flowering stage started"
-        }
-      }
-    },
-    "remove_plant": {
-      "name": "Remove Plant",
-      "description": "Remove a plant from the growspace",
-      "fields": {
-        "plant_id": {
-          "name": "Plant ID",
-          "description": "ID of the plant to remove"
-        }
-      }
-    }
-  },
-  "issues": {
-    "pending_growspace_fail": {
-      "title": "Failed to create pending growspace",
-      "description": "The system failed to create the pending growspace {name}. Error: {error}. Please check the logs for more details."
-    },
-    "exhaust_fan_migration": {
-      "title": "Exhaust fans need to be re-enabled for {growspace}",
-      "description": "Exhaust fans are now controlled by the dedicated exhaust fan controller instead of the dehumidifier. Because of this change, the exhaust fans in {growspace} are no longer being cycled automatically. Open the Exhaust panel for {growspace} and enable the exhaust fan controller to restore automatic control. This was not migrated automatically because the old on/off humidity thresholds do not map onto the new speed-based settings."
-    }
-  },
-  "exceptions": {
-    "phi_not_cleared": {
-      "message": "Cannot harvest {plant_id}: pre-harvest interval not cleared until {clearance_date} ({days_remaining} days remaining)."
-    }
-  },
   "options": {
     "step": {
       "init": {
@@ -378,7 +165,10 @@
           "name": "Growspace Name",
           "rows": "Number of Rows",
           "plants_per_row": "Plants per Row",
-          "notification_target": "Notification Target"
+          "notification_target": "Notification Target",
+          "length": "Length (cm)",
+          "width": "Width (cm)",
+          "height": "Height (cm)"
         },
         "data_description": {
           "notification_target": "Optional: notification service (e.g., mobile_app_your_phone)"
@@ -445,6 +235,306 @@
           "vision_checkup_enabled": "Enable AI vision checkups",
           "ai_task_entity_id": "AI task entity (for vision analysis)"
         }
+      },
+      "select_growspace_for_env": {
+        "title": "Select Growspace",
+        "description": "Choose which growspace to configure the environment for.",
+        "data": {
+          "growspace_id": "Growspace"
+        }
+      },
+      "irrigation_overview": {
+        "title": "Irrigation for {growspace_name}",
+        "description": "Configure the pump, schedule, and VWC crop-steering strategy for this growspace.",
+        "data": {
+          "growspace_id_read_only": "Growspace",
+          "irrigation_pump_entity": "Irrigation Pump",
+          "irrigation_duration": "Irrigation Duration (seconds)",
+          "current_irrigation_times": "Irrigation Times",
+          "drain_pump_entity": "Drain Pump",
+          "drain_duration": "Drain Duration (seconds)",
+          "current_drain_times": "Drain Times",
+          "soil_trigger_percent": "Soil Moisture Trigger (%)",
+          "max_cycles_per_day": "Maximum Cycles per Day",
+          "daily_volume_cap_liters": "Daily Volume Cap (L)",
+          "pause_on_low_tank": "Pause When Tank Is Low",
+          "skip_during_dark": "Skip During Dark Period",
+          "log_to_logbook": "Log Waterings to the Logbook",
+          "use_vwc_steering": "Enable VWC Crop Steering",
+          "substrate_media_type": "Substrate Media Type",
+          "substrate_liters_per_pot": "Substrate Volume per Pot (L)",
+          "target_vwc_percent": "Target VWC (%)",
+          "maintenance_dryback_percent": "Maintenance Dryback (%)",
+          "shot_sizing_mode": "Shot Sizing Mode",
+          "pump_flow_rate_ml_per_sec": "Pump Flow Rate (ml/s)",
+          "lights_on_time": "Lights-On Time",
+          "p0_duration_minutes": "P0 Duration (minutes)",
+          "p1_shot_volume_percent": "P1 Shot Volume (%)",
+          "p1_shot_duration_seconds": "P1 Shot Duration (seconds)",
+          "p1_shot_interval_minutes": "P1 Shot Interval (minutes)",
+          "auto_advance_p1_to_p2": "Auto-Advance P1 to P2",
+          "p2_shot_volume_percent": "P2 Shot Volume (%)",
+          "p2_shot_duration_seconds": "P2 Shot Duration (seconds)",
+          "p2_shot_interval_minutes": "P2 Shot Interval (minutes)",
+          "p2_stop_before_lights_off_minutes": "Stop P2 Before Lights Off (minutes)",
+          "auto_advance_p2_to_p3": "Auto-Advance P2 to P3",
+          "ec_modulation_enabled": "Enable EC Modulation",
+          "pore_ec_target_min": "Minimum Pore EC Target",
+          "pore_ec_target_max": "Maximum Pore EC Target",
+          "halt_on_runoff_ec_threshold": "Halt on Runoff EC Above"
+        },
+        "data_description": {
+          "shot_sizing_mode": "Duration Mode uses fixed shot durations; Volume Mode derives them from the pump flow rate and substrate volume.",
+          "growspace_id_read_only": "The growspace these settings apply to. Read-only."
+        }
+      },
+      "update_growspace": {
+        "title": "Update Growspace",
+        "description": "Change the name, dimensions, or notification target of this growspace.",
+        "data": {
+          "name": "Growspace Name",
+          "length": "Length (cm)",
+          "width": "Width (cm)",
+          "height": "Height (cm)",
+          "rows": "Number of Rows",
+          "plants_per_row": "Plants per Row",
+          "notification_target": "Notification Target"
+        },
+        "data_description": {
+          "notification_target": "Optional: notification service (e.g., mobile_app_your_phone)"
+        }
+      },
+      "confirm_remove_growspace": {
+        "title": "Remove Growspace",
+        "description": "Remove {growspace_name} and every plant in it? This cannot be undone."
+      },
+      "configure_humidifier": {
+        "title": "Humidifier Thresholds for {growspace_name}",
+        "description": "Set the VPD band that turns the humidifier on and off, per growth stage and day/night cycle.",
+        "data": {
+          "seedling_day_on": "Seedling — Day turn on (kPa)",
+          "seedling_day_off": "Seedling — Day turn off (kPa)",
+          "seedling_night_on": "Seedling — Night turn on (kPa)",
+          "seedling_night_off": "Seedling — Night turn off (kPa)",
+          "veg_day_on": "Vegetative — Day turn on (kPa)",
+          "veg_day_off": "Vegetative — Day turn off (kPa)",
+          "veg_night_on": "Vegetative — Night turn on (kPa)",
+          "veg_night_off": "Vegetative — Night turn off (kPa)",
+          "flower_early_day_on": "Early Flower — Day turn on (kPa)",
+          "flower_early_day_off": "Early Flower — Day turn off (kPa)",
+          "flower_early_night_on": "Early Flower — Night turn on (kPa)",
+          "flower_early_night_off": "Early Flower — Night turn off (kPa)",
+          "flower_mid_day_on": "Mid Flower — Day turn on (kPa)",
+          "flower_mid_day_off": "Mid Flower — Day turn off (kPa)",
+          "flower_mid_night_on": "Mid Flower — Night turn on (kPa)",
+          "flower_mid_night_off": "Mid Flower — Night turn off (kPa)",
+          "flower_late_day_on": "Late Flower — Day turn on (kPa)",
+          "flower_late_day_off": "Late Flower — Day turn off (kPa)",
+          "flower_late_night_on": "Late Flower — Night turn on (kPa)",
+          "flower_late_night_off": "Late Flower — Night turn off (kPa)",
+          "dry_day_on": "Drying — Day turn on (kPa)",
+          "dry_day_off": "Drying — Day turn off (kPa)",
+          "dry_night_on": "Drying — Night turn on (kPa)",
+          "dry_night_off": "Drying — Night turn off (kPa)",
+          "cure_day_on": "Curing — Day turn on (kPa)",
+          "cure_day_off": "Curing — Day turn off (kPa)",
+          "cure_night_on": "Curing — Night turn on (kPa)",
+          "cure_night_off": "Curing — Night turn off (kPa)"
+        }
+      },
+      "configure_dehumidifier": {
+        "title": "Dehumidifier Thresholds for {growspace_name}",
+        "description": "Set the VPD band that turns the dehumidifier on and off, per growth stage and day/night cycle.",
+        "data": {
+          "seedling_day_on": "Seedling — Day turn on (kPa)",
+          "seedling_day_off": "Seedling — Day turn off (kPa)",
+          "seedling_night_on": "Seedling — Night turn on (kPa)",
+          "seedling_night_off": "Seedling — Night turn off (kPa)",
+          "veg_day_on": "Vegetative — Day turn on (kPa)",
+          "veg_day_off": "Vegetative — Day turn off (kPa)",
+          "veg_night_on": "Vegetative — Night turn on (kPa)",
+          "veg_night_off": "Vegetative — Night turn off (kPa)",
+          "flower_early_day_on": "Early Flower — Day turn on (kPa)",
+          "flower_early_day_off": "Early Flower — Day turn off (kPa)",
+          "flower_early_night_on": "Early Flower — Night turn on (kPa)",
+          "flower_early_night_off": "Early Flower — Night turn off (kPa)",
+          "flower_mid_day_on": "Mid Flower — Day turn on (kPa)",
+          "flower_mid_day_off": "Mid Flower — Day turn off (kPa)",
+          "flower_mid_night_on": "Mid Flower — Night turn on (kPa)",
+          "flower_mid_night_off": "Mid Flower — Night turn off (kPa)",
+          "flower_late_day_on": "Late Flower — Day turn on (kPa)",
+          "flower_late_day_off": "Late Flower — Day turn off (kPa)",
+          "flower_late_night_on": "Late Flower — Night turn on (kPa)",
+          "flower_late_night_off": "Late Flower — Night turn off (kPa)",
+          "dry_day_on": "Drying — Day turn on (kPa)",
+          "dry_day_off": "Drying — Day turn off (kPa)",
+          "dry_night_on": "Drying — Night turn on (kPa)",
+          "dry_night_off": "Drying — Night turn off (kPa)",
+          "cure_day_on": "Curing — Day turn on (kPa)",
+          "cure_day_off": "Curing — Day turn off (kPa)",
+          "cure_night_on": "Curing — Night turn on (kPa)",
+          "cure_night_off": "Curing — Night turn off (kPa)"
+        }
+      },
+      "configure_advanced_bayesian": {
+        "title": "Advanced Bayesian Settings for {growspace_name}",
+        "description": "Tune the Bayesian probabilities behind the environment sensors. Field names are derived from your configured sensors and are shown untranslated."
+      },
+      "configure_sensor_placement": {
+        "title": "Sensor Placement for {growspace_name}",
+        "description": "Give each sensor its X/Y/Z position inside the growspace. Field names are derived from your configured sensors and are shown untranslated."
+      },
+      "configure_fan_controller": {
+        "title": "Circulation Fan for {growspace_name}",
+        "description": "Choose how the circulation fan is regulated and the speed range it may use.",
+        "data": {
+          "enabled": "Enable Fan Controller",
+          "regulation_mode": "Regulation Mode",
+          "min_speed": "Minimum Speed (%)",
+          "max_speed": "Maximum Speed (%)",
+          "wind_enabled": "Enable Wind Simulation"
+        }
+      },
+      "configure_fan_vpd": {
+        "title": "VPD Fan Regulation for {growspace_name}",
+        "description": "Set the VPD target the fan regulates towards and the critical temperatures that override it.",
+        "data": {
+          "vpd_target": "VPD Target (kPa)",
+          "vpd_tolerance": "VPD Tolerance (kPa)",
+          "stage_vpd_enabled": "Use Per-Stage VPD Targets",
+          "critical_temp_high": "Critical High Temperature (°C)",
+          "critical_temp_low": "Critical Low Temperature (°C)",
+          "critical_temp_hysteresis": "Critical Temperature Hysteresis (°C)"
+        }
+      },
+      "configure_fan_humidity": {
+        "title": "Humidity Fan Regulation for {growspace_name}",
+        "description": "Set the humidity target the fan regulates towards.",
+        "data": {
+          "humidity_target": "Humidity Target (%)",
+          "humidity_tolerance": "Humidity Tolerance (%)"
+        }
+      },
+      "configure_fan_temperature": {
+        "title": "Temperature Fan Regulation for {growspace_name}",
+        "description": "Set the temperature target the fan regulates towards.",
+        "data": {
+          "temperature_target": "Temperature Target (°C)",
+          "temperature_tolerance": "Temperature Tolerance (°C)"
+        }
+      },
+      "configure_fan_wind": {
+        "title": "Wind Simulation for {growspace_name}",
+        "description": "Vary the fan speed over time to simulate natural wind.",
+        "data": {
+          "wind_amplitude_pct": "Wind Amplitude (%)",
+          "wind_period_seconds": "Wind Period (seconds)"
+        }
+      },
+      "manage_strain_library": {
+        "title": "Manage Strain Library",
+        "description": "Add, edit, import, or export the strains available to your plants.",
+        "data": {
+          "action": "Action",
+          "strain_id": "Select Strain"
+        }
+      },
+      "add_strain": {
+        "title": "Add Strain",
+        "description": "Add a new strain to the library.",
+        "data": {
+          "strain": "Strain Name",
+          "phenotype": "Phenotype",
+          "breeder": "Breeder",
+          "breeder_logo": "Breeder Logo URL",
+          "type": "Type",
+          "lineage": "Lineage",
+          "sex": "Sex",
+          "flower_days_min": "Minimum Flowering Days",
+          "flower_days_max": "Maximum Flowering Days",
+          "description": "Description",
+          "sativa_percentage": "Sativa (%)",
+          "indica_percentage": "Indica (%)",
+          "yield_potential": "Yield Potential"
+        }
+      },
+      "edit_strain": {
+        "title": "Edit Strain",
+        "description": "Change the details of an existing strain.",
+        "data": {
+          "strain": "Strain Name",
+          "phenotype": "Phenotype",
+          "breeder": "Breeder",
+          "breeder_logo": "Breeder Logo URL",
+          "type": "Type",
+          "lineage": "Lineage",
+          "sex": "Sex",
+          "flower_days_min": "Minimum Flowering Days",
+          "flower_days_max": "Maximum Flowering Days",
+          "description": "Description",
+          "sativa_percentage": "Sativa (%)",
+          "indica_percentage": "Indica (%)",
+          "yield_potential": "Yield Potential"
+        }
+      },
+      "import_strain_library": {
+        "title": "Import Strain Library",
+        "description": "Import strains from a ZIP archive. Imported strains are merged into the existing library.",
+        "data": {
+          "file_path": "ZIP File Path"
+        },
+        "data_description": {
+          "file_path": "Full path to the archive, e.g. {default_path}"
+        }
+      },
+      "export_strain_library": {
+        "title": "Export Strain Library",
+        "description": "The strain library was exported to {path}."
+      },
+      "manage_breeder_blacklist": {
+        "title": "Breeder Blacklist",
+        "description": "Breeders listed here are hidden from strain suggestions.",
+        "data": {
+          "blacklist_breeders": "Blacklisted Breeders"
+        }
+      },
+      "manage_timed_notifications": {
+        "title": "Timed Notifications",
+        "description": "Add, edit, or delete notifications that fire on a given day of a grow.",
+        "data": {
+          "action": "Action",
+          "notification_id": "Select Notification"
+        }
+      },
+      "add_timed_notification": {
+        "title": "Add Timed Notification",
+        "description": "Send a message once a grow reaches the given day.",
+        "data": {
+          "message": "Message",
+          "trigger_type": "Count Days From",
+          "day": "Day",
+          "growspace_ids": "Growspaces"
+        },
+        "data_description": {
+          "growspace_ids": "Leave empty to apply to every growspace"
+        }
+      },
+      "edit_timed_notification": {
+        "title": "Edit Timed Notification",
+        "description": "Change when this notification fires and what it says.",
+        "data": {
+          "message": "Message",
+          "trigger_type": "Count Days From",
+          "day": "Day",
+          "growspace_ids": "Growspaces"
+        },
+        "data_description": {
+          "growspace_ids": "Leave empty to apply to every growspace"
+        }
+      },
+      "delete_timed_notification": {
+        "title": "Delete Timed Notification",
+        "description": "Delete notification {notification_id}? This cannot be undone."
       }
     },
     "error": {
@@ -454,7 +544,248 @@
       "invalid_position": "The selected position is outside the growspace boundaries",
       "assistant_required": "An AI assistant entity must be selected when AI features are enabled",
       "strain_delete_blocked": "Cannot delete {strain}: {detail}. Resolve those references first, then try again.",
-      "delete_failed": "The strain could not be deleted because of an unexpected error. Check the logs for details."
+      "delete_failed": "The strain could not be deleted because of an unexpected error. Check the logs for details.",
+      "setup_error": "The integration is not set up yet. Try again once it has finished loading.",
+      "file_not_found": "No file was found at that path. Check the path and try again.",
+      "invalid_zip": "That file is not a valid strain library archive.",
+      "import_failed": "The strain library could not be imported. Check the logs for details.",
+      "add_failed": "The item could not be added because of an unexpected error. Check the logs for details.",
+      "update_failed": "The item could not be updated because of an unexpected error. Check the logs for details.",
+      "remove_failed": "The item could not be removed because of an unexpected error. Check the logs for details.",
+      "select_growspace": "Select a growspace to continue",
+      "fan_speed_invalid": "The minimum fan speed must be lower than the maximum fan speed",
+      "invalid_tuple_format": "The advanced Bayesian values must be entered as number pairs, for example (0.1, 0.9)"
+    },
+    "abort": {
+      "setup_error": "The integration is not set up yet. Try again once it has finished loading.",
+      "export_failed": "The strain library could not be exported. Check the logs for details.",
+      "growspace_not_found": "The selected growspace could not be found.",
+      "plant_not_found": "The selected plant could not be found.",
+      "notification_not_found": "The selected notification could not be found.",
+      "no_growspaces": "No growspaces are configured yet. Add one first."
+    }
+  },
+  "services": {
+    "add_growspace": {
+      "name": "Add Growspace",
+      "description": "Create a new growspace for managing plants",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "Name of the growspace"
+        },
+        "rows": {
+          "name": "Rows",
+          "description": "Number of rows in the growspace"
+        },
+        "plants_per_row": {
+          "name": "Plants per Row",
+          "description": "Number of plants per row"
+        },
+        "notification_target": {
+          "name": "Notification Target",
+          "description": "Notification service target (e.g., mobile_app_your_phone)"
+        }
+      }
+    },
+    "remove_growspace": {
+      "name": "Remove Growspace",
+      "description": "Remove a growspace and all its plants",
+      "fields": {
+        "growspace_id": {
+          "name": "Growspace ID",
+          "description": "ID of the growspace to remove"
+        }
+      }
+    },
+    "add_plant": {
+      "name": "Add Plant",
+      "description": "Add a plant to a growspace",
+      "fields": {
+        "growspace_id": {
+          "name": "Growspace ID",
+          "description": "ID of the target growspace"
+        },
+        "strain": {
+          "name": "Strain",
+          "description": "Plant strain name"
+        },
+        "row": {
+          "name": "Row",
+          "description": "Row position in the growspace"
+        },
+        "col": {
+          "name": "Column",
+          "description": "Column position in the growspace"
+        },
+        "phenotype": {
+          "name": "Phenotype",
+          "description": "Plant phenotype (optional)"
+        },
+        "veg_start": {
+          "name": "Vegetative Start",
+          "description": "When vegetative stage started"
+        },
+        "flower_start": {
+          "name": "Flowering Start",
+          "description": "When flowering stage started"
+        }
+      }
+    },
+    "update_plant": {
+      "name": "Update Plant",
+      "description": "Update plant information",
+      "fields": {
+        "plant_id": {
+          "name": "Plant ID",
+          "description": "ID of the plant to update"
+        },
+        "strain": {
+          "name": "Strain",
+          "description": "Plant strain name"
+        },
+        "phenotype": {
+          "name": "Phenotype",
+          "description": "Plant phenotype"
+        },
+        "row": {
+          "name": "Row",
+          "description": "Row position in the growspace"
+        },
+        "col": {
+          "name": "Column",
+          "description": "Column position in the growspace"
+        },
+        "veg_start": {
+          "name": "Vegetative Start",
+          "description": "When vegetative stage started"
+        },
+        "flower_start": {
+          "name": "Flowering Start",
+          "description": "When flowering stage started"
+        }
+      }
+    },
+    "remove_plant": {
+      "name": "Remove Plant",
+      "description": "Remove a plant from the growspace",
+      "fields": {
+        "plant_id": {
+          "name": "Plant ID",
+          "description": "ID of the plant to remove"
+        }
+      }
+    },
+    "trigger_vision_checkup": {
+      "name": "Trigger vision checkup",
+      "description": "Capture camera snapshot(s) and run AI vision analysis to detect plant health issues like drooping, pests, or nutrient deficiencies.",
+      "fields": {
+        "growspace_id": {
+          "name": "Growspace ID",
+          "description": "The ID of the growspace to analyze."
+        }
+      }
+    }
+  },
+  "issues": {
+    "pending_growspace_fail": {
+      "title": "Failed to create pending growspace",
+      "description": "The system failed to create the pending growspace {name}. Error: {error}. Please check the logs for more details."
+    },
+    "exhaust_fan_migration": {
+      "title": "Exhaust fans need to be re-enabled for {growspace}",
+      "description": "Exhaust fans are now controlled by the dedicated exhaust fan controller instead of the dehumidifier. Because of this change, the exhaust fans in {growspace} are no longer being cycled automatically. Open the Exhaust panel for {growspace} and enable the exhaust fan controller to restore automatic control. This was not migrated automatically because the old on/off humidity thresholds do not map onto the new speed-based settings."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "vpd": {
+        "name": "VPD"
+      },
+      "growspaces_list": {
+        "name": "Growspaces List"
+      },
+      "strain_library": {
+        "name": "Strain Library"
+      },
+      "dli": {
+        "name": "Daily Light Integral"
+      },
+      "crop_steering": {
+        "name": "Crop Steering Score"
+      },
+      "energy_usage": {
+        "name": "Energy Usage"
+      },
+      "water_usage": {
+        "name": "Water Usage"
+      },
+      "ec_target": {
+        "name": "EC Target"
+      },
+      "vision_checkup": {
+        "name": "Vision checkup"
+      },
+      "tank_derived_water": {
+        "name": "Tank water consumption"
+      },
+      "calculated_vpd": {
+        "name": "Calculated VPD"
+      },
+      "plant": {
+        "name": "Plant"
+      },
+      "seed_inventory": {
+        "name": "Seed inventory"
+      },
+      "drying_weight": {
+        "name": "Drying weight"
+      },
+      "drying_moisture": {
+        "name": "Drying moisture"
+      },
+      "air_exchange": {
+        "name": "Air Exchange"
+      },
+      "overview": {
+        "name": "Overview"
+      },
+      "power_usage": {
+        "name": "Power Usage"
+      }
+    },
+    "binary_sensor": {
+      "light_verification": {
+        "name": "Light cycle verification"
+      },
+      "drying_ready_for_cure": {
+        "name": "Ready for cure"
+      },
+      "stress": {
+        "name": "Stress"
+      },
+      "mold": {
+        "name": "Mold Risk"
+      },
+      "optimal": {
+        "name": "Optimal Conditions"
+      },
+      "drying": {
+        "name": "Drying"
+      },
+      "curing": {
+        "name": "Curing"
+      }
+    },
+    "switch": {
+      "notifications": {
+        "name": "Notifications"
+      }
+    }
+  },
+  "exceptions": {
+    "phi_not_cleared": {
+      "message": "Cannot harvest {plant_id}: pre-harvest interval not cleared until {clearance_date} ({days_remaining} days remaining)."
     }
   }
 }

--- a/custom_components/growspace_manager/translations/en.json
+++ b/custom_components/growspace_manager/translations/en.json
@@ -479,12 +479,9 @@
       },
       "import_strain_library": {
         "title": "Import Strain Library",
-        "description": "Import strains from a ZIP archive. Imported strains are merged into the existing library.",
+        "description": "Import strains from a ZIP archive, for example {default_path}. Imported strains are merged into the existing library.",
         "data": {
           "file_path": "ZIP File Path"
-        },
-        "data_description": {
-          "file_path": "Full path to the archive, e.g. {default_path}"
         }
       },
       "export_strain_library": {

--- a/tests/contract/test_translation_parity.py
+++ b/tests/contract/test_translation_parity.py
@@ -41,16 +41,30 @@ def _leaf_keys(value: Any, prefix: str = "") -> set[str]:
     }
 
 
-def _step_ids_shown_by_flows() -> set[str]:
-    """Collect every literal ``step_id`` the config and options flows show."""
+def _literals_matching(pattern: str) -> set[str]:
+    """Collect every string literal the component matches against ``pattern``."""
     return {
         match
         for source in COMPONENT_DIR.rglob("*.py")
-        for match in re.findall(
-            r'step_id\s*=\s*["\']([A-Za-z0-9_]+)["\']',
-            source.read_text(encoding="utf-8"),
-        )
+        for match in re.findall(pattern, source.read_text(encoding="utf-8"))
     }
+
+
+def _step_ids_shown_by_flows() -> set[str]:
+    """Collect every literal ``step_id`` the config and options flows show."""
+    return _literals_matching(r'step_id\s*=\s*["\']([A-Za-z0-9_]+)["\']')
+
+
+def _error_keys_set_by_flows() -> set[str]:
+    """Collect every literal key the flows put on ``errors["base"]``."""
+    # Both spellings the handlers use: ``errors={"base": "x"}`` and
+    # ``errors["base"] = "x"``.
+    return _literals_matching(r'"base"\]?\s*[:=]\s*["\']([A-Za-z0-9_]+)["\']')
+
+
+def _abort_reasons_raised_by_flows() -> set[str]:
+    """Collect every literal reason the flows abort with."""
+    return _literals_matching(r'reason\s*=\s*["\']([A-Za-z0-9_]+)["\']')
 
 
 def test_strings_and_en_translations_have_the_same_keys() -> None:
@@ -78,6 +92,27 @@ def test_every_shown_step_has_a_translation() -> None:
 
     assert not untranslated, (
         f"steps shown by a flow with no strings.json entry: {untranslated}"
+    )
+
+
+def test_every_error_and_abort_the_flows_raise_has_a_translation() -> None:
+    """No form error or abort dialog renders as a raw translation key.
+
+    Only the options flow reaches ``config_handlers/``; the config flow builds
+    its one step inline, which is why both are checked against ``options``.
+    """
+    options = _load(STRINGS_PATH)["options"]
+
+    untranslated_errors = sorted(_error_keys_set_by_flows() - set(options["error"]))
+    untranslated_aborts = sorted(
+        _abort_reasons_raised_by_flows() - set(options["abort"])
+    )
+
+    assert not untranslated_errors, (
+        f"errors raised by a flow with no strings.json entry: {untranslated_errors}"
+    )
+    assert not untranslated_aborts, (
+        f"aborts raised by a flow with no strings.json entry: {untranslated_aborts}"
     )
 
 

--- a/tests/contract/test_translation_parity.py
+++ b/tests/contract/test_translation_parity.py
@@ -1,0 +1,102 @@
+"""Keep ``strings.json`` and ``translations/en.json`` from drifting apart.
+
+Home Assistant loads a custom component's translations from
+``translations/<lang>.json``; ``strings.json`` is only the source a translation
+generator would read. This repository has no generator, so both files are
+hand-maintained and a key added to one but not the other renders in the UI as a
+raw translation key. These tests are what makes that drift fail loudly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+COMPONENT_DIR = Path(__file__).parents[2] / "custom_components" / "growspace_manager"
+STRINGS_PATH = COMPONENT_DIR / "strings.json"
+EN_PATH = COMPONENT_DIR / "translations" / "en.json"
+
+# Steps whose form fields are named after the user's own entities, so no static
+# translation can cover them. The step's title and description are translated;
+# the individual fields are intentionally left raw.
+STEPS_WITH_GENERATED_FIELDS = frozenset(
+    {"configure_advanced_bayesian", "configure_sensor_placement"}
+)
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _leaf_keys(value: Any, prefix: str = "") -> set[str]:
+    """Flatten a translation tree into dotted paths to its leaf strings."""
+    if not isinstance(value, dict):
+        return {prefix}
+    return {
+        key
+        for name, child in value.items()
+        for key in _leaf_keys(child, f"{prefix}.{name}" if prefix else name)
+    }
+
+
+def _step_ids_shown_by_flows() -> set[str]:
+    """Collect every literal ``step_id`` the config and options flows show."""
+    return {
+        match
+        for source in COMPONENT_DIR.rglob("*.py")
+        for match in re.findall(
+            r'step_id\s*=\s*["\']([A-Za-z0-9_]+)["\']',
+            source.read_text(encoding="utf-8"),
+        )
+    }
+
+
+def test_strings_and_en_translations_have_the_same_keys() -> None:
+    """Every key in one file exists in the other, across all sections."""
+    strings_keys = _leaf_keys(_load(STRINGS_PATH))
+    en_keys = _leaf_keys(_load(EN_PATH))
+
+    missing_from_en = sorted(strings_keys - en_keys)
+    missing_from_strings = sorted(en_keys - strings_keys)
+
+    assert not missing_from_en, (
+        f"keys in strings.json missing from translations/en.json: {missing_from_en}"
+    )
+    assert not missing_from_strings, (
+        f"keys in translations/en.json missing from strings.json: "
+        f"{missing_from_strings}"
+    )
+
+
+def test_every_shown_step_has_a_translation() -> None:
+    """No flow step renders as a raw translation key."""
+    strings = _load(STRINGS_PATH)
+    translated = set(strings["config"]["step"]) | set(strings["options"]["step"])
+    untranslated = sorted(_step_ids_shown_by_flows() - translated)
+
+    assert not untranslated, (
+        f"steps shown by a flow with no strings.json entry: {untranslated}"
+    )
+
+
+def test_translated_steps_carry_a_title() -> None:
+    """A step entry without a title is drift that the key check cannot see."""
+    strings = _load(STRINGS_PATH)
+    for section in ("config", "options"):
+        for step_id, step in strings[section]["step"].items():
+            assert "title" in step, f"{section}.step.{step_id} has no title"
+
+
+def test_step_fields_are_translated_unless_generated() -> None:
+    """Steps whose fields come from a static schema label all of them."""
+    strings = _load(STRINGS_PATH)
+    for step_id in STEPS_WITH_GENERATED_FIELDS:
+        assert step_id in strings["options"]["step"], (
+            f"{step_id} is listed as having generated fields but has no entry"
+        )
+        assert "data" not in strings["options"]["step"][step_id], (
+            f"{step_id} has generated field names; drop its 'data' block or "
+            "remove it from STEPS_WITH_GENERATED_FIELDS"
+        )


### PR DESCRIPTION
Closes #568.

## What changed

**`strings.json` + `translations/en.json`**

- **23 missing options steps added.** Every `step_id` that `config_handlers/` passes to `async_show_form` now has a title, description, and field labels: the strain library (`manage_strain_library`, `add_strain`, `edit_strain`, `import_strain_library`, `export_strain_library`, `manage_breeder_blacklist`), timed notifications (`manage_`/`add_`/`edit_`/`delete_timed_notification`), growspaces (`update_growspace`, `confirm_remove_growspace`, `select_growspace_for_env`), irrigation (`irrigation_overview`), the fan controller (`configure_fan_controller`/`_vpd`/`_humidity`/`_temperature`/`_wind`), and the appliance/Bayesian steps (`configure_humidifier`, `configure_dehumidifier`, `configure_advanced_bayesian`, `configure_sensor_placement`).
- **Error keys completed.** `setup_error`, `file_not_found`, `invalid_zip`, `import_failed` (the four `async_step_import_strain_library` emits) plus `add_failed`, `update_failed`, `remove_failed`, `select_growspace`, `fan_speed_invalid`, `invalid_tuple_format` — all sourced by grepping what the handlers actually set on `errors["base"]`.
- **`options.abort` created.** It did not exist. `export_failed` is an abort reason, not an error, so it lands here alongside `setup_error`, `growspace_not_found`, `plant_not_found`, `notification_not_found`, `no_growspaces`.
- `add_growspace` gained the `length`/`width`/`height` labels its schema always built but strings never named.
- The 9 entity names that lived only in `en.json` were added to `strings.json`; the `trigger_vision_checkup` service strings that lived only in `strings.json` now reach `en.json`. `en.json` is now an exact mirror of `strings.json`.

**`tests/contract/test_translation_parity.py`** (new) — four checks that make the drift fail loudly:

1. whole-file key-set parity in both directions (not scoped to `options`, because `services` and `entity` had drifted too — an options-only check would have passed green on a drifted file)
2. every `step_id` shown by a flow has a `strings.json` entry
3. every step entry carries a `title`
4. the two steps with entity-derived field names keep no `data` block, so "intentionally untranslated" stays an explicit, reviewed decision

## Notes for the reviewer

- **AC1 was already satisfied before this branch.** Commit `1071ece` on `prerelease` (a side-effect of #567 — hassfest rejects an `options` section with no `step` key) synced the options block. Verified 0 key diff in both directions; not claiming it as work here. The other three ACs are this PR.
- **Two steps are deliberately field-untranslated.** `configure_advanced_bayesian` and `configure_sensor_placement` build field names from the user's own configured sensors (`coord_{sensor}_x`, per-sensor Bayesian keys). No static translation can cover them, so they get a translated title/description and their descriptions say the field names are shown untranslated. Test 4 pins this.
- **Stage-threshold fields were enumerated, not skipped.** `configure_humidifier`/`configure_dehumidifier` build `{stage}_{cycle}_{on,off}` keys — dynamic in form but a closed set (7 stages × day/night × on/off), so all 28 are labelled per step.
- **Stale entries left in place.** `main_menu`, `edit_pump_settings`, `add`/`remove_irrigation_time`, `add`/`remove_drain_time`, and `configure_irrigation` (superseded by `irrigation_overview`) have no live `step_id`. No AC asks for deletion and a step id could be constructed somewhere the grep can't see, so they stay — worth a follow-up if you want them gone.
- **Out of scope, flagged:** `config_flow.py:106` and `:148` pass `errors={"base": f"Error: {err}"}` — an interpolated string, not a translation key, so it can never resolve. Separate bug.
- The `en.json` diff looks larger than it is: sections are reordered to match `strings.json`, no values were changed.

## Verification

- `pytest tests/` — 4928 passed
- `ruff check` / `ruff format --check` clean on the new test
- hassfest: `Validating translations... done`, no translation errors (the one reported error is a pre-existing `aiosqlite>=0.17.0` requirement-normalization failure, untouched by this PR)
- Mutation-checked the parity test: deleting one key from `en.json` fails it with a readable diff

Not verified in the running UI — worth a look, since this changes visible text across the whole options flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)