### PR TITLE
Normalize timed notification trigger vocabulary

### DIFF
--- a/custom_components/growspace_manager/calendar.py
+++ b/custom_components/growspace_manager/calendar.py
@@ -19,6 +19,7 @@ from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .coordinator import GrowspaceCoordinator
+from .notifications.timed import normalize_timed_notifications
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -112,8 +113,12 @@ class GrowspaceCalendar(CalendarEntity):  # type: ignore[misc]
     def _generate_events(self) -> None:
         """Generate all calendar events for the growspace based on timed notifications."""
         events = []
-        notifications = self.coordinator.options.get("timed_notifications", [])
-        plants = self.coordinator.services.growspaces.get_growspace_plants(self.growspace_id)
+        notifications = normalize_timed_notifications(
+            self.coordinator.options.get("timed_notifications", [])
+        )
+        plants = self.coordinator.services.growspaces.get_growspace_plants(
+            self.growspace_id
+        )
 
         for plant in plants:
             for notification in notifications:

--- a/custom_components/growspace_manager/config_handlers/notification_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/notification_config_handler.py
@@ -13,6 +13,10 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.helpers import selector
 
+from ..notifications.timed import (
+    TIMED_NOTIFICATION_TRIGGER_OPTIONS,
+    normalize_timed_notification_trigger,
+)
 from . import AbortFlow, BaseConfigHandler
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,7 +71,9 @@ class NotificationConfigHandler(BaseConfigHandler[dict[str, Any]]):
                 user_input["day"],
                 user_input.get("growspace_ids"),
             )
-            return self.flow.async_create_entry(title="", data=self.config_entry.options)
+            return self.flow.async_create_entry(
+                title="", data=self.config_entry.options
+            )
 
         return self.flow.async_show_form(
             step_id="add_timed_notification",
@@ -102,7 +108,9 @@ class NotificationConfigHandler(BaseConfigHandler[dict[str, Any]]):
                 user_input["day"],
                 user_input.get("growspace_ids"),
             )
-            return self.flow.async_create_entry(title="", data=self.config_entry.options)
+            return self.flow.async_create_entry(
+                title="", data=self.config_entry.options
+            )
 
         return self.flow.async_show_form(
             step_id="edit_timed_notification",
@@ -119,7 +127,9 @@ class NotificationConfigHandler(BaseConfigHandler[dict[str, Any]]):
         notification_id = self.flow.selected_notification_id
 
         if user_input is not None:
-            await coordinator.services.notifications.async_remove_timed_notification(notification_id)
+            await coordinator.services.notifications.async_remove_timed_notification(
+                notification_id
+            )
             return self.flow.async_create_entry(title="", data={})
 
         return self.flow.async_show_form(
@@ -184,17 +194,14 @@ class NotificationConfigHandler(BaseConfigHandler[dict[str, Any]]):
             ): selector.TextSelector(),
             vol.Required(
                 "trigger_type",
-                default=notification.get("trigger_type", "days_since_flip"),
+                default=normalize_timed_notification_trigger(
+                    notification.get("trigger_type", "flower")
+                ),
             ): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[
-                        selector.SelectOptionDict(
-                            value="days_since_flip", label="Days Since Flip"
-                        ),
-                        selector.SelectOptionDict(
-                            value="days_since_germination",
-                            label="Days Since Germination",
-                        ),
+                        selector.SelectOptionDict(value=value, label=label)
+                        for value, label in TIMED_NOTIFICATION_TRIGGER_OPTIONS
                     ],
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )

--- a/custom_components/growspace_manager/notification_manager.py
+++ b/custom_components/growspace_manager/notification_manager.py
@@ -37,6 +37,7 @@ from .exceptions import GrowspaceError
 from .notification_rewriter import AINotificationRewriter
 from .notifications.evaluation_snapshot import EvaluationSnapshot
 from .notifications.formatting import generate_notification_message
+from .notifications.timed import normalize_timed_notifications
 
 if TYPE_CHECKING:
     from .coordinator import GrowspaceCoordinator
@@ -492,7 +493,9 @@ class NotificationManager:
 
     async def async_check_timed_notifications(self) -> None:
         """Check all configured timed notifications and send them if the conditions are met."""
-        notifications = self.coordinator.options.get("timed_notifications", [])
+        notifications = normalize_timed_notifications(
+            self.coordinator.options.get("timed_notifications", [])
+        )
         if not notifications:
             return
 

