### PR TITLE
Prune Ancestor Strains after their final lineage reference is removed

### DIFF
--- a/custom_components/growspace_manager/managers/lineage.py
+++ b/custom_components/growspace_manager/managers/lineage.py
@@ -15,6 +15,9 @@ from ..exceptions import GrowspaceError
 
 _LOGGER = logging.getLogger(__name__)
 
+# Upper bound on prune passes, so a lineage cycle cannot loop forever.
+_MAX_PRUNE_PASSES = 32
+
 type StoredParent = dict[str, str]
 type StoredParents = list[StoredParent]
 type LineageNode = dict[str, Any]
@@ -171,6 +174,89 @@ class StrainLineageManager:
             )
         await self._db.commit()
 
+    async def prune_orphan_ancestor_strains(
+        self, protected: set[str] | None = None
+    ) -> list[str]:
+        """Delete Ancestor Strains that no lineage references any more.
+
+        An Ancestor Strain (``is_stub = 1``) exists only to hold a position in
+        someone's lineage. Once the last ``strain_ancestry`` row naming it is
+        gone, the record is unreachable and would otherwise accumulate with
+        every lineage edit.
+
+        Deleting a stub drops the ancestry rows where it was the *descendant*,
+        which can orphan its own parents, so this repeats until a pass deletes
+        nothing. Catalogued Strains are never touched — ``is_stub = 1`` is the
+        whole guard. ``protected`` shields names the caller is mid-way through
+        writing, whose ancestry rows may not exist yet.
+
+        Returns the names pruned, oldest pass first.
+        """
+        if self._db is None:
+            return []
+
+        protected = protected or set()
+        pruned: list[str] = []
+
+        # Bounded so a cyclic lineage cannot spin forever; each pass must
+        # delete at least one row to continue, so the cap is never reached by
+        # a well-formed graph.
+        for _ in range(_MAX_PRUNE_PASSES):
+            # ``await execute`` rather than ``async with``, matching
+            # _rebuild_strain_ancestry above.
+            cursor = await self._db.execute(
+                """
+                SELECT s.strain_id, s.strain_name
+                FROM strains s
+                WHERE s.is_stub = 1
+                  AND NOT EXISTS (
+                      SELECT 1 FROM strain_ancestry sa
+                      WHERE sa.ancestor_name = s.strain_name
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1 FROM harvests h
+                      JOIN phenotypes p ON p.phenotype_id = h.phenotype_id
+                      WHERE p.strain_id = s.strain_id
+                  )
+                """
+            )
+            rows = await cursor.fetchall()
+            orphans = [(row[0], row[1]) for row in rows if row[1] not in protected]
+
+            if not orphans:
+                break
+
+            for strain_id, strain_name in orphans:
+                # No ON DELETE CASCADE on phenotypes, so tear down in the same
+                # order remove_strain does or the rows leak.
+                await self._db.execute(
+                    "DELETE FROM phenotypes WHERE strain_id = ?", (strain_id,)
+                )
+                await self._db.execute(
+                    "DELETE FROM strain_ancestry WHERE descendant_strain_id = ?",
+                    (strain_id,),
+                )
+                await self._db.execute(
+                    "DELETE FROM strains WHERE strain_id = ?", (strain_id,)
+                )
+                pruned.append(strain_name)
+            await self._db.commit()
+        else:
+            # Loop ran its full budget with orphans still pending, which means
+            # the ancestry graph has a cycle. Truncating silently would hide it.
+            _LOGGER.warning(
+                "Stopped pruning ancestor strains after %d passes with orphans"
+                " remaining; the lineage graph may contain a cycle",
+                _MAX_PRUNE_PASSES,
+            )
+
+        if pruned:
+            self._lineage_cache.clear()
+            if self._load_callback is not None:
+                await self._load_callback()
+            _LOGGER.info("Pruned %d unreferenced ancestor strains", len(pruned))
+        return pruned
+
     async def update_strain_lineage_tree(
         self,
         strain_name: str,
@@ -193,6 +279,7 @@ class StrainLineageManager:
         if self._load_callback is not None:
             await self._load_callback()
         await self._rebuild_strain_ancestry(strain_name)
+        await self.prune_orphan_ancestor_strains(protected={strain_name})
         _LOGGER.info("Updated lineage tree for strain '%s'", strain_name)
         return flat_lineage
 
@@ -289,6 +376,16 @@ class StrainLineageManager:
         self._lineage_cache.clear()
         for name in lineage_by_node:
             await self._rebuild_strain_ancestry(name)
+        # Only after every node's ancestry is rebuilt — pruning inside the loop
+        # would delete stubs that a later node is about to reference.
+        # Every name this import touched, not just the nodes that have parents:
+        # a leaf ancestor gets a stub but never a lineage_by_node entry, and if
+        # the root has no strains row yet the rebuild above no-ops, leaving
+        # nothing to name it. Stubs from a previous tree are absent from
+        # all_names, so a re-import still prunes them.
+        await self.prune_orphan_ancestor_strains(
+            protected={root_strain_name, *all_names}
+        )
         _LOGGER.info(
             "Imported seedfinder lineage tree for '%s' (%d nodes)",
             root_strain_name,

--- a/custom_components/growspace_manager/strain_library.py
+++ b/custom_components/growspace_manager/strain_library.py
@@ -338,14 +338,18 @@ class StrainLibrary:
                     crop_meta = json.loads(raw_crop)
                 except json.JSONDecodeError:
                     crop_meta = None
-            gallery = [{"path": image_path, "crop_meta": crop_meta, "is_thumbnail": True}]
+            gallery = [
+                {"path": image_path, "crop_meta": crop_meta, "is_thumbnail": True}
+            ]
             await self._db.execute(
                 "UPDATE phenotypes SET images = ? WHERE phenotype_id = ?",
                 (json.dumps(gallery), row["phenotype_id"]),
             )
 
         await self._db.commit()
-        _LOGGER.info("Migrated %d phenotype(s) from image_path to images gallery", len(rows))
+        _LOGGER.info(
+            "Migrated %d phenotype(s) from image_path to images gallery", len(rows)
+        )
 
     async def load(self) -> None:
         """Load all strain and phenotype data into the in-memory cache."""
@@ -440,7 +444,7 @@ class StrainLibrary:
                         val = row[field]
                         try:
                             meta[field] = json.loads(val) if val else []
-                        except (json.JSONDecodeError, TypeError):
+                        except json.JSONDecodeError, TypeError:
                             meta[field] = []
 
                     if lineage_tree is not None:
@@ -470,8 +474,10 @@ class StrainLibrary:
                         try:
                             parsed = json.loads(raw_images)
                             images = [
-                                img for img in parsed
-                                if isinstance(img, dict) and "=404" not in (img.get("path") or "")
+                                img
+                                for img in parsed
+                                if isinstance(img, dict)
+                                and "=404" not in (img.get("path") or "")
                             ] or None
                         except json.JSONDecodeError:
                             _LOGGER.warning(
@@ -483,7 +489,9 @@ class StrainLibrary:
                     phenotype_data = {
                         "phenotype_id": pheno_id,
                         "description": row["description"],
-                        "image_path": None if (raw_image_path and "=404" in raw_image_path) else raw_image_path,
+                        "image_path": None
+                        if (raw_image_path and "=404" in raw_image_path)
+                        else raw_image_path,
                         "image_crop_meta": image_crop_meta,
                         "images": images,
                         "flower_days_min": row["flower_days_min"],
@@ -799,7 +807,10 @@ class StrainLibrary:
                 # Store only immediate parents (StoredParents flat list), not the
                 # full nested tree — get_strain_lineage_tree() builds the tree on demand.
                 [
-                    {"name": p.get("name", "").strip(), "source": p.get("source", "library")}
+                    {
+                        "name": p.get("name", "").strip(),
+                        "source": p.get("source", "library"),
+                    }
                     for p in (lineage_tree.get("parents") or [])[:2]
                     if p.get("name", "").strip()
                 ]
@@ -873,6 +884,9 @@ class StrainLibrary:
                     [(name, strain_id, depth, url) for name, url, depth in ancestors],
                 )
             await self._db.commit()
+            await self._lineage_manager.prune_orphan_ancestor_strains(
+                protected={strain}
+            )
         # Prepare phenotype data
         pheno_data = {
             "description": description,
@@ -1007,7 +1021,9 @@ class StrainLibrary:
         self, strain_name: str, parents: StoredParents
     ) -> str:
         """Replace a strain's recorded parents and rebuild its lineage tree."""
-        return await self._lineage_manager.update_strain_lineage_tree(strain_name, parents)
+        return await self._lineage_manager.update_strain_lineage_tree(
+            strain_name, parents
+        )
 
     async def async_import_seedfinder_lineage_tree(
         self,
@@ -1024,7 +1040,9 @@ class StrainLibrary:
         self, strain_name: str, generation: str
     ) -> None:
         """Update the recorded generation label for a strain."""
-        await self._lineage_manager.async_update_strain_generation(strain_name, generation)
+        await self._lineage_manager.async_update_strain_generation(
+            strain_name, generation
+        )
 
     def get_strain_lineage_tree(
         self,
@@ -1101,7 +1119,10 @@ class StrainLibrary:
             return result
 
         # Fallback: prefer "default", then alphabetical siblings
-        fallback_order = ["default", *sorted(k for k in phenotypes if k not in ("default", normalized))]
+        fallback_order = [
+            "default",
+            *sorted(k for k in phenotypes if k not in ("default", normalized)),
+        ]
         for sibling_name in fallback_order:
             sibling = phenotypes.get(sibling_name, {})
             result = _thumbnail_from(sibling)
@@ -1258,6 +1279,10 @@ class StrainLibrary:
                 "DELETE FROM strains WHERE strain_id = ?", (strain_id,)
             )
         await self._db.commit()
+
+        # Demoting or deleting this strain drops the ancestry rows it owned,
+        # which can leave its own ancestors with no descendant left.
+        await self._lineage_manager.prune_orphan_ancestor_strains()
 
         safe_strain = slugify(strain)
         for phenotype_name in phenotype_names:

--- a/tests/services/test_strain_ancestor_pruning.py
+++ b/tests/services/test_strain_ancestor_pruning.py
@@ -1,0 +1,305 @@
+"""Pruning of Ancestor Strains once their last lineage reference is gone.
+
+An Ancestor Strain (``strains.is_stub = 1``) exists only to hold a position in
+someone's lineage. Two things create them: the seedfinder import, which inserts
+a stub per ancestor node, and ``remove_strain``, which demotes a Catalogued
+Strain that is still referenced by another lineage. Both are exercised here.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiosqlite
+import pytest
+
+from custom_components.growspace_manager.strain_library import StrainLibrary
+
+
+@pytest.fixture
+def mock_hass() -> MagicMock:
+    """Mock Home Assistant instance."""
+    hass = MagicMock()
+    hass.config.path = MagicMock(side_effect=lambda *args: "/".join(args))
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda f, *args: f(*args))
+    hass.config_entries.async_entries = MagicMock(return_value=[])
+    return hass
+
+
+@pytest.fixture
+async def strain_library(mock_hass: MagicMock) -> Any:
+    """A StrainLibrary backed by an in-memory database."""
+    real_connect = aiosqlite.connect
+
+    async def mock_connect(database: str, **kwargs: Any) -> Any:
+        return await real_connect(":memory:", **kwargs)
+
+    with (
+        patch(
+            "custom_components.growspace_manager.strain_library.ImageManager",
+            return_value=MagicMock(
+                delete_image=MagicMock(),
+                async_setup=AsyncMock(),
+                async_migrate_to_webp=AsyncMock(return_value=False),
+            ),
+        ),
+        patch(
+            "custom_components.growspace_manager.strain_library.ImportExportManager",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "custom_components.growspace_manager.strain_library.aiosqlite.connect",
+            side_effect=mock_connect,
+        ),
+    ):
+        library = StrainLibrary(mock_hass)
+        await library.async_setup()
+        yield library
+        await library.async_close()
+
+
+def _node(name: str, *parents: dict[str, Any]) -> dict[str, Any]:
+    """Build a lineage_tree node."""
+    return {"name": name, "parents": list(parents)}
+
+
+async def _strain_names(library: StrainLibrary) -> set[str]:
+    """Every strain row currently in the database."""
+    async with library._db.execute("SELECT strain_name FROM strains") as cursor:
+        return {row[0] for row in await cursor.fetchall()}
+
+
+async def _stub_names(library: StrainLibrary) -> set[str]:
+    """Every Ancestor Strain (stub) row currently in the database."""
+    async with library._db.execute(
+        "SELECT strain_name FROM strains WHERE is_stub = 1"
+    ) as cursor:
+        return {row[0] for row in await cursor.fetchall()}
+
+
+async def _orphan_phenotype_count(library: StrainLibrary) -> int:
+    """Phenotype rows whose strain no longer exists."""
+    async with library._db.execute(
+        """
+        SELECT COUNT(*) FROM phenotypes p
+        WHERE NOT EXISTS (SELECT 1 FROM strains s WHERE s.strain_id = p.strain_id)
+        """
+    ) as cursor:
+        return (await cursor.fetchone())[0]
+
+
+async def _add_root(library: StrainLibrary, name: str = "Root") -> None:
+    """Add a Catalogued Strain to hang a lineage off."""
+    await library.add_strain(name, "default", breeder="Breeder")
+
+
+async def _import_chain(library: StrainLibrary, root: str = "Root") -> None:
+    """Import Root <- Parent <- Grandparent, creating two ancestor stubs."""
+    await library.async_import_seedfinder_lineage_tree(
+        root, _node(root, _node("Parent", _node("Grandparent")))
+    )
+
+
+@pytest.mark.asyncio
+async def test_final_reference_removal_prunes_the_ancestor(
+    strain_library: StrainLibrary,
+) -> None:
+    """Dropping the last lineage referencing an ancestor deletes it."""
+    await _add_root(strain_library)
+    await _import_chain(strain_library)
+    assert await _stub_names(strain_library) == {"Parent", "Grandparent"}
+
+    await strain_library.update_strain_lineage_tree("Root", [])
+
+    assert await _stub_names(strain_library) == set()
+    assert await _strain_names(strain_library) == {"Root"}
+
+
+@pytest.mark.asyncio
+async def test_ancestor_shared_by_another_lineage_survives(
+    strain_library: StrainLibrary,
+) -> None:
+    """An ancestor another strain still descends from is kept.
+
+    Both ancestors are flat, one level up, so this isolates sharing from the
+    recursive-ancestry rule covered by the next test.
+    """
+    await _add_root(strain_library, "Root")
+    await _add_root(strain_library, "Sibling")
+    await strain_library.async_import_seedfinder_lineage_tree(
+        "Root", _node("Root", _node("Shared"), _node("RootOnly"))
+    )
+    await strain_library.async_import_seedfinder_lineage_tree(
+        "Sibling", _node("Sibling", _node("Shared"))
+    )
+
+    await strain_library.update_strain_lineage_tree("Root", [])
+
+    # Sibling still descends from Shared; nothing references RootOnly.
+    assert await _stub_names(strain_library) == {"Shared"}
+
+
+@pytest.mark.asyncio
+async def test_recursively_required_ancestors_are_kept(
+    strain_library: StrainLibrary,
+) -> None:
+    """Ancestors of a retained ancestor are not pruned."""
+    await _add_root(strain_library, "Root")
+    await _add_root(strain_library, "Sibling")
+    await strain_library.async_import_seedfinder_lineage_tree(
+        "Root", _node("Root", _node("Parent", _node("Grandparent")))
+    )
+    await strain_library.async_import_seedfinder_lineage_tree(
+        "Sibling", _node("Sibling", _node("Parent", _node("Grandparent")))
+    )
+
+    await strain_library.update_strain_lineage_tree("Root", [])
+
+    # Sibling keeps Parent alive, and Parent's own ancestry keeps Grandparent.
+    assert await _stub_names(strain_library) == {"Parent", "Grandparent"}
+
+
+@pytest.mark.asyncio
+async def test_catalogued_strain_is_never_pruned(
+    strain_library: StrainLibrary,
+) -> None:
+    """A Catalogued Strain with no descendants is left alone."""
+    await _add_root(strain_library, "Root")
+    await _add_root(strain_library, "Lonely")
+    await _import_chain(strain_library, "Root")
+
+    await strain_library.update_strain_lineage_tree("Root", [])
+
+    assert "Lonely" in await _strain_names(strain_library)
+    assert await _stub_names(strain_library) == set()
+
+
+@pytest.mark.asyncio
+async def test_pruning_cascades_through_a_chain(
+    strain_library: StrainLibrary,
+) -> None:
+    """Deleting a stub orphans its own ancestors, which go in the same call."""
+    await _add_root(strain_library)
+    await strain_library.async_import_seedfinder_lineage_tree(
+        "Root",
+        _node("Root", _node("P1", _node("P2", _node("P3", _node("P4"))))),
+    )
+    assert await _stub_names(strain_library) == {"P1", "P2", "P3", "P4"}
+
+    await strain_library.update_strain_lineage_tree("Root", [])
+
+    assert await _stub_names(strain_library) == set()
+
+
+@pytest.mark.asyncio
+async def test_pruning_leaves_no_orphaned_phenotype_rows(
+    strain_library: StrainLibrary,
+) -> None:
+    """The import gives each stub a 'default' phenotype; pruning clears it."""
+    await _add_root(strain_library)
+    await _import_chain(strain_library)
+    assert await _orphan_phenotype_count(strain_library) == 0
+
+    await strain_library.update_strain_lineage_tree("Root", [])
+
+    assert await _orphan_phenotype_count(strain_library) == 0
+
+
+@pytest.mark.asyncio
+async def test_import_does_not_prune_the_stubs_it_just_created(
+    strain_library: StrainLibrary,
+) -> None:
+    """Pruning runs after the whole import, not per rebuilt node."""
+    await _add_root(strain_library)
+    await _import_chain(strain_library)
+
+    assert await _stub_names(strain_library) == {"Parent", "Grandparent"}
+    async with strain_library._db.execute(
+        "SELECT COUNT(*) FROM strain_ancestry sa"
+        " WHERE NOT EXISTS ("
+        "   SELECT 1 FROM strains s WHERE s.strain_name = sa.ancestor_name"
+        " )"
+    ) as cursor:
+        dangling = (await cursor.fetchone())[0]
+    assert dangling == 0
+
+
+@pytest.mark.asyncio
+async def test_add_strain_lineage_replacement_prunes(
+    strain_library: StrainLibrary,
+) -> None:
+    """The add_strain upsert path prunes too, not just the lineage-tree path."""
+    await _add_root(strain_library)
+    await _import_chain(strain_library)
+
+    await strain_library.add_strain(
+        "Root",
+        "default",
+        lineage_tree=_node("Root"),
+    )
+
+    assert await _stub_names(strain_library) == set()
+
+
+@pytest.mark.asyncio
+async def test_remove_strain_prunes_ancestors_it_orphans(
+    strain_library: StrainLibrary,
+) -> None:
+    """Deleting the only descendant prunes the ancestors it leaves behind."""
+    await _add_root(strain_library)
+    await _import_chain(strain_library)
+
+    await strain_library.remove_strain("Root")
+
+    assert await _strain_names(strain_library) == set()
+
+
+@pytest.mark.asyncio
+async def test_demoted_strain_is_not_pruned_while_referenced(
+    strain_library: StrainLibrary,
+) -> None:
+    """remove_strain demotes a referenced strain; the prune must not undo that."""
+    await _add_root(strain_library, "Parent")
+    await _add_root(strain_library, "Child")
+    await strain_library.async_import_seedfinder_lineage_tree(
+        "Child", _node("Child", _node("Parent"))
+    )
+
+    await strain_library.remove_strain("Parent")
+
+    # Demoted to an ancestor stub, but Child still descends from it.
+    assert "Parent" in await _stub_names(strain_library)
+
+
+@pytest.mark.asyncio
+async def test_import_for_an_unknown_root_keeps_its_stubs(
+    strain_library: StrainLibrary,
+) -> None:
+    """A root with no strains row yet must not lose the stubs just created.
+
+    _rebuild_strain_ancestry early-returns when the root has no row, so nothing
+    names the new stubs — only the protected set stands between them and the
+    prune.
+    """
+    await strain_library.async_import_seedfinder_lineage_tree(
+        "Ghost", _node("Ghost", _node("GhostParent"))
+    )
+
+    assert await _stub_names(strain_library) == {"GhostParent"}
+
+
+@pytest.mark.asyncio
+async def test_reimport_prunes_the_previous_trees_ancestors(
+    strain_library: StrainLibrary,
+) -> None:
+    """Re-importing a lineage prunes the ancestors the old tree left behind."""
+    await _add_root(strain_library)
+    await strain_library.async_import_seedfinder_lineage_tree(
+        "Root", _node("Root", _node("Old"))
+    )
+    assert await _stub_names(strain_library) == {"Old"}
+
+    await strain_library.async_import_seedfinder_lineage_tree(
+        "Root", _node("Root", _node("New"))
+    )
+
+    assert await _stub_names(strain_library) == {"New"}


### PR DESCRIPTION
Closes #558. Builds on #557 / PR #562 — that made deletion reference-aware; this is the other half, cleaning up ancestors nothing references any more.

## The rule

`StrainLineageManager.prune_orphan_ancestor_strains()` deletes rows where `is_stub = 1` and no `strain_ancestry` row names them.

The predicate is deliberately narrow, and two acceptance criteria fall out of it rather than needing their own checks:

- **Catalogued Strains are never pruned** — `is_stub = 1` is the whole guard, so it holds by construction.
- **Recursively required ancestry survives** — `strain_ancestry` stores each descendant's *whole flattened closure* (`_collect_ancestors` walks the full tree), so an ancestor needed by a retained lineage still has a row naming it. No graph walk needed.

Deleting a stub drops the rows where it was the *descendant*, which can orphan its own parents, so the pass repeats to a fixpoint under a bounded loop that warns rather than truncating silently if a cycle ever exhausts it.

## Where it is hooked

Four call sites, each **after** the mutation completes:

| Path | File |
| --- | --- |
| `update_strain_lineage_tree` | `managers/lineage.py` |
| `async_import_seedfinder_lineage_tree` | `managers/lineage.py` |
| the `add_strain` upsert, when `lineage_tree` is given | `strain_library.py` |
| `remove_strain` | `strain_library.py` |

**Not** inside `_rebuild_strain_ancestry`, deliberately. The seedfinder import calls it once per node; pruning mid-loop would delete a stub that a later node is about to reference, and that node's rebuild would then re-insert an ancestry row naming a `strains` record that no longer exists — losing `is_stub` and the phenotype. It survives a single-strain-edit test and corrupts a real import.

## A bug this caught mid-review

The import's `protected` set was first written as `{root_strain_name, *lineage_by_node}`. `lineage_by_node` only holds nodes that *have* parents, so leaf ancestors were unprotected. Importing `Ghost <- GhostParent` for a root with no `strains` row makes `_rebuild_strain_ancestry` early-return at the `row is None` guard, so nothing ever names `GhostParent` — and the prune deleted the stub the import had just created. Chains survived by luck because interior nodes land in `lineage_by_node`; single-level leaves did not.

Fixed by protecting `all_names`. Old-tree stubs are absent from `all_names`, so re-import still prunes them — `test_reimport_prunes_the_previous_trees_ancestors` pins that, and `test_import_for_an_unknown_root_keeps_its_stubs` pins the regression (it fails on the previous version).

## Tests

`tests/services/test_strain_ancestor_pruning.py`, 12 tests against a real in-memory SQLite DB rather than mocks, one per AC plus the edges: final-reference removal, shared ancestry (flat, so it isolates sharing from the recursive rule), recursive ancestry, Catalogued Strain protection, a 4-deep cascade that genuinely needs multiple passes, no orphaned `phenotypes` rows, the fresh-import guard, the re-import replacement, the `add_strain` and `remove_strain` paths, and demotion-while-referenced.

## Notes for the reviewer

- **`phenotypes` has no `ON DELETE CASCADE`** (checked the DDL), so the prune deletes phenotypes → ancestry → strain, mirroring `remove_strain`'s order. A test asserts no orphaned phenotype rows are left.
- **The `NOT EXISTS (harvests …)` guard is defensive and untested.** I believe it is unreachable — stubs are filtered out of the pickers (`sensor/strain.py:69`) and demotion deletes the target's phenotypes first — so I have not claimed coverage for it. Say the word if you would rather it came out.
- **Paths I checked and ruled out:** `delete_breeder` only nulls `breeder`/`breeder_logo`; the ZIP `import_library` goes through `add_strain` (and `replace=True` calls `clear()` first), so neither can strand a stub. `StrainLibrary._rebuild_strain_ancestry` is a passthrough with no production callers, only tests.
- The prune uses `await execute(...)` rather than `async with`, matching `_rebuild_strain_ancestry` in the same class — the existing lineage tests use a DB double that only supports that form.

## Verification

- `pytest tests/` — 4941 passed
- `ruff check` / `ruff format` clean across `custom_components/` and the new test

🤖 Generated with [Claude Code](https://claude.com/claude-code)