### PR TITLE
Delete seven options.step entries no flow can reach

### DIFF
--- a/custom_components/growspace_manager/strings.json
+++ b/custom_components/growspace_manager/strings.json
@@ -19,80 +19,11 @@
         "title": "Growspace Manager Options",
         "description": "Manage your growspaces and plants"
       },
-      "main_menu": {
-        "title": "Growspace Manager",
-        "description": "Choose what you would like to manage",
-        "menu_options": {
-          "manage_growspaces": "Manage Growspaces",
-          "manage_plants": "Manage Plants",
-          "configure_environment": "Configure Growspace Environment",
-          "configure_global": "Configure Global Sensors",
-          "configure_irrigation": "Configure Irrigation",
-          "configure_general": "General Settings"
-        }
-      },
       "select_growspace_for_irrigation": {
         "title": "Select Growspace for Irrigation",
         "description": "Choose which growspace to configure the irrigation controller for.",
         "data": {
           "growspace_id": "Growspace"
-        }
-      },
-      "configure_irrigation": {
-        "title": "Configure Irrigation for {growspace_name}",
-        "description": "Manage the irrigation and drain controller for this growspace.",
-        "menu_options": {
-          "edit_pump_settings": "Edit Pump Settings",
-          "add_irrigation_time": "Add Irrigation Time",
-          "remove_irrigation_time": "Remove Irrigation Time",
-          "add_drain_time": "Add Drain Time",
-          "remove_drain_time": "Remove Drain Time"
-        }
-      },
-      "edit_pump_settings": {
-        "title": "Edit Pump Settings for {growspace_name}",
-        "description": "Configure the switch entities and default run durations.",
-        "data": {
-          "irrigation_pump_entity": "Irrigation Pump Switch",
-          "drain_pump_entity": "Drain Pump Switch",
-          "irrigation_duration": "Default Irrigation Duration (seconds)",
-          "drain_duration": "Default Drain Duration (seconds)"
-        }
-      },
-      "add_irrigation_time": {
-        "title": "Add Irrigation Time for {growspace_name}",
-        "description": "Add a new time slot for an irrigation event. You can optionally set a custom duration.",
-        "data": {
-          "time": "Time",
-          "duration": "Custom Duration (seconds)"
-        },
-        "data_description": {
-          "duration": "Optional: a custom duration for this specific event."
-        }
-      },
-      "remove_irrigation_time": {
-        "title": "Remove Irrigation Time for {growspace_name}",
-        "description": "Select an irrigation time to remove.",
-        "data": {
-          "time": "Irrigation Time"
-        }
-      },
-      "add_drain_time": {
-        "title": "Add Drain Time for {growspace_name}",
-        "description": "Add a new time slot for a drain event. You can optionally set a custom duration.",
-        "data": {
-          "time": "Time",
-          "duration": "Custom Duration (seconds)"
-        },
-        "data_description": {
-          "duration": "Optional: a custom duration for this specific event."
-        }
-      },
-      "remove_drain_time": {
-        "title": "Remove Drain Time for {growspace_name}",
-        "description": "Select a drain time to remove.",
-        "data": {
-          "time": "Drain Time"
         }
       },
       "configure_global": {

--- a/custom_components/growspace_manager/translations/en.json
+++ b/custom_components/growspace_manager/translations/en.json
@@ -19,80 +19,11 @@
         "title": "Growspace Manager Options",
         "description": "Manage your growspaces and plants"
       },