--- a/custom_components/growspace_manager/notifications/notification_settings_manager.py
+++ b/custom_components/growspace_manager/notifications/notification_settings_manager.py
@@ -9,6 +9,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 import uuid
 
+from .timed import normalize_timed_notification_trigger, normalize_timed_notifications
+
 if TYPE_CHECKING:
     from .custom_components.growspace_manager.coordinator import GrowspaceCoordinator
     from .custom_components.growspace_manager.models import Growspace
@@ -97,7 +99,9 @@ class NotificationSettingsManager:
         Returns:
             List of timed notification configurations
         """
-        return self.config_entry.options.get("timed_notifications", [])  # type: ignore[no-any-return]
+        return normalize_timed_notifications(
+            self.config_entry.options.get("timed_notifications", [])
+        )
 
     def create_timed_notification(
         self,
@@ -120,7 +124,7 @@ class NotificationSettingsManager:
         return {
             "id": str(uuid.uuid4()),
             "message": message,
-            "trigger_type": trigger_type,
+            "trigger_type": normalize_timed_notification_trigger(trigger_type),
             "day": int(day),
             "growspace_ids": growspace_ids or [],
         }
@@ -150,7 +154,9 @@ class NotificationSettingsManager:
         for notification in notifications:
             if notification["id"] == notification_id:
                 notification["message"] = message
-                notification["trigger_type"] = trigger_type
+                notification["trigger_type"] = normalize_timed_notification_trigger(
+                    trigger_type
+                )
                 notification["day"] = int(day)
                 notification["growspace_ids"] = growspace_ids or []
                 return True

--- a/custom_components/growspace_manager/notifications/timed.py
+++ b/custom_components/growspace_manager/notifications/timed.py
@@ -1,0 +1,44 @@
+"""Timed notification trigger vocabulary."""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+TIMED_NOTIFICATION_TRIGGER_OPTIONS: Final = (
+    ("clone", "Clone"),
+    ("veg", "Vegetative"),
+    ("flower", "Flowering"),
+    ("dry", "Drying"),
+)
+
+_LEGACY_TRIGGER_TYPES: Final = {
+    "days_since_flip": "flower",
+    # Seed-grown plants enter the supported timed-notification vocabulary at veg.
+    "days_since_germination": "veg",
+    "clone_start": "clone",
+    "veg_start": "veg",
+    "flower_start": "flower",
+    "dry_start": "dry",
+}
+
+
+def normalize_timed_notification_trigger(trigger_type: str) -> str:
+    """Return the bare stage name for a timed notification trigger."""
+    return _LEGACY_TRIGGER_TYPES.get(trigger_type, trigger_type)
+
+
+def normalize_timed_notifications(
+    notifications: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return timed notifications with legacy trigger values normalized."""
+    return [
+        {
+            **notification,
+            "trigger_type": normalize_timed_notification_trigger(
+                notification["trigger_type"]
+            ),
+        }
+        if "trigger_type" in notification
+        else notification.copy()
+        for notification in notifications
+    ]

--- a/custom_components/growspace_manager/view_model_builder.py
+++ b/custom_components/growspace_manager/view_model_builder.py
@@ -15,6 +15,7 @@ from .crop_steering import get_crop_steering_state
 from .domain.stage import StageDays
 from .domain.water_aggregation import compute_growspace_water
 from .models import Plant
+from .notifications.timed import normalize_timed_notifications
 from .presentation import GrowspaceViewModelBuilder
 from .utils import calculate_days_since
 
@@ -239,7 +240,9 @@ class ViewModelBuilder:
         serialized["ai_auto_alerts"] = options.get("ai_settings", {}).get(
             "ai_auto_alerts", True
         )
-        serialized["timed_notifications"] = options.get("timed_notifications", [])
+        serialized["timed_notifications"] = normalize_timed_notifications(
+            options.get("timed_notifications", [])
+        )
 
         # Top-level timestamp for efficient frontend equality checks (change detection)
         serialized["_ts"] = int(current_time * 1000)
@@ -299,7 +302,9 @@ class ViewModelBuilder:
             "notifications_sent": self.notifications_sent,
             "notifications_enabled": self.notifications_enabled,
             "notification_settings": options.get("notification_settings", {}),
