### PR TITLE
Preserve omitted environment fields at the service schema boundary

### DIFF
--- a/custom_components/growspace_manager/schemas.py
+++ b/custom_components/growspace_manager/schemas.py
@@ -528,14 +528,17 @@ CONFIGURE_ENVIRONMENT_SCHEMA = vol.Schema(
         vol.Optional(CONF_EXHAUST_ENTITY): str,
         vol.Optional(CONF_HUMIDIFIER_ENTITY): str,
         vol.Optional(CONF_SOIL_MOISTURE_SENSOR): str,
-        vol.Optional(CONF_CONTROL_DEHUMIDIFIER, default=False): bool,
+        # No defaults on any optional key: the patch seam (ADR-0026) distinguishes
+        # an omitted field from an explicit set, so a schema-injected default would
+        # turn every sparse caller into a silent write.
+        vol.Optional(CONF_CONTROL_DEHUMIDIFIER): bool,
         vol.Optional(CONF_DEHUMIDIFIER_THRESHOLDS): dict,
-        vol.Optional(CONF_CONTROL_HUMIDIFIER, default=False): bool,
+        vol.Optional(CONF_CONTROL_HUMIDIFIER): bool,
         vol.Optional(CONF_HUMIDIFIER_THRESHOLDS): dict,
-        vol.Optional(CONF_STRESS_THRESHOLD, default=0.70): vol.All(
+        vol.Optional(CONF_STRESS_THRESHOLD): vol.All(
             vol.Coerce(float), vol.Range(min=0.0, max=1.0)
         ),
-        vol.Optional(CONF_MOLD_THRESHOLD, default=0.75): vol.All(
+        vol.Optional(CONF_MOLD_THRESHOLD): vol.All(
             vol.Coerce(float), vol.Range(min=0.0, max=1.0)
         ),
         # Multi-device support — basic sensors

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -13,6 +13,19 @@ from custom_components.growspace_manager.const import (
 from custom_components.growspace_manager.schemas import CONFIGURE_ENVIRONMENT_SCHEMA
 
 
+def test_configure_environment_schema_injects_no_defaults() -> None:
+    """No optional key may carry a default (ADR-0026 patch semantics).
+
+    The patch seam reads presence as intent, so any ``default=`` on this schema
+    turns every sparse caller into a silent write of that field. Asserting on
+    the validated payload rather than voluptuous' markers catches a default on
+    any future key, not just today's.
+    """
+    assert set(CONFIGURE_ENVIRONMENT_SCHEMA({"growspace_id": "gs1"})) == {
+        "growspace_id"
+    }
+
+
 def test_configure_environment_schema_supports_multi_entities() -> None:
     """Test that CONFIGURE_ENVIRONMENT_SCHEMA accepts multi-entity selection lists."""
 

--- a/tests/core/test_services_environment.py
+++ b/tests/core/test_services_environment.py
@@ -3,13 +3,17 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import voluptuous as vol
 
 from custom_components.growspace_manager.const import (
     CONF_BULK_EC_SENSORS,
+    CONF_CONTROL_DEHUMIDIFIER,
     CONF_CONTROL_HUMIDIFIER,
     CONF_DEHUMIDIFIER_THRESHOLDS,
     CONF_HUMIDITY_SENSOR,
+    CONF_MOLD_THRESHOLD,
     CONF_PORE_EC_SENSORS,
+    CONF_STRESS_THRESHOLD,
     CONF_TEMP_SENSOR,
 )
 from custom_components.growspace_manager.models import (
@@ -1182,6 +1186,93 @@ async def test_schema_validated_payload_omitting_bundles_preserves(
     await handle_configure_environment(mock_hass, mock_coordinator, mock_call)
 
     assert mock_gs.environment_config.humidifier_ac_infinity_devices == [existing]
+
+
+# Scalar keys that used to carry a schema default, and so were written on every
+# sparse call. Stored values are deliberately off EnvironmentConfig's own
+# defaults, otherwise the preserve assertion would pass even with the defaults
+# back in place.
+_SCALAR_OMISSION_FIELDS = [
+    pytest.param(CONF_CONTROL_DEHUMIDIFIER, True, False, id="control_dehumidifier"),
+    pytest.param(CONF_CONTROL_HUMIDIFIER, True, False, id="control_humidifier"),
+    pytest.param(CONF_STRESS_THRESHOLD, 0.42, 0.9, id="stress_threshold"),
+    pytest.param(CONF_MOLD_THRESHOLD, 0.55, 0.95, id="mold_threshold"),
+]
+
+
+def _seeded_growspace(mock_coordinator, field: str, stored: bool | float) -> MagicMock:
+    """Register a growspace whose environment config holds ``stored`` in ``field``."""
+    mock_gs = MagicMock()
+    mock_gs.name = "Test GS"
+    mock_gs.environment_config = EnvironmentConfig(**{field: stored})
+    mock_coordinator.growspaces = {"gs1": mock_gs}
+    return mock_gs
+
+
+@pytest.mark.parametrize(("field", "stored", "sent"), _SCALAR_OMISSION_FIELDS)
+@pytest.mark.asyncio
+async def test_schema_validated_payload_omitting_scalar_preserves(
+    mock_hass,
+    mock_coordinator,
+    mock_call,
+    field: str,
+    stored: bool | float,
+    sent: bool | float,
+) -> None:
+    """Regression guard: the schema must not inject defaults for scalar keys.
+
+    These four keys carried ``default=`` until issue #586, so a caller editing
+    only a sensor silently reset the grower's control toggles and Bayesian
+    thresholds. The assertion runs the real boundary — schema validation, then
+    patch construction and application — because a builder-only test cannot see
+    a key the schema invented.
+    """
+    mock_gs = _seeded_growspace(mock_coordinator, field, stored)
+
+    validated = CONFIGURE_ENVIRONMENT_SCHEMA(
+        {"growspace_id": "gs1", CONF_TEMP_SENSOR: "sensor.temp"}
+    )
+    assert field not in validated
+    mock_call.data = validated
+
+    await handle_configure_environment(mock_hass, mock_coordinator, mock_call)
+
+    assert getattr(mock_gs.environment_config, field) == stored
+
+
+@pytest.mark.parametrize(("field", "stored", "sent"), _SCALAR_OMISSION_FIELDS)
+@pytest.mark.asyncio
+async def test_schema_validated_payload_applies_explicit_scalar(
+    mock_hass,
+    mock_coordinator,
+    mock_call,
+    field: str,
+    stored: bool | float,
+    sent: bool | float,
+) -> None:
+    """An explicitly sent value still validates and reaches the stored config."""
+    mock_gs = _seeded_growspace(mock_coordinator, field, stored)
+
+    mock_call.data = CONFIGURE_ENVIRONMENT_SCHEMA({"growspace_id": "gs1", field: sent})
+
+    await handle_configure_environment(mock_hass, mock_coordinator, mock_call)
+
+    assert getattr(mock_gs.environment_config, field) == sent
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid"),
+    [
+        pytest.param(CONF_STRESS_THRESHOLD, 1.5, id="stress_threshold"),
+        pytest.param(CONF_MOLD_THRESHOLD, -0.1, id="mold_threshold"),
+    ],
+)
+def test_threshold_range_validation_survives_default_removal(
+    field: str, invalid: float
+) -> None:
+    """Dropping the defaults must not drop the 0.0-1.0 range check with them."""
+    with pytest.raises(vol.Invalid):
+        CONFIGURE_ENVIRONMENT_SCHEMA({"growspace_id": "gs1", field: invalid})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #586

## What

`CONFIGURE_ENVIRONMENT_SCHEMA` injected defaults for `control_humidifier`, `control_dehumidifier`, `stress_threshold` and `mold_threshold`. A sparse `configure_environment` call therefore reached the patch builder carrying keys the caller never sent, and the builder cannot distinguish that from a deliberate set — so editing one sensor silently reset the grower's control toggles and Bayesian thresholds. That is exactly the write-on-omit the patch contract (ADR-0026) exists to prevent.

This drops the four `default=`s. Range validation on the two thresholds is unchanged, and `EnvironmentConfig`'s own field defaults (0.70 / 0.75 / False) still apply to a fresh config, so nothing user-visible changes for a new growspace.

## Tests

- `tests/core/test_services_environment.py` — parametrized over the four fields, running the real boundary (schema validation → patch construction → application) with stored values deliberately off the model defaults. A builder-only test cannot observe a key the schema invented. Both directions are covered: omission preserves, explicit value applies.
- Range validation for the thresholds asserted directly, so removing the defaults cannot quietly take the bounds check with them.
- `tests/core/test_schemas.py` — a payload of only `growspace_id` must validate to only `growspace_id`. That guards every future optional key against acquiring write-on-omit semantics, not just today's four.

Verified the new tests fail against the pre-fix schema. Full suite: 5048 passed.

## Out of scope

`services.yaml` still carries `default:` for `stress_threshold` / `mold_threshold`. That is UI prefill for the developer-tools form, not validation — a user submitting a filled form *is* an explicit set. Changing the service UI is wider than this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sibling seams checked

`CONFIGURE_CIRCULATION_FAN_SCHEMA` and `CONFIGURE_EXHAUST_FAN_SCHEMA` write onto the same `EnvironmentConfig` through the same patch seam. Neither carries a `default=`, and their keys land on whole-replacement sub-configs (`circulation_fan_config` / `exhaust_fan_config`), where a default would be correct-by-design anyway. Same for `on_speed` / the sunrise entities on the AC-Infinity bundle schemas — those are item fields inside lists that are replaced wholesale when present. No sibling instance of this bug.

Note: this PR targets `prerelease`, not the default branch, so `Closes #586` will not auto-close — close it by hand on merge.
