### PR TITLE
feat(environment): add the Acceptable Moisture Band to Plant Stress

### DIFF
--- a/custom_components/growspace_manager/bayesian_evaluator.py
+++ b/custom_components/growspace_manager/bayesian_evaluator.py
@@ -48,8 +48,6 @@ from .bayesian_constants import (
     SENSITIVITY_BASE_PROB,
     SENSITIVITY_FALSE_MULTIPLIER,
     SENSITIVITY_TRUE_MULTIPLIER,
-    SOIL_MOISTURE_HIGH_THRESHOLD,
-    SOIL_MOISTURE_LOW_THRESHOLD,
     TEMP_COLD_THRESHOLD,
     TEMP_EXTREME_COLD_THRESHOLD,
     TEMP_EXTREME_HEAT_THRESHOLD,
@@ -94,6 +92,7 @@ from .const import (
     CONF_TREND_THRESHOLD_MAP,
 )
 from .domain.environmental_targets import StageEnvironmentalTargets
+from .domain.moisture_band import effective_moisture_band
 from .domain.stage import BayesianStage, StageClassification, StageDays, classify_stages
 from .models import EnvironmentState
 
@@ -107,15 +106,17 @@ Obs = tuple[float, float]
 
 
 def _classify(state: EnvironmentState) -> StageClassification:
-    return classify_stages(StageDays(
-        veg=state.veg_days,
-        flower=state.flower_days,
-        dry=state.dry_days,
-        cure=state.cure_days,
-        seedling=state.seedling_days,
-        clone=state.clone_days,
-        mother=state.mother_days,
-    ))
+    return classify_stages(
+        StageDays(
+            veg=state.veg_days,
+            flower=state.flower_days,
+            dry=state.dry_days,
+            cure=state.cure_days,
+            seedling=state.seedling_days,
+            clone=state.clone_days,
+            mother=state.mother_days,
+        )
+    )
 
 
 Reason = tuple[float, str]
@@ -547,7 +548,9 @@ def evaluate_direct_humidity_stress(
     if sc.stage_a == BayesianStage.EMPTY:
         return observations, reasons
 
-    band = StageEnvironmentalTargets(sc.stage_a, sc.stage_b, sc.factor).humidity_band(env_config)
+    band = StageEnvironmentalTargets(sc.stage_a, sc.stage_b, sc.factor).humidity_band(
+        env_config
+    )
 
     if hum < band.low or hum > band.high:
         observations.append(band.prob)
@@ -628,14 +631,24 @@ def evaluate_soil_moisture_stress(
     moisture = state.soil_moisture
     prob_stress = PROB_SOIL_MOISTURE_STRESS
 
-    # Simple thresholds: < SOIL_MOISTURE_LOW_THRESHOLD (Dry) or > SOIL_MOISTURE_HIGH_THRESHOLD (Wet)
-    # These could be made configurable in the future
-    if moisture < SOIL_MOISTURE_LOW_THRESHOLD:
+    # Acceptable Moisture Band: the growspace's custom pair when it has one,
+    # otherwise the inherited default. Boundaries are inclusive, so a reading
+    # exactly on a bound adds no evidence.
+    band = effective_moisture_band(
+        env_config.get("soil_moisture_min"), env_config.get("soil_moisture_max")
+    )
+    classification = band.classify(moisture)
+
+    if classification == "too_dry":
         observations.append(prob_stress)
-        reasons.append((prob_stress[0], f"Soil Moisture Low ({moisture}%)"))
-    elif moisture > SOIL_MOISTURE_HIGH_THRESHOLD:
+        reasons.append(
+            (prob_stress[0], f"Soil Moisture Low ({moisture}% < {band.minimum:g}%)")
+        )
+    elif classification == "too_wet":
         observations.append(prob_stress)
-        reasons.append((prob_stress[0], f"Soil Moisture High ({moisture}%)"))
+        reasons.append(
+            (prob_stress[0], f"Soil Moisture High ({moisture}% > {band.maximum:g}%)")
+        )
 
     return observations, reasons
 
@@ -796,9 +809,9 @@ def evaluate_optimal_vpd(
     time_of_day = "night" if state.is_lights_on is False else "day"
     vpd_overrides: dict[str, Any] = env_config.get("vpd_optimal_overrides", {})
 
-    bands = StageEnvironmentalTargets(sc.stage_a, sc.stage_b, sc.factor).vpd_optimal_band(
-        time_of_day, vpd_overrides
-    )
+    bands = StageEnvironmentalTargets(
+        sc.stage_a, sc.stage_b, sc.factor
+    ).vpd_optimal_band(time_of_day, vpd_overrides)
 
     for p_low, p_high, prob in bands:
         if p_low <= state.vpd <= p_high:

--- a/custom_components/growspace_manager/domain/environment_patch.py
+++ b/custom_components/growspace_manager/domain/environment_patch.py
@@ -44,6 +44,7 @@ from custom_components.growspace_manager.models import (
 )
 
 from .fan_control import FAN_VPD_STAGE_DEFAULTS
+from .moisture_band import MOISTURE_BAND_CEILING, MOISTURE_BAND_FLOOR, is_valid_band
 
 _VALID_STAGE_KEYS = {stage.value for stage in FAN_VPD_STAGE_DEFAULTS}
 _VPD_OVERRIDE_MIN = 0.1
@@ -468,11 +469,48 @@ def _build_patch(
         else:
             _parse_plain_field(key, val, values, warnings)
 
+    _validate_moisture_band(values)
+
     return EnvironmentPatch(
         values=values,
         bayesian_updates=bayesian_updates,
         warnings=tuple(warnings),
     )
+
+
+def _validate_moisture_band(values: dict[str, Any]) -> None:
+    """Keep the Acceptable Moisture Band an atomic, valid pair.
+
+    Patch semantics would otherwise let a payload carrying only one bound
+    combine with the stored other bound into a partial or inverted band, so a
+    payload touching either bound must carry both. Both ``None`` is the
+    deliberate clear back to the inherited default.
+    """
+    present = {"soil_moisture_min", "soil_moisture_max"} & values.keys()
+    if not present:
+        return
+    if len(present) == 1:
+        raise EnvironmentPatchError(
+            "The Acceptable Moisture Band is set as a pair: send both "
+            "'soil_moisture_min' and 'soil_moisture_max', or neither."
+        )
+
+    minimum = values["soil_moisture_min"]
+    maximum = values["soil_moisture_max"]
+    if minimum is None and maximum is None:
+        return
+    if minimum is None or maximum is None:
+        raise EnvironmentPatchError(
+            "The Acceptable Moisture Band needs both bounds or neither; "
+            "clear it by sending both as null."
+        )
+    if not is_valid_band(minimum, maximum):
+        raise EnvironmentPatchError(
+            f"Invalid Acceptable Moisture Band ({minimum}–{maximum}%): requires "
+            f"{MOISTURE_BAND_FLOOR:g} ≤ minimum < maximum ≤ {MOISTURE_BAND_CEILING:g}."
+        )
+    values["soil_moisture_min"] = float(minimum)
+    values["soil_moisture_max"] = float(maximum)
 
 
 def _parse_plain_field(

--- a/custom_components/growspace_manager/domain/environment_state_assembler.py
+++ b/custom_components/growspace_manager/domain/environment_state_assembler.py
@@ -18,7 +18,11 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 
 from ..models import (
     EnvironmentConfig,
@@ -28,6 +32,7 @@ from ..models import (
     Plant,
 )
 from ..utils import VPDCalculator, calculate_days_since
+from .moisture_band import is_percentage_unit
 
 if TYPE_CHECKING:
     from homeassistant.core import State
@@ -105,7 +110,7 @@ class EnvironmentStateAssembler:
             )
 
         co2 = self._sensor_value(config.co2_sensor)
-        soil_moisture = self._sensor_value(config.soil_moisture_sensor)
+        soil_moisture = self._moisture_value(config.soil_moisture_sensor)
         substrate_temp = self._aggregated_value(config.substrate_temperature_sensors)
 
         # ``.get(..., 0)`` mirrors the historical default and tolerates the
@@ -177,6 +182,22 @@ class EnvironmentStateAssembler:
             return float(state.state)
         except ValueError, TypeError:
             return None
+
+    def _moisture_value(self, sensor_id: str | None) -> float | None:
+        """Read a soil-moisture sensor, excluding non-percentage units.
+
+        The Acceptable Moisture Band interprets readings as percentages, so a
+        sensor explicitly reporting some other unit contributes nothing. A
+        sensor with no unit metadata keeps the legacy 0–100 assumption.
+        """
+        if not sensor_id:
+            return None
+        value = self._sensor_value(sensor_id)
+        if value is None:
+            return None
+        state = self._get_state(sensor_id)
+        unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) if state else None
+        return value if is_percentage_unit(unit) else None
 
     def _aggregated_value(self, sensor_ids: list[str]) -> float | None:
         """Average the valid numeric readings from a list of sensor ids."""

--- a/custom_components/growspace_manager/domain/moisture_band.py
+++ b/custom_components/growspace_manager/domain/moisture_band.py
@@ -1,0 +1,114 @@
+"""Acceptable Moisture Band — the one place the effective band is derived.
+
+A growspace either inherits the legacy default band or carries a complete
+custom pair on its :class:`EnvironmentConfig`. Both the Bayesian stress
+evaluator and the outbound growspace payload resolve the band through
+:func:`effective_moisture_band`, so the classification the card previews and
+the classification Plant Stress applies can never drift apart.
+
+Boundaries are inclusive: a reading exactly on the minimum or the maximum sits
+*inside* the band and contributes no moisture-stress evidence.
+
+Pure module: no hass, no I/O.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+from typing import Any
+
+from custom_components.growspace_manager.bayesian_constants import (
+    SOIL_MOISTURE_HIGH_THRESHOLD,
+    SOIL_MOISTURE_LOW_THRESHOLD,
+)
+
+DEFAULT_MOISTURE_MIN = float(SOIL_MOISTURE_LOW_THRESHOLD)
+DEFAULT_MOISTURE_MAX = float(SOIL_MOISTURE_HIGH_THRESHOLD)
+
+MOISTURE_BAND_FLOOR = 0.0
+MOISTURE_BAND_CEILING = 100.0
+
+# Percentage is the only unit the band can be interpreted in. A sensor with no
+# unit metadata keeps the legacy 0–100 assumption; anything else explicitly
+# declares itself to be measuring something other than a moisture percentage.
+PERCENTAGE_UNIT = "%"
+
+
+@dataclass(frozen=True, slots=True)
+class MoistureBand:
+    """The band actually applied to a reading, and where it came from."""
+
+    minimum: float
+    maximum: float
+    is_custom: bool
+
+    def classify(self, reading: float) -> str:
+        """Return ``"too_dry"``, ``"in_band"`` or ``"too_wet"``.
+
+        Inclusive boundaries: a reading equal to either bound is in band.
+        """
+        if reading < self.minimum:
+            return "too_dry"
+        if reading > self.maximum:
+            return "too_wet"
+        return "in_band"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for the growspace payload."""
+        return {
+            "min": self.minimum,
+            "max": self.maximum,
+            "is_custom": self.is_custom,
+        }
+
+
+DEFAULT_MOISTURE_BAND = MoistureBand(
+    minimum=DEFAULT_MOISTURE_MIN,
+    maximum=DEFAULT_MOISTURE_MAX,
+    is_custom=False,
+)
+
+
+def effective_moisture_band(minimum: Any, maximum: Any) -> MoistureBand:
+    """Resolve a stored override pair into the band to apply.
+
+    Accepts the raw ``soil_moisture_min`` / ``soil_moisture_max`` values from
+    either an :class:`EnvironmentConfig` or its ``to_dict()`` form. Anything
+    that is not a complete, valid pair falls back to the default band — the
+    Environment Patch builder rejects bad pairs at the write seam, so this
+    tolerance only covers configs written before that seam existed.
+    """
+    if not is_valid_band(minimum, maximum):
+        return DEFAULT_MOISTURE_BAND
+    return MoistureBand(minimum=float(minimum), maximum=float(maximum), is_custom=True)
+
+
+def is_valid_band(minimum: Any, maximum: Any) -> bool:
+    """Return True when the pair is complete and satisfies 0 ≤ min < max ≤ 100."""
+    low = _as_finite_float(minimum)
+    high = _as_finite_float(maximum)
+    if low is None or high is None:
+        return False
+    return MOISTURE_BAND_FLOOR <= low < high <= MOISTURE_BAND_CEILING
+
+
+def is_percentage_unit(unit: str | None) -> bool:
+    """Return True when a reading in ``unit`` can be read as a moisture percent.
+
+    ``None`` (no unit metadata) is the legacy case and stays supported.
+    """
+    if unit is None:
+        return True
+    return unit.strip() == PERCENTAGE_UNIT
+
+
+def _as_finite_float(value: Any) -> float | None:
+    """Coerce to a finite float, or None when the value cannot be one."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if isfinite(number) else None

--- a/custom_components/growspace_manager/models/growspace.py
+++ b/custom_components/growspace_manager/models/growspace.py
@@ -221,6 +221,11 @@ class EnvironmentConfig(BaseModel):
     vpd_sensor: str | None = None
     co2_sensor: str | None = None
     soil_moisture_sensor: str | None = None
+    # Acceptable Moisture Band override — an atomic pair. Both None means the
+    # growspace inherits the default band; a complete pair overrides it. The
+    # pair is validated (and kept atomic) by the Environment Patch builder.
+    soil_moisture_min: float | None = None
+    soil_moisture_max: float | None = None
     veg_day_hours: int = 18
     flower_day_hours: int = 12
 
@@ -506,6 +511,8 @@ ENVIRONMENT_FIELD_OWNERSHIP: dict[str, FieldOwnership] = {
     "vpd_sensor": FieldOwnership(canonical="vpd_sensors"),
     "co2_sensor": _GROWER,
     "soil_moisture_sensor": _GROWER,
+    "soil_moisture_min": _GROWER,
+    "soil_moisture_max": _GROWER,
     "veg_day_hours": _GROWER,
     "flower_day_hours": _GROWER,
     "temperature_sensors": _GROWER,

--- a/custom_components/growspace_manager/presentation/growspace_view_model.py
+++ b/custom_components/growspace_manager/presentation/growspace_view_model.py
@@ -28,10 +28,15 @@ from custom_components.growspace_manager.const import (
     CONF_VPD_SENSORS,
     DOMAIN,
 )
+from custom_components.growspace_manager.domain.moisture_band import (
+    effective_moisture_band,
+    is_percentage_unit,
+)
 from custom_components.growspace_manager.tank_water_tracker import (
     consumption_buckets_24h,
 )
 from custom_components.growspace_manager.utils import days_to_week
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT
 from homeassistant.util import dt as dt_util
 
 from .entity_queries import EntityQueries
@@ -524,12 +529,31 @@ class GrowspaceViewModelBuilder:
             attributes[CONF_VPD_SENSOR] = vpd_entity
             attributes["vpd"] = state_obj.state if state_obj else None
 
-        # Soil Moisture Sensor
+        # Soil Moisture Sensor + Acceptable Moisture Band.
+        #
+        # The raw override pair and the effective band are exposed
+        # unconditionally: a stored custom pair survives removing or replacing
+        # the sensor, so hiding it behind the sensor gate would make the card
+        # believe the growspace had reverted to the inherited default.
+        band = effective_moisture_band(
+            env_config.soil_moisture_min, env_config.soil_moisture_max
+        )
+        attributes["soil_moisture_min"] = env_config.soil_moisture_min
+        attributes["soil_moisture_max"] = env_config.soil_moisture_max
+        attributes["soil_moisture_band"] = band.to_dict()
+
         soil_moisture_entity = env_config.soil_moisture_sensor
         if soil_moisture_entity:
             state_obj = self.hass.states.get(soil_moisture_entity)
             attributes["soil_moisture_sensor"] = soil_moisture_entity
             attributes["soil_moisture_value"] = state_obj.state if state_obj else None
+            unit = (
+                state_obj.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+                if state_obj
+                else None
+            )
+            attributes["soil_moisture_unit"] = unit
+            attributes["soil_moisture_band_compatible"] = is_percentage_unit(unit)
 
         # Light Sensors
         attributes[CONF_LIGHT_SENSORS] = env_config.light_sensors

--- a/custom_components/growspace_manager/schemas.py
+++ b/custom_components/growspace_manager/schemas.py
@@ -693,6 +693,16 @@ SET_IRRIGATION_STRATEGY_SCHEMA = vol.Schema(
             None, vol.All(vol.Coerce(float), vol.Range(min=0.0))
         ),
         vol.Optional("ec_modulation_enabled"): bool,
+        # Acceptable Moisture Band. Both edges are nullable so the pair can be
+        # cleared back to the inherited default; the atomic pair and the
+        # 0 ≤ min < max ≤ 100 relation are enforced by the Environment Patch
+        # builder, which sees both values at once.
+        vol.Optional("soil_moisture_min"): vol.Any(
+            None, vol.All(vol.Coerce(float), vol.Range(min=0.0, max=100.0))
+        ),
+        vol.Optional("soil_moisture_max"): vol.Any(
+            None, vol.All(vol.Coerce(float), vol.Range(min=0.0, max=100.0))
+        ),
     }
 )
 

--- a/scratch_mock_test.py
+++ b/scratch_mock_test.py
@@ -2,13 +2,14 @@ import asyncio
 import gc
 from unittest.mock import AsyncMock
 
+
 async def main():
     mock_irr = AsyncMock()
     coro = mock_irr.async_cancel_listeners()
-    
+
     mock_func = mock_irr.async_cancel_listeners
     print("mock_func attributes:", dir(mock_func))
-    
+
     # Check if we can find unawaited coroutines in gc.get_objects()
     # that are instances of coroutine and have AsyncMockMixin._execute_mock_call
     for obj in gc.get_objects():
@@ -18,7 +19,7 @@ async def main():
                 # Let's try closing it!
                 obj.close()
                 print("Closed coroutine found in gc")
-    
+
     # Let's clean up coro to prevent warning in this script if gc didn't close it
     try:
         coro.close()

--- a/tests/contract/test_growspace_payload_contract.py
+++ b/tests/contract/test_growspace_payload_contract.py
@@ -78,6 +78,10 @@ def _maximal_environment_config(prefix: str) -> EnvironmentConfig:
         vpd_sensor=vpd,
         co2_sensor=f"sensor.{prefix}_co2",
         soil_moisture_sensor=f"sensor.{prefix}_soil_moisture",
+        # Deliberately decimal and different from the inherited 20–60 default,
+        # so the encoded band proves a custom override serializes as custom.
+        soil_moisture_min=32.5,
+        soil_moisture_max=54.0,
         veg_day_hours=18,
         flower_day_hours=12,
         temperature_sensors=[temperature, f"sensor.{prefix}_temperature_2"],
@@ -524,6 +528,8 @@ def _set_runtime_states(hass: HomeAssistant) -> None:
             if entity_id == "humidifier.contract_dehumidifier"
             else {"status": "normal"}
             if "tank_depletion" in entity_id
+            else {"unit_of_measurement": "%"}
+            if "soil_moisture" in entity_id
             else None
         )
         hass.states.async_set(entity_id, state, attributes)

--- a/tests/core/snapshots/test_models_snapshots.ambr
+++ b/tests/core/snapshots/test_models_snapshots.ambr
@@ -155,6 +155,8 @@
     'sensor_groups': list([
     ]),
     'snapshot_interval_hours': 24,
+    'soil_moisture_max': None,
+    'soil_moisture_min': None,
     'soil_moisture_sensor': None,
     'stress_threshold': 0.7,
     'substrate_temperature_sensors': list([
@@ -322,6 +324,8 @@
       'sensor_groups': list([
       ]),
       'snapshot_interval_hours': 24,
+      'soil_moisture_max': None,
+      'soil_moisture_min': None,
       'soil_moisture_sensor': None,
       'stress_threshold': 0.7,
       'substrate_temperature_sensors': list([

--- a/tests/core/snapshots/test_presentation_snapshots.ambr
+++ b/tests/core/snapshots/test_presentation_snapshots.ambr
@@ -109,6 +109,13 @@
       ]),
       'runoff_ec_sensors': list([
       ]),
+      'soil_moisture_band': dict({
+        'is_custom': False,
+        'max': 60.0,
+        'min': 20.0,
+      }),
+      'soil_moisture_max': None,
+      'soil_moisture_min': None,
       'substrate_temperature_sensors': list([
       ]),
       'temperature': None,

--- a/tests/domain/test_environment_patch.py
+++ b/tests/domain/test_environment_patch.py
@@ -758,3 +758,107 @@ def test_item_list_null_clears() -> None:
     """Null on a dataclass-list field is a deliberate clear."""
     patch = patch_from_service_call({"irrigation_tanks": None})
     assert patch.values["irrigation_tanks"] == []
+
+
+# -- Acceptable Moisture Band ----------------------------------------------
+
+
+def test_moisture_band_saves_a_complete_decimal_pair() -> None:
+    """Both bounds are stored, coerced to float, in one atomic write."""
+    verdict = apply_environment_patch(
+        EnvironmentConfig(),
+        patch_from_service_call(
+            {"growspace_id": "gs1", "soil_moisture_min": 32.5, "soil_moisture_max": 54}
+        ),
+    )
+    assert verdict.config.soil_moisture_min == 32.5
+    assert verdict.config.soil_moisture_max == 54.0
+    assert verdict.changed("soil_moisture_min", "soil_moisture_max")
+
+
+def test_moisture_band_both_null_clears_back_to_inherited() -> None:
+    """Reset-and-save removes the override rather than storing 20–60."""
+    stored = EnvironmentConfig(soil_moisture_min=32.5, soil_moisture_max=54.0)
+    verdict = apply_environment_patch(
+        stored,
+        patch_from_service_call({"soil_moisture_min": None, "soil_moisture_max": None}),
+    )
+    assert verdict.config.soil_moisture_min is None
+    assert verdict.config.soil_moisture_max is None
+
+
+def test_moisture_band_untouched_payload_preserves_a_stored_pair() -> None:
+    """Patch semantics: a save that omits both bounds keeps the override."""
+    stored = EnvironmentConfig(soil_moisture_min=32.5, soil_moisture_max=54.0)
+    verdict = apply_environment_patch(
+        stored, patch_from_service_call({"co2_sensor": "sensor.co2"})
+    )
+    assert verdict.config.soil_moisture_min == 32.5
+    assert verdict.config.soil_moisture_max == 54.0
+
+
+def test_moisture_band_survives_replacing_and_removing_the_sensor() -> None:
+    """The override outlives the sensor it was configured against."""
+    stored = EnvironmentConfig(
+        soil_moisture_sensor="sensor.old",
+        soil_moisture_min=32.5,
+        soil_moisture_max=54.0,
+    )
+    replaced = apply_environment_patch(
+        stored, patch_from_service_call({"soil_moisture_sensor": "sensor.new"})
+    ).config
+    assert (replaced.soil_moisture_min, replaced.soil_moisture_max) == (32.5, 54.0)
+
+    removed = apply_environment_patch(
+        replaced, patch_from_service_call({"soil_moisture_sensor": None})
+    ).config
+    assert removed.soil_moisture_sensor is None
+    assert (removed.soil_moisture_min, removed.soil_moisture_max) == (32.5, 54.0)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({"soil_moisture_min": 30.0}, id="minimum-alone"),
+        pytest.param({"soil_moisture_max": 55.0}, id="maximum-alone"),
+        pytest.param(
+            {"soil_moisture_min": 30.0, "soil_moisture_max": None}, id="half-cleared"
+        ),
+        pytest.param(
+            {"soil_moisture_min": None, "soil_moisture_max": 55.0}, id="half-set"
+        ),
+    ],
+)
+def test_moisture_band_rejects_a_partial_pair(payload: dict[str, Any]) -> None:
+    """A lone bound would combine with the stored one into an unintended band."""
+    with pytest.raises(EnvironmentPatchError, match="Acceptable Moisture Band"):
+        patch_from_service_call(payload)
+
+
+@pytest.mark.parametrize(
+    ("minimum", "maximum"),
+    [
+        pytest.param(60.0, 30.0, id="inverted"),
+        pytest.param(40.0, 40.0, id="equal-bounds"),
+        pytest.param(-1.0, 50.0, id="below-floor"),
+        pytest.param(20.0, 101.0, id="above-ceiling"),
+        pytest.param(float("nan"), 50.0, id="not-finite"),
+    ],
+)
+def test_moisture_band_rejects_an_invalid_pair(minimum: float, maximum: float) -> None:
+    """0 ≤ minimum < maximum ≤ 100 is enforced at the write seam."""
+    with pytest.raises(EnvironmentPatchError, match="Acceptable Moisture Band"):
+        patch_from_service_call(
+            {"soil_moisture_min": minimum, "soil_moisture_max": maximum}
+        )
+
+
+def test_moisture_band_round_trips_through_serialization() -> None:
+    """The pair survives a to_dict/from_dict cycle (storage + restart)."""
+    stored = apply_environment_patch(
+        EnvironmentConfig(),
+        patch_from_service_call({"soil_moisture_min": 32.5, "soil_moisture_max": 54.0}),
+    ).config
+    restored = EnvironmentConfig.from_dict(stored.to_dict())
+    assert restored.soil_moisture_min == 32.5
+    assert restored.soil_moisture_max == 54.0

--- a/tests/domain/test_environment_state_assembler.py
+++ b/tests/domain/test_environment_state_assembler.py
@@ -8,7 +8,7 @@ coordinator is involved. They pin the sensor-reading logic that moved off
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, timedelta
 
 import pytest
@@ -32,6 +32,7 @@ class FakeState:
 
     state: str
     domain: str = "sensor"
+    attributes: dict[str, object] = field(default_factory=dict)
 
 
 def make_get_state(states: dict[str, FakeState]):
@@ -403,3 +404,42 @@ def test_state_and_observations_share_one_read() -> None:
     assert result.observations["humidity"] == result.state.humidity
     assert result.observations["co2"] == result.state.co2
     assert result.observations["soil_moisture"] == result.state.soil_moisture
+
+
+# -- soil moisture unit compatibility --------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("unit", "expected"),
+    [
+        pytest.param("%", 42.0, id="percentage-participates"),
+        pytest.param(None, 42.0, id="legacy-no-unit-participates"),
+        pytest.param("°C", None, id="temperature-excluded"),
+        pytest.param("m³/m³", None, id="volumetric-ratio-excluded"),
+    ],
+)
+def test_soil_moisture_excluded_for_non_percentage_units(
+    unit: str | None, expected: float | None
+) -> None:
+    """Only percentage and unit-less sensors reach moisture classification."""
+    config = EnvironmentConfig(soil_moisture_sensor="sensor.moisture")
+    attributes: dict[str, object] = (
+        {} if unit is None else {"unit_of_measurement": unit}
+    )
+    states = {"sensor.moisture": FakeState("42.0", attributes=attributes)}
+
+    result = build_assembler(config, states).assemble()
+
+    assert result.state.soil_moisture == expected
+    assert result.observations["soil_moisture"] == expected
+
+
+def test_soil_moisture_unavailable_reading_yields_none() -> None:
+    """An unavailable sensor produces no reading to classify."""
+    config = EnvironmentConfig(soil_moisture_sensor="sensor.moisture")
+    states = {
+        "sensor.moisture": FakeState(
+            STATE_UNAVAILABLE, attributes={"unit_of_measurement": "%"}
+        )
+    }
+    assert build_assembler(config, states).assemble().state.soil_moisture is None

--- a/tests/domain/test_moisture_band.py
+++ b/tests/domain/test_moisture_band.py
@@ -1,0 +1,137 @@
+"""Unit tests for the Acceptable Moisture Band domain helper.
+
+Pure tests: no Home Assistant instance, no coordinator. They pin the band
+resolution and classification that both the Bayesian stress evaluator and the
+outbound growspace payload share.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.growspace_manager.domain.moisture_band import (
+    DEFAULT_MOISTURE_BAND,
+    DEFAULT_MOISTURE_MAX,
+    DEFAULT_MOISTURE_MIN,
+    MoistureBand,
+    effective_moisture_band,
+    is_percentage_unit,
+    is_valid_band,
+)
+
+
+def test_default_band_is_the_legacy_20_60_inclusive_range() -> None:
+    """No override inherits the historic 20–60% band, marked as inherited."""
+    assert DEFAULT_MOISTURE_MIN == 20.0
+    assert DEFAULT_MOISTURE_MAX == 60.0
+    assert DEFAULT_MOISTURE_BAND == MoistureBand(20.0, 60.0, is_custom=False)
+
+
+def test_no_override_resolves_to_the_default_band() -> None:
+    """Both bounds absent means the growspace inherits, not overrides."""
+    band = effective_moisture_band(None, None)
+    assert band == DEFAULT_MOISTURE_BAND
+    assert band.is_custom is False
+
+
+def test_complete_decimal_pair_resolves_to_a_custom_band() -> None:
+    """A stored pair overrides the default and reports itself as custom."""
+    band = effective_moisture_band(32.5, 54.5)
+    assert band == MoistureBand(32.5, 54.5, is_custom=True)
+
+
+@pytest.mark.parametrize(
+    ("minimum", "maximum"),
+    [
+        pytest.param(30.0, None, id="max-missing"),
+        pytest.param(None, 55.0, id="min-missing"),
+        pytest.param(60.0, 30.0, id="inverted"),
+        pytest.param(40.0, 40.0, id="equal-bounds"),
+        pytest.param(-0.5, 50.0, id="below-floor"),
+        pytest.param(20.0, 100.5, id="above-ceiling"),
+        pytest.param(float("nan"), 50.0, id="nan"),
+        pytest.param(float("inf"), float("inf"), id="infinite"),
+        pytest.param("not-a-number", 50.0, id="non-numeric"),
+    ],
+)
+def test_incomplete_or_invalid_pairs_fall_back_to_the_default(
+    minimum: Any, maximum: Any
+) -> None:
+    """Anything short of a complete valid pair inherits rather than half-applies."""
+    assert is_valid_band(minimum, maximum) is False
+    assert effective_moisture_band(minimum, maximum) == DEFAULT_MOISTURE_BAND
+
+
+@pytest.mark.parametrize(
+    ("minimum", "maximum"),
+    [
+        pytest.param(0.0, 100.0, id="full-range"),
+        pytest.param(0.0, 0.1, id="floor-touching"),
+        pytest.param(99.9, 100.0, id="ceiling-touching"),
+        pytest.param(32.5, 54.5, id="decimal-pair"),
+    ],
+)
+def test_valid_pairs_span_the_whole_permitted_range(
+    minimum: float, maximum: float
+) -> None:
+    """0 ≤ minimum < maximum ≤ 100 is accepted, edges included."""
+    assert is_valid_band(minimum, maximum) is True
+
+
+@pytest.mark.parametrize(
+    ("reading", "expected"),
+    [
+        pytest.param(19.9, "too_dry", id="just-below-minimum"),
+        pytest.param(20.0, "in_band", id="exactly-on-minimum"),
+        pytest.param(40.0, "in_band", id="mid-band"),
+        pytest.param(60.0, "in_band", id="exactly-on-maximum"),
+        pytest.param(60.1, "too_wet", id="just-above-maximum"),
+    ],
+)
+def test_classification_boundaries_are_inclusive(
+    reading: float, expected: str
+) -> None:
+    """A reading exactly on either bound sits inside the band."""
+    assert DEFAULT_MOISTURE_BAND.classify(reading) == expected
+
+
+def test_classification_follows_a_custom_band_not_the_default() -> None:
+    """A reading in the default band can be out of a narrower custom band."""
+    custom = effective_moisture_band(32.5, 54.0)
+    assert DEFAULT_MOISTURE_BAND.classify(56.0) == "in_band"
+    assert custom.classify(56.0) == "too_wet"
+    assert custom.classify(30.0) == "too_dry"
+
+
+def test_band_serializes_for_the_growspace_payload() -> None:
+    """The wire shape carries both bounds and the inherited/custom distinction."""
+    assert effective_moisture_band(32.5, 54.0).to_dict() == {
+        "min": 32.5,
+        "max": 54.0,
+        "is_custom": True,
+    }
+    assert DEFAULT_MOISTURE_BAND.to_dict() == {
+        "min": 20.0,
+        "max": 60.0,
+        "is_custom": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("unit", "compatible"),
+    [
+        pytest.param("%", True, id="percentage"),
+        pytest.param(" % ", True, id="percentage-padded"),
+        pytest.param(None, True, id="legacy-no-unit-metadata"),
+        pytest.param("°C", False, id="temperature"),
+        pytest.param("m³/m³", False, id="volumetric-ratio"),
+        pytest.param("", False, id="empty-string-unit"),
+    ],
+)
+def test_only_percentage_and_unitless_sensors_participate(
+    unit: str | None, compatible: bool
+) -> None:
+    """Explicitly non-percentage units are excluded; missing metadata is legacy."""
+    assert is_percentage_unit(unit) is compatible

--- a/tests/domain/test_moisture_band.py
+++ b/tests/domain/test_moisture_band.py
@@ -26,7 +26,7 @@ def test_default_band_is_the_legacy_20_60_inclusive_range() -> None:
     """No override inherits the historic 20–60% band, marked as inherited."""
     assert DEFAULT_MOISTURE_MIN == 20.0
     assert DEFAULT_MOISTURE_MAX == 60.0
-    assert DEFAULT_MOISTURE_BAND == MoistureBand(20.0, 60.0, is_custom=False)
+    assert MoistureBand(20.0, 60.0, is_custom=False) == DEFAULT_MOISTURE_BAND
 
 
 def test_no_override_resolves_to_the_default_band() -> None:

--- a/tests/fixtures/contract/growspace_payload.json
+++ b/tests/fixtures/contract/growspace_payload.json
@@ -187,7 +187,16 @@
     "pore_ec_sensors": ["sensor.contract_pore_ec"],
     "power_sensors": ["sensor.contract_power"],
     "runoff_ec_sensors": ["sensor.contract_runoff_ec"],
+    "soil_moisture_band": {
+      "is_custom": true,
+      "max": 54.0,
+      "min": 32.5
+    },
+    "soil_moisture_band_compatible": true,
+    "soil_moisture_max": 54.0,
+    "soil_moisture_min": 32.5,
     "soil_moisture_sensor": "sensor.contract_soil_moisture",
+    "soil_moisture_unit": "%",
     "soil_moisture_value": "56.0",
     "substrate_ec_delta": 0.4,
     "substrate_temperature_sensors": ["sensor.contract_substrate_temperature"],
@@ -727,6 +736,8 @@
           }
         ],
         "snapshot_interval_hours": 6,
+        "soil_moisture_max": 54.0,
+        "soil_moisture_min": 32.5,
         "soil_moisture_sensor": "sensor.subarea_soil_moisture",
         "stress_threshold": 0.65,
         "substrate_temperature_sensors": [

--- a/tests/integration/snapshots/test_services_growspace_coverage.ambr
+++ b/tests/integration/snapshots/test_services_growspace_coverage.ambr
@@ -142,6 +142,8 @@
       'sensor_groups': list([
       ]),
       'snapshot_interval_hours': 24,
+      'soil_moisture_max': None,
+      'soil_moisture_min': None,
       'soil_moisture_sensor': None,
       'stress_threshold': 0.7,
       'substrate_temperature_sensors': list([

--- a/tests/logic/test_soil_moisture_stress.py
+++ b/tests/logic/test_soil_moisture_stress.py
@@ -9,9 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from custom_components.growspace_manager.bayesian_data import (
-    PROB_SOIL_MOISTURE_STRESS,
-)
+from custom_components.growspace_manager.bayesian_data import PROB_SOIL_MOISTURE_STRESS
 from custom_components.growspace_manager.bayesian_evaluator import (
     evaluate_soil_moisture_stress,
 )

--- a/tests/logic/test_soil_moisture_stress.py
+++ b/tests/logic/test_soil_moisture_stress.py
@@ -1,0 +1,115 @@
+"""Tests for soil-moisture stress evaluation against the Acceptable Moisture Band.
+
+These pin the evidence side of the band: which readings add moisture-stress
+evidence, which add none, and that the reasons name both the reading and the
+effective boundary a grower needs to act on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.growspace_manager.bayesian_data import (
+    PROB_SOIL_MOISTURE_STRESS,
+)
+from custom_components.growspace_manager.bayesian_evaluator import (
+    evaluate_soil_moisture_stress,
+)
+from custom_components.growspace_manager.models import (
+    EnvironmentConfig,
+    EnvironmentState,
+)
+
+
+def _state(soil_moisture: float | None) -> EnvironmentState:
+    """Build an EnvironmentState carrying only a moisture reading."""
+    return EnvironmentState(soil_moisture=soil_moisture)
+
+
+def _env(minimum: float | None = None, maximum: float | None = None) -> dict:
+    """Serialize an EnvironmentConfig the way StressEvaluatorStrategy does."""
+    return EnvironmentConfig(
+        soil_moisture_min=minimum, soil_moisture_max=maximum
+    ).to_dict()
+
+
+@pytest.mark.parametrize(
+    ("moisture", "expected_fragment"),
+    [
+        pytest.param(15.0, "Soil Moisture Low (15.0% < 20%)", id="below-default-min"),
+        pytest.param(65.0, "Soil Moisture High (65.0% > 60%)", id="above-default-max"),
+    ],
+)
+def test_default_band_reasons_name_reading_and_boundary(
+    moisture: float, expected_fragment: str
+) -> None:
+    """An inherited band still explains itself with the effective boundary."""
+    observations, reasons = evaluate_soil_moisture_stress(_state(moisture), _env())
+
+    assert observations == [PROB_SOIL_MOISTURE_STRESS]
+    assert [reason for _, reason in reasons] == [expected_fragment]
+
+
+@pytest.mark.parametrize(
+    "moisture",
+    [
+        pytest.param(20.0, id="exactly-on-minimum"),
+        pytest.param(40.0, id="mid-band"),
+        pytest.param(60.0, id="exactly-on-maximum"),
+    ],
+)
+def test_in_band_readings_add_no_evidence(moisture: float) -> None:
+    """Inclusive boundaries: on-bound and in-band readings add nothing.
+
+    Nothing positive either — the absence of moisture-stress evidence must not
+    become evidence that conditions are optimal.
+    """
+    observations, reasons = evaluate_soil_moisture_stress(_state(moisture), _env())
+
+    assert observations == []
+    assert reasons == []
+
+
+def test_custom_band_narrows_what_counts_as_stress() -> None:
+    """A reading acceptable under the default is stress under a tighter band."""
+    in_default, _ = evaluate_soil_moisture_stress(_state(56.0), _env())
+    assert in_default == []
+
+    observations, reasons = evaluate_soil_moisture_stress(
+        _state(56.0), _env(32.5, 54.0)
+    )
+    assert observations == [PROB_SOIL_MOISTURE_STRESS]
+    assert reasons[0][1] == "Soil Moisture High (56.0% > 54%)"
+
+
+def test_custom_band_widens_what_counts_as_stress() -> None:
+    """A reading that is stress under the default can be fine under a wider band."""
+    observations, reasons = evaluate_soil_moisture_stress(
+        _state(15.0), _env(10.0, 80.0)
+    )
+    assert observations == []
+    assert reasons == []
+
+
+def test_custom_band_reason_reports_the_custom_boundary() -> None:
+    """The boundary in the reason is the effective one, not the default."""
+    _, reasons = evaluate_soil_moisture_stress(_state(30.0), _env(32.5, 54.0))
+    assert reasons[0][1] == "Soil Moisture Low (30.0% < 32.5%)"
+
+
+def test_missing_reading_produces_no_evidence() -> None:
+    """An unavailable or excluded sensor leaves stress evaluation untouched."""
+    observations, reasons = evaluate_soil_moisture_stress(
+        _state(None), _env(32.5, 54.0)
+    )
+    assert observations == []
+    assert reasons == []
+
+
+def test_partial_stored_band_falls_back_to_the_default() -> None:
+    """A half-written config (pre-dating the write seam) still classifies sanely."""
+    observations, reasons = evaluate_soil_moisture_stress(
+        _state(15.0), _env(minimum=32.5)
+    )
+    assert observations == [PROB_SOIL_MOISTURE_STRESS]
+    assert reasons[0][1] == "Soil Moisture Low (15.0% < 20%)"

--- a/tests/presentation/test_moisture_band_payload.py
+++ b/tests/presentation/test_moisture_band_payload.py
@@ -1,0 +1,132 @@
+"""Contract tests for the Acceptable Moisture Band in the growspace payload.
+
+The card never reads sensor entity attributes, so the band has to reach it
+through the growspace view model. These pin what the card needs to tell an
+inherited band from a custom one, and to show an incompatibility state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.growspace_manager.models import (
+    EnvironmentConfig,
+    Growspace,
+    GrowspaceType,
+)
+from custom_components.growspace_manager.presentation.growspace_view_model import (
+    GrowspaceViewModelBuilder,
+)
+from homeassistant.core import HomeAssistant
+
+MOISTURE_SENSOR = "sensor.test_soil_moisture"
+
+
+def _growspace(env: EnvironmentConfig) -> Growspace:
+    """Build a growspace carrying the given environment config."""
+    return Growspace(
+        id="gs1",
+        name="Test",
+        growspace_type=GrowspaceType.FLOWER,
+        environment_config=env,
+    )
+
+
+def _environment(hass: HomeAssistant, env: EnvironmentConfig) -> dict:
+    """Return the environment attribute block the card receives."""
+    return GrowspaceViewModelBuilder(hass)._get_environment_attributes(_growspace(env))
+
+
+async def test_inherited_band_is_reported_as_effective_but_not_custom(
+    hass: HomeAssistant,
+) -> None:
+    """The card can show 20–60% without presenting it as a saved override."""
+    attributes = _environment(hass, EnvironmentConfig())
+
+    assert attributes["soil_moisture_min"] is None
+    assert attributes["soil_moisture_max"] is None
+    assert attributes["soil_moisture_band"] == {
+        "min": 20.0,
+        "max": 60.0,
+        "is_custom": False,
+    }
+
+
+async def test_custom_band_is_reported_as_a_saved_override(
+    hass: HomeAssistant,
+) -> None:
+    """A stored pair reaches the card as both raw values and an effective band."""
+    attributes = _environment(
+        hass, EnvironmentConfig(soil_moisture_min=32.5, soil_moisture_max=54.0)
+    )
+
+    assert attributes["soil_moisture_min"] == 32.5
+    assert attributes["soil_moisture_max"] == 54.0
+    assert attributes["soil_moisture_band"] == {
+        "min": 32.5,
+        "max": 54.0,
+        "is_custom": True,
+    }
+
+
+async def test_stored_band_is_visible_without_any_sensor(
+    hass: HomeAssistant,
+) -> None:
+    """Removing the sensor must not make a stored override look discarded."""
+    attributes = _environment(
+        hass,
+        EnvironmentConfig(soil_moisture_min=32.5, soil_moisture_max=54.0),
+    )
+
+    assert "soil_moisture_sensor" not in attributes
+    assert attributes["soil_moisture_min"] == 32.5
+    assert attributes["soil_moisture_max"] == 54.0
+
+
+@pytest.mark.parametrize(
+    ("unit", "compatible"),
+    [
+        pytest.param("%", True, id="percentage"),
+        pytest.param(None, True, id="legacy-no-unit-metadata"),
+        pytest.param("°C", False, id="temperature"),
+        pytest.param("m³/m³", False, id="volumetric-ratio"),
+    ],
+)
+async def test_sensor_unit_compatibility_reaches_the_card(
+    hass: HomeAssistant, unit: str | None, compatible: bool
+) -> None:
+    """The card needs the unit to render an incompatibility state."""
+    hass.states.async_set(
+        MOISTURE_SENSOR,
+        "42.0",
+        {} if unit is None else {"unit_of_measurement": unit},
+    )
+
+    attributes = _environment(
+        hass, EnvironmentConfig(soil_moisture_sensor=MOISTURE_SENSOR)
+    )
+
+    assert attributes["soil_moisture_sensor"] == MOISTURE_SENSOR
+    assert attributes["soil_moisture_value"] == "42.0"
+    assert attributes["soil_moisture_unit"] == unit
+    assert attributes["soil_moisture_band_compatible"] is compatible
+
+
+async def test_band_does_not_depend_on_pump_or_tank_hardware(
+    hass: HomeAssistant,
+) -> None:
+    """Visibility rests on the moisture sensor alone, never on irrigation gear."""
+    hass.states.async_set(MOISTURE_SENSOR, "42.0", {"unit_of_measurement": "%"})
+
+    attributes = _environment(
+        hass,
+        EnvironmentConfig(
+            soil_moisture_sensor=MOISTURE_SENSOR,
+            soil_moisture_min=32.5,
+            soil_moisture_max=54.0,
+            irrigation_tanks=[],
+        ),
+    )
+
+    assert attributes["soil_moisture_band_compatible"] is True
+    assert attributes["soil_moisture_band"]["is_custom"] is True


### PR DESCRIPTION
Closes #577. Unblocks the card-side issue Venosta-web/lovelace-growspace-manager-card#501.

## What changed

Soil-moisture stress was judged against the hardcoded `SOIL_MOISTURE_LOW_THRESHOLD` / `SOIL_MOISTURE_HIGH_THRESHOLD` constants. Growspaces can now carry their own band, and the contract exposes enough for the card to distinguish an inherited default from a custom pair.

- **`domain/moisture_band.py`** — the one place the effective band is derived. Both the Bayesian evaluator and the outbound payload resolve through it, so the classification the card previews and the one Plant Stress applies cannot drift apart. Boundaries are inclusive.
- **`soil_moisture_min` / `soil_moisture_max`** on `EnvironmentConfig`, as an atomic pair. The Environment Patch builder rejects partial pairs (under patch semantics a lone bound would silently combine with the stored one into an unintended band) and enforces `0 ≤ min < max ≤ 100`. Both `null` is the deliberate clear back to the inherited 20–60%.
- **Reasons name the effective boundary** — `Soil Moisture Low (15.0% < 32.5%)` rather than just the reading.
- **Unit handling** — explicitly non-percentage sensors are excluded at the assembler; sensors with no unit metadata keep the legacy 0–100 assumption. `state.soil_moisture` has exactly one consumer (`evaluate_soil_moisture_stress`), so gating there is contained.
- **Contract** — the raw pair and effective band are exposed *outside* the `if soil_moisture_sensor:` gate, because a stored override survives replacing or removing the sensor. Gating it would make the card believe the growspace had reverted to the default. Unit + compatibility flag stay inside the gate.

## Notes for review

- **Subareas** gain no independent band (explicitly out of scope). The two fields appear in their serialized config only because subareas share `EnvironmentConfig`; nothing reads them for subareas.
- **In-band readings** add no moisture-stress evidence, and are not treated as positive evidence that conditions are optimal.
- `bayesian_evaluator.py` shows three unrelated reformats — the file was already ruff-format-dirty on `prerelease` and the pre-commit hook picked it up.
- The contract fixture's maximal builder now sets a deliberately decimal, non-default pair (32.5–54.0) against the existing 56.0 reading, so the fixture proves `is_custom` serialization rather than accidentally matching the default.

## Testing

- Full suite: **5021 passed**.
- New: `tests/domain/test_moisture_band.py`, `tests/logic/test_soil_moisture_stress.py`, `tests/presentation/test_moisture_band_payload.py`; band cases added to `test_environment_patch.py` and `test_environment_state_assembler.py`.
- Covers defaults, custom decimal bounds, exact boundaries, validation/atomicity, incompatible units, explanatory reasons, persistence through the sensor being replaced and removed, serialization round-trip, and hardware-independent visibility.
- mypy clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)