-            "timed_notifications": options.get("timed_notifications", []),
+            "timed_notifications": normalize_timed_notifications(
+                options.get("timed_notifications", [])
+            ),
             "_version": dt_util.now().isoformat(),
             "serialized_growspaces": serialized_growspaces,
             "air_exchange_recommendations": recs,

--- a/tests/components/test_calendar.py
+++ b/tests/components/test_calendar.py
@@ -129,6 +129,28 @@ async def test_growspace_calendar_update_and_get_events(mock_coordinator: Mock) 
 
 
 @pytest.mark.asyncio
+async def test_growspace_calendar_normalizes_legacy_trigger(
+    mock_coordinator: Mock,
+) -> None:
+    """Test calendar events use the normalized stage for legacy triggers."""
+    mock_coordinator.options["timed_notifications"] = [
+        {
+            "id": "legacy_flower_reminder",
+            "growspace_ids": ["gs1"],
+            "trigger_type": "days_since_flip",
+            "day": "1",
+            "message": "First day of flower",
+        }
+    ]
+
+    calendar = GrowspaceCalendar(mock_coordinator, "gs1")
+    await calendar.async_update()
+
+    assert len(calendar._events) == 1
+    assert calendar._events[0].summary.startswith("Flower Day 1")
+
+
+@pytest.mark.asyncio
 async def test_growspace_calendar_event_property(mock_coordinator: Mock) -> None:
     """Test the event property to get the next upcoming event."""
     calendar = GrowspaceCalendar(mock_coordinator, "gs1")

--- a/tests/config/test_notification_config_handler.py
+++ b/tests/config/test_notification_config_handler.py
@@ -76,6 +76,29 @@ def test_get_add_edit_schema_with_growspaces(
     assert "growspace_id" in str(schema.schema)
 
 
+def test_get_add_edit_schema_uses_bare_stage_triggers(
+    handler: NotificationConfigHandler,
+) -> None:
+    """Test timed notification forms expose the firing path's vocabulary."""
+    coordinator = MagicMock()
+    coordinator.growspaces = {}
+
+    schema = handler.get_add_edit_schema(coordinator)
+    trigger_selector = next(
+        value
+        for key, value in schema.schema.items()
+        if getattr(key, "schema", None) == "trigger_type"
+    )
+
+    assert trigger_selector.config["options"] == [
+        {"value": "clone", "label": "Clone"},
+        {"value": "veg", "label": "Vegetative"},
+        {"value": "flower", "label": "Flowering"},
+        {"value": "dry", "label": "Drying"},
+    ]
+    assert trigger_selector.config["options"][2]["value"] == "flower"
+
+
 def test_get_add_edit_schema_defaults(handler: NotificationConfigHandler) -> None:
     """Test schema defaults from existing notification."""
     coordinator = MagicMock()

--- a/tests/fixtures/contract/growspace_payload.json
+++ b/tests/fixtures/contract/growspace_payload.json
@@ -770,7 +770,7 @@
       "growspace_ids": ["contract_growspace"],
       "id": "contract-notification",
       "message": "Inspect irrigation runoff",
-      "trigger_type": "flower_start"
+      "trigger_type": "flower"
     }
   ]
 }

