### PR TITLE
Bump test baseline to Home Assistant 2026.8.1

### DIFF
--- a/docs/adr/0020-ci-merge-gate-and-ha-core-aligned-test-rules.md
+++ b/docs/adr/0020-ci-merge-gate-and-ha-core-aligned-test-rules.md
@@ -10,7 +10,7 @@ the integration branch:
 1. **No branch protection.** Every branch was unprotected, so even when `tests.yaml`
    went red a PR could still be merged. The workflows existed but enforced nothing.
 2. **CI never ran ruff or mypy.** `tests.yaml` ran `pytest --cov` only. Linting and
-   type-checking lived solely in `.pre-commit-config.yaml`, which checks *staged*
+   type-checking lived solely in `.pre-commit-config.yaml`, which checks _staged_
    files. A `git commit --no-verify` (or any path where the hook didn't fire) merged
    lint- and type-dirty code. Run repo-wide, the accumulated debt was **3887 ruff
    errors** and **460 mypy errors in 74 files**.
@@ -40,7 +40,7 @@ indistinguishable from no gate.
 
 3. **`per-file-ignores` are re-pointed at this repo's layout to match HA core's own
    stance**, ignoring `SLF001` and the docstring `D1xx` rules under `tests/**`. This
-   is a *correction* of an inherited path mismatch, not a relaxation of the bar:
+   is a _correction_ of an inherited path mismatch, not a relaxation of the bar:
    production code in `custom_components/` stays fully strict. Tests legitimately
    poke internals and do not need docstrings on every function — the same judgement
    HA core makes for its own tests.
@@ -53,7 +53,7 @@ indistinguishable from no gate.
 
 ## Consequences
 
-- Stacked feature branches that PR into *other* feature branches are not gated until
+- Stacked feature branches that PR into _other_ feature branches are not gated until
   they land on `dev`. That is the intended place for the gate to bite.
 - Choosing fix-first over ratchet is the larger up-front cost, paid once, in exchange
   for a clean repo-wide bar with no per-file suppression to reason about later.
@@ -112,13 +112,13 @@ Two decisions follow:
    `homeassistant==2026.5.4` → `hassil==3.5.0`; HA ships that mapping as
    `homeassistant/package_constraints.txt`, so it is a fact to be read, not a
    judgement to be made. The near-term mechanism is a direct pin. The intended
-   end state is a constrained install — `pip install -r requirements.txt -c
-   <site-packages>/homeassistant/package_constraints.txt` after installing
-   `homeassistant` — which closes the class rather than one member of it. A
+   end state is a constrained install using Home Assistant's packaged
+   `package_constraints.txt` after installing `homeassistant` — which closes the
+   class rather than one member of it. A
    dry-run confirms the constraints file resolves cleanly against this
    `requirements.txt` with no conflicts.
 
-   *Rejected:* a lockfile. A stale `uv.lock` is tracked in the repo root, last
+   _Rejected:_ a lockfile. A stale `uv.lock` is tracked in the repo root, last
    touched 2026-05-11, referenced by no workflow, and does not contain `hassil`.
    It is debris, not a live mechanism. Adopting a lockfile would mean maintaining
    a second source of truth alongside HA's constraints file, which would drift
@@ -146,3 +146,27 @@ Two decisions follow:
 - Pinning transitively-owned dependencies by hand is a stopgap. Until the
   constrained install lands, a `homeassistant` bump that changes a pin we mirror
   will fail CI until the mirrored value is updated by hand.
+
+## Amendment (2026-08-12) — test against Home Assistant 2026.8.1
+
+The standalone test and CI baseline moves from Home Assistant 2026.5.4 to
+2026.8.1. Its coupled dependency chain moves with it:
+
+- `pytest-homeassistant-custom-component==0.13.355` pins
+  `homeassistant==2026.8.1`;
+- Home Assistant 2026.8.1's packaged constraints pin `hassil==3.11.0` and
+  `home-assistant-intents==2026.7.30`.
+
+The two-phase constrained install remains the source of truth for the rest of
+Home Assistant's dependency graph. The explicit `hassil` and
+`home-assistant-intents` pins remain mirrored in `requirements.txt` so an
+accidental unconstrained install still fails deterministically rather than
+silently selecting a different pair.
+
+`hacs.json` retains Home Assistant 2026.5.4 as the minimum supported runtime.
+Moving the development baseline does not by itself justify dropping working
+installations on 2026.5 through 2026.7. Compatibility fixes exposed by the new
+baseline must preserve that minimum; a change that cannot do so requires a
+separate decision to raise it. CI continues to exercise one Home Assistant
+version for now. A minimum-and-latest matrix is a separate reliability change
+with its own paired test-helper dependency maintenance.

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,7 @@ syrupy>=5.0.0
 # lint.yaml's version so a local `ruff check` agrees with the gate; lint.yaml is the
 # source of truth, so bump it there first.
 ruff==0.15.12
+mypy==1.20.2
 pre-commit
 pylint
 yamllint

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@
 # Home Assistant Core (Minimal)
 # Kept in lockstep with pytest-homeassistant-custom-component, which pins this exact
 # homeassistant version; bumping one requires bumping the other.
-homeassistant==2026.5.4
+homeassistant==2026.8.1
 aiosqlite==0.22.1
 Pillow
 python-dateutil==2.9.0.post0
@@ -40,15 +40,15 @@ coverage
 pydantic
 pipdeptree
 pytest-asyncio
-pytest-homeassistant-custom-component==0.13.333
+pytest-homeassistant-custom-component==0.13.355
 pytest-cov
 pytest
 PyTurboJPEG
 pytest-xdist
 freezegun
 requests-mock
-hassil==3.5.0
-home-assistant-intents==2026.5.5
+hassil==3.11.0
+home-assistant-intents==2026.7.30
 syrupy>=5.0.0
 
 # Local dev tooling — NOT what the gate runs. CI pins its own copies: ruff and mypy


### PR DESCRIPTION
## Summary

- move the standalone test and CI baseline to Home Assistant 2026.8.1
- update the matching custom-component test helper and HA-owned dependency pins
- install the same pinned mypy version locally that the lint workflow uses
- record the upgrade and compatibility policy in ADR-0020

## Why

Growspace Manager is a standalone HACS custom component and must use its own test environment rather than Home Assistant Core's virtual environment. Updating the baseline keeps CI aligned with Home Assistant 2026.8.1 while retaining reproducible dependency resolution through Home Assistant's packaged constraints.

The HACS minimum remains Home Assistant 2026.5.4 because moving the development baseline alone does not justify dropping older working installations.

## Dependency changes

- `homeassistant==2026.8.1`
- `pytest-homeassistant-custom-component==0.13.355`
- `hassil==3.11.0`
- `home-assistant-intents==2026.7.30`
- `mypy==1.20.2`

## Validation

- verified the exact four-version dependency chain
- `pip check`: passed
- full coverage suite: 5,021 tests passed, 46 snapshots passed, 99% coverage
- targeted pre-commit hooks for both changed files: passed
- local mypy hook now launches successfully and reports the existing non-blocking
  type-checking baseline
- `git diff --check`: passed

The repository-wide pre-commit command was also run. It remains red on unrelated existing repository hygiene issues in tracked scratch/generated files, existing yamllint findings, formatter drift, and the documented non-blocking mypy error baseline; none were included in this focused dependency upgrade.