-      "main_menu": {
-        "title": "Growspace Manager",
-        "description": "Choose what you would like to manage",
-        "menu_options": {
-          "manage_growspaces": "Manage Growspaces",
-          "manage_plants": "Manage Plants",
-          "configure_environment": "Configure Growspace Environment",
-          "configure_global": "Configure Global Sensors",
-          "configure_irrigation": "Configure Irrigation",
-          "configure_general": "General Settings"
-        }
-      },
       "select_growspace_for_irrigation": {
         "title": "Select Growspace for Irrigation",
         "description": "Choose which growspace to configure the irrigation controller for.",
         "data": {
           "growspace_id": "Growspace"
-        }
-      },
-      "configure_irrigation": {
-        "title": "Configure Irrigation for {growspace_name}",
-        "description": "Manage the irrigation and drain controller for this growspace.",
-        "menu_options": {
-          "edit_pump_settings": "Edit Pump Settings",
-          "add_irrigation_time": "Add Irrigation Time",
-          "remove_irrigation_time": "Remove Irrigation Time",
-          "add_drain_time": "Add Drain Time",
-          "remove_drain_time": "Remove Drain Time"
-        }
-      },
-      "edit_pump_settings": {
-        "title": "Edit Pump Settings for {growspace_name}",
-        "description": "Configure the switch entities and default run durations.",
-        "data": {
-          "irrigation_pump_entity": "Irrigation Pump Switch",
-          "drain_pump_entity": "Drain Pump Switch",
-          "irrigation_duration": "Default Irrigation Duration (seconds)",
-          "drain_duration": "Default Drain Duration (seconds)"
-        }
-      },
-      "add_irrigation_time": {
-        "title": "Add Irrigation Time for {growspace_name}",
-        "description": "Add a new time slot for an irrigation event. You can optionally set a custom duration.",
-        "data": {
-          "time": "Time",
-          "duration": "Custom Duration (seconds)"
-        },
-        "data_description": {
-          "duration": "Optional: a custom duration for this specific event."
-        }
-      },
-      "remove_irrigation_time": {
-        "title": "Remove Irrigation Time for {growspace_name}",
-        "description": "Select an irrigation time to remove.",
-        "data": {
-          "time": "Irrigation Time"
-        }
-      },
-      "add_drain_time": {
-        "title": "Add Drain Time for {growspace_name}",
-        "description": "Add a new time slot for a drain event. You can optionally set a custom duration.",
-        "data": {
-          "time": "Time",
-          "duration": "Custom Duration (seconds)"
-        },
-        "data_description": {
-          "duration": "Optional: a custom duration for this specific event."
-        }
-      },
-      "remove_drain_time": {
-        "title": "Remove Drain Time for {growspace_name}",
-        "description": "Select a drain time to remove.",
-        "data": {
-          "time": "Drain Time"
         }
       },
       "configure_global": {

--- a/tests/contract/test_translation_parity.py
+++ b/tests/contract/test_translation_parity.py
@@ -25,6 +25,12 @@ STEPS_WITH_GENERATED_FIELDS = frozenset(
     {"configure_advanced_bayesian", "configure_sensor_placement"}
 )
 
+# Step entries deliberately kept although no flow shows them — a step being
+# reintroduced shortly, say. JSON carries no comments, so the reason lives
+# here. Empty is the healthy state: an entry nothing renders is dead weight
+# that reads as a live screen to whoever finds it next.
+STEPS_TRANSLATED_BUT_NOT_SHOWN: frozenset[str] = frozenset()
+
 
 def _load(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
@@ -53,6 +59,18 @@ def _literals_matching(pattern: str) -> set[str]:
 def _step_ids_shown_by_flows() -> set[str]:
     """Collect every literal ``step_id`` the config and options flows show."""
     return _literals_matching(r'step_id\s*=\s*["\']([A-Za-z0-9_]+)["\']')
+
+
+_STEP_ID_ASSIGNMENT = re.compile(r"step_id\s*=\s*([^,)\n]+)")
+
+
+def _step_id_values_used_by_flows() -> set[str]:
+    """Collect the raw source text of every value passed as ``step_id``."""
+    return {
+        match.strip()
+        for source in COMPONENT_DIR.rglob("*.py")
+        for match in _STEP_ID_ASSIGNMENT.findall(source.read_text(encoding="utf-8"))
+    }
 
 
 # Both spellings the flows use: ``errors={"base": "x"}`` and
@@ -111,6 +129,43 @@ def test_every_shown_step_has_a_translation() -> None:
     assert not untranslated, (
         f"steps shown by a flow with no strings.json entry: {untranslated}"
     )
+
+
+def test_step_ids_are_literals() -> None:
+    """A ``step_id`` built at runtime is invisible to the two step checks.
+
+    Both compare translation keys against the literals found in the source. A
+    computed ``step_id=f"edit_{kind}"`` would make the shown-but-untranslated
+    check miss a raw key, and make the translated-but-unshown check condemn an
+    entry that is in fact live. Keeping every step id a literal is what
+    licenses them.
+    """
+    non_literals = sorted(
+        value
+        for value in _step_id_values_used_by_flows()
+        if not _PLAIN_STRING.match(value)
+    )
+
+    assert not non_literals, (
+        f"step_id must be a string literal, not an expression: {non_literals}"
+    )
+
+
+def test_every_translated_step_is_shown_by_a_flow() -> None:
+    """No step entry describes a screen the flows can no longer reach.
+
+    The reverse of ``test_every_shown_step_has_a_translation``. A stale entry
+    breaks nothing at runtime, which is exactly why it survives: it reads as a
+    live screen and sends the next reader looking for a step that isn't there.
+    """
+    strings = _load(STRINGS_PATH)
+    shown = _step_ids_shown_by_flows() | STEPS_TRANSLATED_BUT_NOT_SHOWN
+    for section in ("config", "options"):
+        unshown = sorted(set(strings[section]["step"]) - shown)
+        assert not unshown, (
+            f"{section}.step entries no flow shows: {unshown} — delete them, or "
+            "add them to STEPS_TRANSLATED_BUT_NOT_SHOWN with the reason"
+        )
 
 
 def test_error_values_are_translation_keys_not_interpolated_strings() -> None:


### PR DESCRIPTION
Closes #571.

## What changed

Removed seven `options.step` entries from `strings.json` and `translations/en.json` (only `en.json` exists — no other locale to clean), and added the reverse-direction parity test the issue asked for.

## Reachability, per entry

Every `async_show_form` / `async_show_menu` call in `config_flow.py` and `config_handlers/` passes an explicit `step_id` (60 calls, 60 `step_id=` assignments), and **all 60 are string literals** — no f-string or variable anywhere in the component. So the literal sweep is complete, and "no literal matches" means unreachable, not "the sweep missed it".

| Entry | Verdict |
| --- | --- |
| `main_menu` | Dead. A `menu_options` block from a menu-based flow; the menu now renders as `step_id="init"` (`config_flow.py:332`) with `get_main_menu_schema()`. Its labels are hardcoded in the selector, and it listed 6 options where the live selector has 9 — stale copy, nothing lost. `init` already carries its own title and description. |
| `configure_irrigation` | Dead. Also a `menu_options` block. `irrigation_config_handler.py:79` routes straight to `async_step_irrigation_overview` and never shows a form of its own; `irrigation_overview` has its own title, description, and full `data` block. |
| `edit_pump_settings` | Dead. No `async_step_edit_pump_settings` exists anywhere; the only other reference was `configure_irrigation`'s menu, deleted with it. |
| `add_irrigation_time`, `remove_irrigation_time`, `add_drain_time`, `remove_drain_time` | Dead **as flow steps**. The names live on as services (`const.py:638-641`, `services.yaml`, `services/irrigation.py`) — the trap the issue flagged. `strings.json`'s `services` block has no entries under these names, so each name occurred exactly twice per file (step key + menu label) and both occurrences were within the dead blocks. |

Nothing on the #544 irrigation map depends on these: it is explicitly plan-only ("Tickets produce decisions and ADRs, not implementations"), and no ticket references these step ids. Reversal is one `git revert`.

## No behaviour change

By construction — a translation entry nothing looks up cannot render. The change rests entirely on the reachability argument above, which is why it is now enforced:

- `test_every_translated_step_is_shown_by_a_flow` — the reverse sweep, over both `config` and `options` (both are clean today), with a `STEPS_TRANSLATED_BUT_NOT_SHOWN` allowlist as the mechanism for the issue's "kept with a comment recording why", since JSON carries no comments. It is empty.
- `test_step_ids_are_literals` — mirrors the existing `errors["base"]` literal check. Without it, a future computed `step_id` would make the reverse sweep condemn a live entry.

Both were mutation-checked: a fake `ghost_step` entry and a fake `f"edit_{kind}"` step id each fail the respective test.

## Verification

- `pytest tests/ -q` → **4946 passed** (46 snapshots), including `tests/contract/test_translation_parity.py` (8 tests) and `tests/config/`, which exercise `async_step_configure_irrigation` directly.
- `ruff check` / `ruff format --check` clean.

## Noticed, not fixed

`get_main_menu_schema()` sets `translation_key="menu_options"` on its selector, but `strings.json` has no `selector` section — the key resolves to nothing and HA falls back to the hardcoded labels. Pre-existing and unrelated to stale entries (it is a gap on a *live* step), so left alone. Worth a follow-up issue if the labels should be translatable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)