--- a/tests/integration/test_growspace_view_model_coverage.py
+++ b/tests/integration/test_growspace_view_model_coverage.py
@@ -751,7 +751,13 @@ def test_view_model_builder_includes_timed_notifications(
 
     result = ViewModelBuilder(coordinator).build_serialized_growspace("gs1")
 
-    assert result["timed_notifications"] == timed
+    assert result["timed_notifications"] == [
+        {
+            **timed[0],
+            "trigger_type": "veg",
+        }
+    ]
+    assert timed[0]["trigger_type"] == "veg_start"
 
 
 def test_view_model_builder_timed_notifications_default_empty(

--- a/tests/notifications/test_notification_settings_manager.py
+++ b/tests/notifications/test_notification_settings_manager.py
@@ -106,6 +106,33 @@ def test_get_timed_notifications_configured() -> None:
 
 
 @pytest.mark.parametrize(
+    ("legacy_trigger", "expected_trigger"),
+    [
+        pytest.param("days_since_flip", "flower", id="days-since-flip"),
+        pytest.param("days_since_germination", "veg", id="days-since-germination"),
+        pytest.param("clone_start", "clone", id="clone-start"),
+        pytest.param("veg_start", "veg", id="veg-start"),
+        pytest.param("flower_start", "flower", id="flower-start"),
+        pytest.param("dry_start", "dry", id="dry-start"),
+    ],
+)
+def test_get_timed_notifications_normalizes_legacy_trigger_types(
+    legacy_trigger: str, expected_trigger: str
+) -> None:
+    """Test legacy trigger values are normalized without mutating stored options."""
+    mock_coordinator = MagicMock()
+    stored_notification = {"id": "1", "trigger_type": legacy_trigger}
+    mock_coordinator.config_entry.options = {
+        "timed_notifications": [stored_notification]
+    }
+
+    manager = NotificationSettingsManager(mock_coordinator)
+
+    assert manager.get_timed_notifications()[0]["trigger_type"] == expected_trigger
+    assert stored_notification["trigger_type"] == legacy_trigger
+
+
+@pytest.mark.parametrize(
     ("growspace_ids", "expected_ids"),
     [
         (None, []),
@@ -200,7 +227,11 @@ def test_remove_timed_notification_from_list() -> None:
 def test_repr() -> None:
     """Test string representation of NotificationSettingsManager."""
     mock_coordinator = MagicMock()
-    mock_coordinator.notification_state.enabled = {"gs1": True, "gs2": False, "gs3": True}
+    mock_coordinator.notification_state.enabled = {
+        "gs1": True,
+        "gs2": False,
+        "gs3": True,
+    }
     mock_coordinator.config_entry.options = {
         "timed_notifications": [
             {"id": "1"},

--- a/tests/services/test_notification_manager.py
+++ b/tests/services/test_notification_manager.py
@@ -209,7 +209,9 @@ async def test_async_send_notification_disabled(
     manager: NotificationManager, mock_coordinator: MagicMock, mock_hass: MagicMock
 ) -> None:
     """Test sending notification when disabled."""
-    mock_coordinator.services.notifications.is_notifications_enabled.return_value = False
+    mock_coordinator.services.notifications.is_notifications_enabled.return_value = (
+        False
+    )
 
     await manager.async_send_notification(GROWSPACE_ID, "Test Title", "Test Message")
 
@@ -287,6 +289,40 @@ async def test_async_check_timed_notifications(
     mock_coordinator.async_commit.assert_awaited()
 
 
+async def test_async_check_timed_notifications_normalizes_legacy_trigger(
+    manager: NotificationManager, mock_coordinator: MagicMock, mock_hass: MagicMock
+) -> None:
+    """Test a legacy stored trigger fires against its normalized stage."""
+    mock_coordinator.options = {
+        "timed_notifications": [
+            {
+                "id": "legacy_notify",
+                "trigger_type": "days_since_flip",
+                "day": 10,
+                "message": "Flower Day 10",
+                "growspace_ids": [GROWSPACE_ID],
+            }
+        ]
+    }
+    plant = create_plant(
+        plant_id="plant_1",
+        growspace_id=GROWSPACE_ID,
+        strain="Strain A",
+    )
+    mock_coordinator.plants = {"plant_1": plant}
+    mock_coordinator.notification_state.sent = {"plant_1": {}}
+
+    with patch(
+        "custom_components.growspace_manager.notification_manager.calculate_days_in_stage",
+        return_value=10,
+    ) as calculate_days:
+        await manager.async_check_timed_notifications()
+
+    calculate_days.assert_called_once_with(plant, "flower")
+    mock_hass.services.async_call.assert_awaited()
+    assert mock_coordinator.notification_state.sent["plant_1"]["timed_legacy_notify"]
+
+
 def test_generate_notification_message_truncation(manager: NotificationManager) -> None:
     """Test message truncation in generate_notification_message."""
     base_message = "Base"
@@ -310,7 +346,6 @@ async def test_async_send_notification_exception(
 
     # Should not raise exception
     await manager.async_send_notification(GROWSPACE_ID, "Title", "Message")
-
 
 
 async def test_async_check_timed_notifications_empty_config(
@@ -373,7 +408,6 @@ async def test_async_send_batched_notification_sensor_name_fallback(
         assert "sensor.no_name" in args[1]
 
 
-
 async def test_async_send_batched_notification_multiple_sensors(
     manager: NotificationManager, mock_coordinator: MagicMock, mock_hass: MagicMock
 ) -> None:
@@ -423,7 +457,9 @@ async def test_async_send_batched_notification_unique_reasons(
         "stress", sensor_name="S1", reasons=[(0.9, "Reason 1"), (0.8, "Reason 2")]
     )
     manager._latest_snapshots[(GROWSPACE_ID, "mold")] = make_snapshot(
-        "mold", sensor_name="S2", reasons=[(0.7, "Reason 1")]  # Duplicate reason
+        "mold",
+        sensor_name="S2",
+        reasons=[(0.7, "Reason 1")],  # Duplicate reason
     )
 
     with patch.object(
@@ -472,7 +508,9 @@ async def test_async_send_notification_disabled_cases(
 ) -> None:
     """Test notification disabled cases (lines 44-45, 49-50)."""
     # CASE: Notifications disabled for growspace
-    mock_coordinator.services.notifications.is_notifications_enabled.return_value = False
+    mock_coordinator.services.notifications.is_notifications_enabled.return_value = (
+        False
+    )
     await manager.async_send_notification(GROWSPACE_ID, "T", "M")
     mock_hass.services.async_call.assert_not_called()
 
@@ -924,8 +962,6 @@ async def test_no_recovery_for_warning_resolve(
         mock_recovery.assert_not_called()
 
 
-
-
 async def test_send_recovery_notification(
     manager: NotificationManager, mock_hass: MagicMock
 ) -> None:
@@ -1049,9 +1085,7 @@ def test_optimal_high_probability_creates_no_pending_alert(
     manager: NotificationManager,
 ) -> None:
     """A triggered optimal snapshot is stored but never creates a pending alert."""
-    manager.report_evaluation(
-        make_snapshot("optimal", is_on=True, probability=0.99)
-    )
+    manager.report_evaluation(make_snapshot("optimal", is_on=True, probability=0.99))
 
     assert (GROWSPACE_ID, "optimal") in manager._latest_snapshots
     assert manager._pending_alerts == {}
@@ -1060,7 +1094,9 @@ def test_optimal_high_probability_creates_no_pending_alert(
 # --- Step 4: light-flip cooldown migration ---
 
 
-def _snapshot_with_lights(sensor_type: str, lights_on: bool | None) -> EvaluationSnapshot:
+def _snapshot_with_lights(
+    sensor_type: str, lights_on: bool | None
+) -> EvaluationSnapshot:
     """Build a resolved snapshot carrying the given light state."""
     return EvaluationSnapshot(
         growspace_id=GROWSPACE_ID,
@@ -1215,7 +1251,9 @@ async def test_check_and_trigger_plant_notification_init(
         )
 
     assert "new_plant" in mock_coordinator.notification_state.sent
-    assert mock_coordinator.notification_state.sent["new_plant"]["timed_notify_1"] is True
+    assert (
+        mock_coordinator.notification_state.sent["new_plant"]["timed_notify_1"] is True
+    )
 
     # Test fallback to growspace.growspace_id if id not present
     del growspace.id
@@ -1372,5 +1410,3 @@ async def test_async_send_notification_no_plants_skips(
     await manager.async_send_notification(GROWSPACE_ID, "Title", "Message")
 
     mock_hass.services.async_call.assert_not_awaited()
-
-


### PR DESCRIPTION
## Summary

- make the options-flow timed-notification form use the bare stage vocabulary: `clone`, `veg`, `flower`, and `dry`
- centralize legacy trigger normalization for stored options, firing, calendar events, and frontend payloads
- map `days_since_flip` to `flower`, `days_since_germination` to `veg`, and legacy `*_start` values to their bare stage
- add regression coverage for every legacy value, options-flow choices, firing, calendar generation, and payload normalization

## Root cause

The options flow wrote `days_since_flip` and `days_since_germination`, while the firing path resolved stage start fields from bare stage names. Legacy values therefore resolved no start field and silently produced zero elapsed days.

## User impact

Timed notifications created through the options flow now fire on the configured day. Existing legacy entries are healed when read and are also exposed to the Lovelace card using the canonical vocabulary.

## Validation

- `146 passed` across the affected config, notification, calendar, view-model, and contract test modules
- scoped repository hooks passed: Ruff check/format, codespell, JSON validation, branch guard, and Prettier
- repository-wide hooks were also attempted, but remain red on unrelated pre-existing scratch files, generated card bundles, YAML, and spelling findings

Closes #575
