### PR TITLE
Give config-flow errors real translation keys, and guard against f-string keys

### DIFF
--- a/custom_components/growspace_manager/config_flow.py
+++ b/custom_components/growspace_manager/config_flow.py
@@ -96,14 +96,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 data_schema=STEP_USER_DATA_SCHEMA,
             )
 
-        except Exception as err:
+        except Exception:
             _LOGGER.exception("Error in async_step_user")
             return self.async_show_form(
                 step_id="user",
                 data_schema=vol.Schema(
                     {vol.Optional("name", default=DEFAULT_NAME): cv.string}
                 ),
-                errors={"base": f"Error: {err}"},
+                errors={"base": "unknown"},
             )
 
     async def async_step_add_growspace(
@@ -138,14 +138,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         "pending_growspace": pending_growspace,
                     },
                 )
-            except Exception as err:
+            except Exception:
                 _LOGGER.exception("Error in async_step_add_growspace")
                 return self.async_show_form(
                     step_id="add_growspace",
                     data_schema=GrowspaceConfigHandler(
                         self.hass, None
                     ).get_add_growspace_schema(),
-                    errors={"base": f"Error: {err}"},
+                    errors={"base": "unknown"},
                 )
 
             _LOGGER.debug("Stored pending growspace data in config entry")

--- a/custom_components/growspace_manager/config_handlers/plant_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/plant_config_handler.py
@@ -122,12 +122,12 @@ class PlantConfigHandler(BaseConfigHandler[dict[str, Any]]):
                 return self.flow.async_create_entry(
                     title="", data=self.config_entry.options
                 )
-            except Exception as err:
+            except Exception:
                 _LOGGER.exception("Error adding plant")
                 return self.flow.async_show_form(
                     step_id="add_plant",
                     data_schema=self.get_add_plant_schema(growspace, coordinator),
-                    errors={"base": str(err)},
+                    errors={"base": "add_failed"},
                 )
 
         return self.flow.async_show_form(
@@ -157,12 +157,12 @@ class PlantConfigHandler(BaseConfigHandler[dict[str, Any]]):
                 return self.flow.async_create_entry(
                     title="", data=self.config_entry.options
                 )
-            except Exception as err:
+            except Exception:
                 _LOGGER.exception("Error updating plant")
                 return self.flow.async_show_form(
                     step_id="update_plant",
                     data_schema=self.get_update_plant_schema(plant, coordinator),
-                    errors={"base": str(err)},
+                    errors={"base": "update_failed"},
                 )
 
         return self.flow.async_show_form(

--- a/custom_components/growspace_manager/strings.json
+++ b/custom_components/growspace_manager/strings.json
@@ -8,6 +8,9 @@
           "name": "Integration Name"
         }
       }
+    },
+    "error": {
+      "unknown": "An unexpected error occurred. Check the logs for details."
     }
   },
   "options": {

--- a/custom_components/growspace_manager/translations/en.json
+++ b/custom_components/growspace_manager/translations/en.json
@@ -8,6 +8,9 @@
           "name": "Integration Name"
         }
       }
+    },
+    "error": {
+      "unknown": "An unexpected error occurred. Check the logs for details."
     }
   },
   "options": {

--- a/tests/config/test_config_flow.py
+++ b/tests/config/test_config_flow.py
@@ -935,7 +935,7 @@ async def test_options_flow_add_plant_error(
     assert result.get("type") == FlowResultType.FORM
     assert "errors" in result
     assert result["errors"] is not None
-    assert result["errors"]["base"] == "Test error"
+    assert result["errors"]["base"] == "add_failed"
 
 
 # ============================================================================
@@ -1012,7 +1012,7 @@ async def test_options_flow_update_plant_error(
     assert result.get("type") == FlowResultType.FORM
     assert "errors" in result
     assert result["errors"] is not None  # Add this assertion
-    assert result["errors"]["base"] == "Test error"
+    assert result["errors"]["base"] == "update_failed"
 
 
 @pytest.mark.asyncio
@@ -1209,7 +1209,7 @@ async def test_config_flow_user_step_exception(
     with patch.object(flow, "async_create_entry", side_effect=Exception("Test error")):
         result = await flow.async_step_user(user_input={"name": "Test"})
         assert result.get("type") == FlowResultType.FORM
-        assert result.get("errors") == {"base": "Error: Test error"}
+        assert result.get("errors") == {"base": "unknown"}
 
 
 @pytest.mark.asyncio
@@ -3134,7 +3134,7 @@ async def test_options_flow_add_plant_exception(
         user_input={"strain": "New", "row": 1, "col": 1}
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["errors"] == {"base": "Invalid"}
+    assert result["errors"] == {"base": "add_failed"}
 
 
 @pytest.mark.asyncio
@@ -3727,3 +3727,42 @@ async def test_async_step_save_and_finish_success(
     mock_save_and_finish.assert_called_once_with(
         growspace, {"temp_sensor": "sensor.temp"}
     )
+
+
+@pytest.mark.asyncio
+async def test_config_flow_user_step_error_uses_a_translation_key(
+    hass: HomeAssistant, mock_coordinator
+) -> None:
+    """The user step's failure path shows a key, not the exception text."""
+    flow = ConfigFlow()
+    flow.hass = hass
+
+    with patch.object(
+        ConfigFlow, "async_create_entry", side_effect=RuntimeError("boom")
+    ):
+        result = await flow.async_step_user(user_input={"name": "My Growspace"})
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "user"
+    assert result.get("errors") == {"base": "unknown"}
+
+
+@pytest.mark.asyncio
+async def test_config_flow_add_growspace_error_uses_a_translation_key(
+    hass: HomeAssistant, mock_coordinator
+) -> None:
+    """The add_growspace step's failure path shows a key, not the exception text."""
+    flow = ConfigFlow()
+    flow.hass = hass
+    hass.data[DOMAIN] = {}
+
+    with patch.object(
+        ConfigFlow, "async_create_entry", side_effect=RuntimeError("boom")
+    ):
+        result = await flow.async_step_add_growspace(
+            user_input={"name": "Tent", "rows": 2, "plants_per_row": 2}
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "add_growspace"
+    assert result.get("errors") == {"base": "unknown"}

--- a/tests/config/test_plant_config_handler.py
+++ b/tests/config/test_plant_config_handler.py
@@ -416,7 +416,7 @@ async def test_async_step_add_plant_error(
     mock_coordinator.services.plants.add_plant.side_effect = Exception("Failed")
     result = await handler.async_step_add_plant({"strain": "S1", "row": 1, "col": 1})
     assert result["type"] == FlowResultType.FORM
-    assert result["errors"] == {"base": "Failed"}
+    assert result["errors"] == {"base": "add_failed"}
 
 
 @pytest.mark.asyncio
@@ -447,7 +447,7 @@ async def test_async_step_update_plant_errors(
     with patch.object(handler, "async_update_plant", side_effect=Exception("Failed")):
         result = await handler.async_step_update_plant({"strain": "New"})
         assert result["type"] == FlowResultType.FORM
-        assert result["errors"] == {"base": "Failed"}
+        assert result["errors"] == {"base": "update_failed"}
 
 
 @pytest.mark.asyncio

--- a/tests/contract/test_translation_parity.py
+++ b/tests/contract/test_translation_parity.py
@@ -55,11 +55,29 @@ def _step_ids_shown_by_flows() -> set[str]:
     return _literals_matching(r'step_id\s*=\s*["\']([A-Za-z0-9_]+)["\']')
 
 
+# Both spellings the flows use: ``errors={"base": "x"}`` and
+# ``errors["base"] = "x"``. The value is captured loosely so a non-literal can
+# be spotted rather than silently skipped.
+_ERROR_ASSIGNMENT = re.compile(r'"base"\]?\s*[:=]\s*([^,}\n]+)')
+_PLAIN_STRING = re.compile(r'^["\'][A-Za-z0-9_]+["\']$')
+
+
+def _error_values_set_by_flows() -> set[str]:
+    """Collect the raw source text of every value assigned to ``errors["base"]``."""
+    return {
+        match.strip()
+        for source in COMPONENT_DIR.rglob("*.py")
+        for match in _ERROR_ASSIGNMENT.findall(source.read_text(encoding="utf-8"))
+    }
+
+
 def _error_keys_set_by_flows() -> set[str]:
     """Collect every literal key the flows put on ``errors["base"]``."""
-    # Both spellings the handlers use: ``errors={"base": "x"}`` and
-    # ``errors["base"] = "x"``.
-    return _literals_matching(r'"base"\]?\s*[:=]\s*["\']([A-Za-z0-9_]+)["\']')
+    return {
+        value.strip("\"'")
+        for value in _error_values_set_by_flows()
+        if _PLAIN_STRING.match(value)
+    }
 
 
 def _abort_reasons_raised_by_flows() -> set[str]:
@@ -95,15 +113,37 @@ def test_every_shown_step_has_a_translation() -> None:
     )
 
 
+def test_error_values_are_translation_keys_not_interpolated_strings() -> None:
+    """A key built with an f-string can never match a strings.json entry.
+
+    ``errors={"base": f"Error: {err}"}`` looks like it works and renders the
+    raw text; the key check below cannot see it, because there is no literal
+    to compare.
+    """
+    non_literals = sorted(
+        value
+        for value in _error_values_set_by_flows()
+        if not _PLAIN_STRING.match(value)
+    )
+
+    assert not non_literals, (
+        "errors['base'] must be given a literal translation key, not an"
+        f" expression: {non_literals}"
+    )
+
+
 def test_every_error_and_abort_the_flows_raise_has_a_translation() -> None:
     """No form error or abort dialog renders as a raw translation key.
 
-    Only the options flow reaches ``config_handlers/``; the config flow builds
-    its one step inline, which is why both are checked against ``options``.
+    Errors are checked against both sections' keys because the two flows share
+    ``config_flow.py``; aborts only against ``options``, since every
+    ``config_handlers/`` abort is reached from ``OptionsFlowHandler``.
     """
-    options = _load(STRINGS_PATH)["options"]
+    strings = _load(STRINGS_PATH)
+    options = strings["options"]
+    error_keys = set(options["error"]) | set(strings["config"].get("error", {}))
 
-    untranslated_errors = sorted(_error_keys_set_by_flows() - set(options["error"]))
+    untranslated_errors = sorted(_error_keys_set_by_flows() - error_keys)
     untranslated_aborts = sorted(
         _abort_reasons_raised_by_flows() - set(options["abort"])
     )


### PR DESCRIPTION
Closes #570.

## What was wrong

`errors={"base": ...}` is looked up by the frontend as `config.error.<key>` / `options.error.<key>`. **Four** call sites passed an expression rather than a key, so all four rendered raw exception text at the user:

| Site | Was | Now |
| --- | --- | --- |
| `config_flow.py` `async_step_user` | `f"Error: {err}"` | `unknown` |
| `config_flow.py` `async_step_add_growspace` | `f"Error: {err}"` | `unknown` |
| `plant_config_handler.py` `async_step_add_plant` | `str(err)` | `add_failed` |
| `plant_config_handler.py` `async_step_update_plant` | `str(err)` | `update_failed` |

The issue named the first two. **The other two were found by the guard the issue asked me to consider adding** — see below.

`config.error` did not exist and now does, holding just `unknown`. `add_failed` / `update_failed` already existed in `options.error` from #569, so the plant sites needed no new strings. Every site already logged through `_LOGGER.exception`, so no diagnostic detail is lost (AC3); the now-unused `as err` bindings are dropped.

No `config.abort` section: re-verified that both `async_abort` calls in `config_flow.py` (:497, :502) sit inside `OptionsFlowHandler`, so they resolve under `options.abort`.

## Why the existing parity check missed this

`test_every_error_and_abort_the_flows_raise_has_a_translation` (added in #569) greps for **literal** keys. An f-string leaves no literal to compare, so these four sites were invisible to it *precisely because they were broken* — the check silently skipped exactly the case it should have caught.

It now captures the assigned value as raw source text and asserts it is a plain string literal. That is what surfaced the two `str(err)` sites. The key check also widened to include `config.error`, since both flows live in `config_flow.py` and a grep over the tree cannot tell which section a given key belongs to.

## Note on scope

Fixing the two plant-handler sites goes slightly beyond the issue, which was written about the config flow. I did it rather than exempting them because they are the identical defect, the new guard fails while they exist, and suitable keys were already in `strings.json`. Happy to split them out if you would rather keep this PR strictly to `config_flow.py`.

## Tests

- Two new tests, one per config-flow error path, asserting `{"base": "unknown"}` (AC4).
- **Six existing tests asserted the old, broken behaviour** — they had encoded the raw exception text (`"Test error"`, `"Invalid"`, `"Failed"`, `"Error: Test error"`) as the expected error key. Updated to the translation keys. Worth a look, since they are the clearest evidence the bug had been baked into the suite.

## Verification

- `pytest tests/` — 4944 passed
- `ruff check` clean on every touched file

`ruff format --check` still reports `config_flow.py` and `test_plant_config_handler.py` as unformatted — that is **pre-existing on `prerelease`** (verified by stashing this branch's changes and re-running), and that CI job is non-blocking. I deliberately did not reformat them: doing so added ~24 lines of unrelated line-wrapping churn to the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)