### PR TITLE
Remove growspaces through the manager in the special-growspace repairs

### DIFF
--- a/custom_components/growspace_manager/managers/growspace.py
+++ b/custom_components/growspace_manager/managers/growspace.py
@@ -143,15 +143,24 @@ class GrowspaceManager(BaseService):
             async_fire_growspace_event(self.hass, EVENT_GROWSPACE_ADDED, growspace)
             return growspace
 
-    async def remove_growspace(self, growspace_id: str) -> None:
-        """Remove a growspace and all plants contained within it."""
+    async def remove_growspace(
+        self, growspace_id: str, *, delete_plants: bool = True
+    ) -> None:
+        """Remove a growspace and all plants contained within it.
+
+        `delete_plants=False` leaves the contained plants in the plant store,
+        still referencing the removed growspace. Only the special-growspace
+        reset uses it: it removes and recreates the canonical growspace, then
+        re-places the detached plants on it through the plant manager.
+        """
         async with self._lock:
             self.validator.validate_growspace_exists(growspace_id)
 
-            # Remove all plants in this growspace
-            plants_to_remove = [
-                p.plant_id for p in self.repository.get_growspace_plants(growspace_id)
-            ]
+            plants_to_remove = (
+                [p.plant_id for p in self.repository.get_growspace_plants(growspace_id)]
+                if delete_plants
+                else []
+            )
 
             for plant_id in plants_to_remove:
                 self.repository.remove_plant(plant_id)

--- a/custom_components/growspace_manager/managers/subsystem.py
+++ b/custom_components/growspace_manager/managers/subsystem.py
@@ -138,6 +138,31 @@ class SubsystemManager:
             await controller.async_setup()
         self.environment_controllers[growspace_id] = controllers
 
+    def teardown_growspace_sub_coordinators(self, growspace_id: str) -> None:
+        """Cancel and drop the sub-coordinators of a single growspace.
+
+        A sub-coordinator holds the `Growspace` object it was built from, so
+        one left behind after its growspace is removed keeps driving actuators
+        from configuration that no longer exists.
+        """
+        if irrigation := self.irrigation_coordinators.pop(growspace_id, None):
+            try:
+                irrigation.async_cancel_listeners()
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.error("Error cancelling irrigation listeners: %s", err)
+
+        if tracker := self.light_cycle_trackers.pop(growspace_id, None):
+            try:
+                tracker.unload()
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.error("Error unloading light cycle tracker: %s", err)
+
+        for controller in self.environment_controllers.pop(growspace_id, []):
+            try:
+                controller.unload()
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.error("Error unloading environment controller: %s", err)
+
     def get_dehumidifier_controller(self, growspace_id: str) -> DehumidifierCoordinator | None:
         """Return the dehumidifier coordinator for a growspace, or None."""
         for c in self.environment_controllers.get(growspace_id, []):

--- a/custom_components/growspace_manager/services/debug.py
+++ b/custom_components/growspace_manager/services/debug.py
@@ -139,9 +139,10 @@ async def _reset_special_growspace(
     canonical = coordinator.services.growspaces.ensure_special_growspace(
         canonical_id, canonical_id
     )
-    # Removing the growspace took its device with it, and recreating the
-    # canonical does not register one.
+    # Removing the growspace took its device and sub-coordinators with it, and
+    # recreating the canonical restores neither.
     await coordinator.async_register_devices()
+    await coordinator.services.growspaces.setup_sub_coordinators(canonical)
     await coordinator.services.growspaces.carry_forward_layout_revision(
         canonical, previous_revision
     )

--- a/custom_components/growspace_manager/services/debug.py
+++ b/custom_components/growspace_manager/services/debug.py
@@ -129,12 +129,19 @@ async def _reset_special_growspace(
     )
 
     for gs_id in ids_to_remove:
-        coordinator.growspaces.pop(gs_id, None)
+        # Preserved plants are detached rather than deleted, and re-placed on
+        # the recreated canonical growspace below.
+        await coordinator.services.growspaces.remove_growspace(
+            gs_id, delete_plants=not preserve_plants
+        )
         _LOGGER.debug("Removed %s growspace %s", canonical_id, gs_id)
 
     canonical = coordinator.services.growspaces.ensure_special_growspace(
         canonical_id, canonical_id
     )
+    # Removing the growspace took its device with it, and recreating the
+    # canonical does not register one.
+    await coordinator.async_register_devices()
     await coordinator.services.growspaces.carry_forward_layout_revision(
         canonical, previous_revision
     )
@@ -301,7 +308,20 @@ async def _consolidate_plants_to_canonical_growspace(
         )
 
     for dup_id in duplicate_ids:
-        coordinator.growspaces.pop(dup_id, None)
+        # Relocation skips a plant the canonical has no room for. Removing the
+        # duplicate would delete it, so a duplicate that still holds plants is
+        # left in place for the next run instead.
+        if remaining := coordinator.services.growspaces.get_growspace_plants(dup_id):
+            _LOGGER.warning(
+                "Keeping duplicate %s growspace %s: %d plant(s) could not be "
+                "relocated to %s",
+                log_prefix,
+                dup_id,
+                len(remaining),
+                canonical_id,
+            )
+            continue
+        await coordinator.services.growspaces.remove_growspace(dup_id)
         _LOGGER.debug("Removed duplicate %s growspace %s", log_prefix, dup_id)
 
 

--- a/custom_components/growspace_manager/services/growspace_facade.py
+++ b/custom_components/growspace_manager/services/growspace_facade.py
@@ -147,6 +147,19 @@ class GrowspaceFacade:
         await self._coordinator._growspace_manager.remove_growspace(
             growspace_id, delete_plants=delete_plants
         )
+        # Mirrors add_growspace, which sets these up.
+        self._coordinator._subsystem_manager.teardown_growspace_sub_coordinators(
+            growspace_id
+        )
+
+    async def setup_sub_coordinators(self, growspace_id: str) -> None:
+        """Set up the sub-coordinators of an existing growspace."""
+        growspace = self._coordinator._data_repository.require_growspace(growspace_id)
+        await (
+            self._coordinator._subsystem_manager.async_setup_growspace_sub_coordinators(
+                growspace_id, growspace
+            )
+        )
 
     def ensure_special_growspace(self, *args: Any, **kwargs: Any) -> Any:
         """Ensure a special growspace exists; delegates to GrowspaceManager."""

--- a/custom_components/growspace_manager/services/growspace_facade.py
+++ b/custom_components/growspace_manager/services/growspace_facade.py
@@ -140,9 +140,13 @@ class GrowspaceFacade:
         _LOGGER.info("Updated growspace %s", growspace_id)
         return growspace
 
-    async def remove_growspace(self, growspace_id: str) -> None:
-        """Remove a growspace."""
-        await self._coordinator._growspace_manager.remove_growspace(growspace_id)
+    async def remove_growspace(
+        self, growspace_id: str, *, delete_plants: bool = True
+    ) -> None:
+        """Remove a growspace, optionally detaching its plants instead."""
+        await self._coordinator._growspace_manager.remove_growspace(
+            growspace_id, delete_plants=delete_plants
+        )
 
     def ensure_special_growspace(self, *args: Any, **kwargs: Any) -> Any:
         """Ensure a special growspace exists; delegates to GrowspaceManager."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -88,6 +88,7 @@ def mock_coordinator():
 
     coordinator._growspace_manager.add_growspace = AsyncMock(side_effect=_mock_add_gs)
     coordinator._growspace_manager.update_growspace = AsyncMock()
+    coordinator._growspace_manager.remove_growspace = AsyncMock()
     coordinator._growspace_manager.ensure_special_growspace = MagicMock(
         return_value="special_gs"
     )
@@ -103,6 +104,7 @@ def mock_coordinator():
     coordinator.async_commit = AsyncMock()
     coordinator.async_load = AsyncMock()
     coordinator.async_refresh = AsyncMock()
+    coordinator.async_register_devices = AsyncMock()
     coordinator.async_request_refresh = AsyncMock()
     coordinator.async_transition_plant_stage = AsyncMock()
     coordinator.async_update_environment_config = AsyncMock()

--- a/tests/integration/test_debug_repair_removal.py
+++ b/tests/integration/test_debug_repair_removal.py
@@ -117,6 +117,33 @@ async def test_reset_restores_default_dimensions(
     assert canonical.plants_per_row == DEFAULT_PLANTS_PER_ROW
 
 
+async def test_reset_re_places_a_plant_the_default_grid_no_longer_fits(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    strain_library: MagicMock,
+) -> None:
+    """Shrinking back to the default grid moves a stranded plant, not deletes it."""
+    coordinator = init_integration.runtime_data
+    await coordinator.services.growspaces.update_growspace(
+        CANONICAL_DRY, rows=DEFAULT_ROWS + 2, plants_per_row=DEFAULT_PLANTS_PER_ROW + 2
+    )
+    plant = await coordinator.services.plants.add_plant(
+        growspace_id=CANONICAL_DRY,
+        strain="OG Kush",
+        row=DEFAULT_ROWS + 2,
+        col=DEFAULT_PLANTS_PER_ROW + 2,
+    )
+
+    await handle_debug_reset_special_growspaces(
+        hass, coordinator, strain_library, _reset_call()
+    )
+
+    relocated = coordinator.plants[plant.plant_id]
+    assert relocated.growspace_id == CANONICAL_DRY
+    assert 1 <= relocated.row <= DEFAULT_ROWS
+    assert 1 <= relocated.col <= DEFAULT_PLANTS_PER_ROW
+
+
 async def test_reset_removes_the_duplicates_it_folded_in(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,

--- a/tests/integration/test_debug_repair_removal.py
+++ b/tests/integration/test_debug_repair_removal.py
@@ -1,0 +1,194 @@
+"""Removal behaviour of the special-growspace repair services.
+
+Every assertion here runs against a live coordinator: `coordinator.growspaces`
+is a snapshot rebuilt on each access, so a repair that mutates it removes
+nothing from the store and only a real coordinator exposes that.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.growspace_manager.const import (
+    DEFAULT_PLANTS_PER_ROW,
+    DEFAULT_ROWS,
+    DOMAIN,
+)
+from custom_components.growspace_manager.services.debug import (
+    handle_debug_consolidate_duplicate_special,
+    handle_debug_reset_special_growspaces,
+)
+from custom_components.growspace_manager.strain_library import StrainLibrary
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import device_registry as dr
+from tests.common import MockConfigEntry
+
+CANONICAL_DRY = "dry"
+
+
+@pytest.fixture
+def strain_library() -> MagicMock:
+    """Return the strain library argument every debug handler ignores."""
+    return MagicMock(spec=StrainLibrary)
+
+
+def _service_call(**data: object) -> ServiceCall:
+    """Return a service call carrying the given data."""
+    call = MagicMock(spec=ServiceCall)
+    call.data = data
+    return call
+
+
+def _reset_call(*, preserve_plants: bool = True) -> ServiceCall:
+    """Return a reset call that touches only the dry growspace."""
+    return _service_call(
+        reset_dry=True, reset_cure=False, preserve_plants=preserve_plants
+    )
+
+
+async def test_consolidation_removes_every_duplicate(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    strain_library: MagicMock,
+) -> None:
+    """Every emptied duplicate is gone from the store, not just from a snapshot."""
+    coordinator = init_integration.runtime_data
+    first = await coordinator.services.growspaces.add_growspace(name="dry")
+    second = await coordinator.services.growspaces.add_growspace(name="dry")
+    plant = await coordinator.services.plants.add_plant(
+        growspace_id=first.id, strain="OG Kush"
+    )
+
+    await handle_debug_consolidate_duplicate_special(
+        hass, coordinator, strain_library, _service_call()
+    )
+
+    assert first.id not in coordinator.growspaces
+    assert second.id not in coordinator.growspaces
+    assert CANONICAL_DRY in coordinator.growspaces
+    assert coordinator.plants[plant.plant_id].growspace_id == CANONICAL_DRY
+
+
+async def test_consolidation_keeps_a_duplicate_it_could_not_empty(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    strain_library: MagicMock,
+) -> None:
+    """A plant with nowhere to go keeps its duplicate alive instead of dying with it."""
+    coordinator = init_integration.runtime_data
+    await coordinator.services.growspaces.update_growspace(
+        CANONICAL_DRY, rows=1, plants_per_row=1
+    )
+    await coordinator.services.plants.add_plant(
+        growspace_id=CANONICAL_DRY, strain="OG Kush"
+    )
+    duplicate = await coordinator.services.growspaces.add_growspace(name="dry")
+    stranded = await coordinator.services.plants.add_plant(
+        growspace_id=duplicate.id, strain="Blue Dream"
+    )
+
+    await handle_debug_consolidate_duplicate_special(
+        hass, coordinator, strain_library, _service_call()
+    )
+
+    assert duplicate.id in coordinator.growspaces
+    assert coordinator.plants[stranded.plant_id].growspace_id == duplicate.id
+
+
+async def test_reset_restores_default_dimensions(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    strain_library: MagicMock,
+) -> None:
+    """The reset recreates the canonical growspace, so its defaults come back."""
+    coordinator = init_integration.runtime_data
+    await coordinator.services.growspaces.update_growspace(
+        CANONICAL_DRY, rows=DEFAULT_ROWS + 2, plants_per_row=DEFAULT_PLANTS_PER_ROW + 2
+    )
+
+    await handle_debug_reset_special_growspaces(
+        hass, coordinator, strain_library, _reset_call()
+    )
+
+    canonical = coordinator.growspaces[CANONICAL_DRY]
+    assert canonical.rows == DEFAULT_ROWS
+    assert canonical.plants_per_row == DEFAULT_PLANTS_PER_ROW
+
+
+async def test_reset_removes_the_duplicates_it_folded_in(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    strain_library: MagicMock,
+) -> None:
+    """Overview duplicates are removed and their plants land on the canonical."""
+    coordinator = init_integration.runtime_data
+    # `<canonical>_overview_*` is the legacy id shape the reset folds in; ids
+    # minted by `add_growspace` are UUIDs and never match it.
+    duplicate_id = coordinator.services.growspaces.ensure_special_growspace(
+        f"{CANONICAL_DRY}_overview_1", "dry overview 1"
+    )
+    plant = await coordinator.services.plants.add_plant(
+        growspace_id=duplicate_id, strain="OG Kush"
+    )
+
+    await handle_debug_reset_special_growspaces(
+        hass, coordinator, strain_library, _reset_call()
+    )
+
+    assert duplicate_id not in coordinator.growspaces
+    assert coordinator.plants[plant.plant_id].growspace_id == CANONICAL_DRY
+
+
+async def test_reset_preserving_plants_deletes_none_of_them(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    strain_library: MagicMock,
+) -> None:
+    """`preserve_plants: true` keeps every plant, on the recreated canonical."""
+    coordinator = init_integration.runtime_data
+    plant = await coordinator.services.plants.add_plant(
+        growspace_id=CANONICAL_DRY, strain="OG Kush"
+    )
+
+    await handle_debug_reset_special_growspaces(
+        hass, coordinator, strain_library, _reset_call()
+    )
+
+    assert plant.plant_id in coordinator.plants
+    assert coordinator.plants[plant.plant_id].growspace_id == CANONICAL_DRY
+
+
+async def test_reset_without_preserving_plants_deletes_them(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    strain_library: MagicMock,
+) -> None:
+    """`preserve_plants: false` now removes the plants along with the growspace."""
+    coordinator = init_integration.runtime_data
+    plant = await coordinator.services.plants.add_plant(
+        growspace_id=CANONICAL_DRY, strain="OG Kush"
+    )
+
+    await handle_debug_reset_special_growspaces(
+        hass, coordinator, strain_library, _reset_call(preserve_plants=False)
+    )
+
+    assert plant.plant_id not in coordinator.plants
+
+
+async def test_reset_leaves_the_canonical_growspace_a_device(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    strain_library: MagicMock,
+) -> None:
+    """Removing the canonical takes its device; the reset registers it again."""
+    coordinator = init_integration.runtime_data
+
+    await handle_debug_reset_special_growspaces(
+        hass, coordinator, strain_library, _reset_call()
+    )
+
+    device_registry = dr.async_get(hass)
+    assert device_registry.async_get_device(identifiers={(DOMAIN, CANONICAL_DRY)})

--- a/tests/integration/test_debug_services.py
+++ b/tests/integration/test_debug_services.py
@@ -295,12 +295,7 @@ async def test_handle_reset_dry_growspace_preserve_plants_no_plants(
     """Test _handle_reset_dry_growspace when preserve_plants is true but no plants are found."""
     preserve_plants = True
 
-    mock_coordinator.growspaces = MagicMock(spec=dict)
-    mock_coordinator.growspaces.keys.return_value = ["dry"]
-    mock_coordinator.growspaces.__contains__.side_effect = lambda x: x == "dry"
-    mock_coordinator.growspaces.__getitem__.side_effect = lambda x: MagicMock(
-        name="Dry", layout_revision=0
-    )
+    mock_coordinator.growspaces = {"dry": MagicMock(layout_revision=0)}
 
     mock_coordinator.services.growspaces.get_growspace_plants = MagicMock(
         return_value=[]
@@ -309,11 +304,12 @@ async def test_handle_reset_dry_growspace_preserve_plants_no_plants(
     mock_coordinator._growspace_manager.ensure_special_growspace = MagicMock(
         return_value="dry"
     )
-    # mock_coordinator.growspaces.pop is already a MagicMock from the fixture
 
     await _handle_reset_dry_growspace(mock_hass, mock_coordinator, preserve_plants)
 
-    mock_coordinator.growspaces.pop.assert_called_once_with("dry", None)
+    mock_coordinator._growspace_manager.remove_growspace.assert_awaited_once_with(
+        "dry", delete_plants=False
+    )
     mock_coordinator._growspace_manager.ensure_special_growspace.assert_called_once_with(
         "dry", "dry"
     )
@@ -332,18 +328,10 @@ async def test_handle_reset_dry_growspace_preserve_plants_with_plants(
     """Test _handle_reset_dry_growspace when preserve_plants is true and plants are found."""
     preserve_plants = True
 
-    mock_coordinator.growspaces = MagicMock(spec=dict)
-    mock_coordinator.growspaces.keys.return_value = ["dry", "dry_overview_1"]
-    mock_coordinator.growspaces.__contains__.side_effect = lambda x: (
-        x
-        in [
-            "dry",
-            "dry_overview_1",
-        ]
-    )
-    mock_coordinator.growspaces.__getitem__.side_effect = lambda x: MagicMock(
-        name="Dry", layout_revision=0
-    )
+    mock_coordinator.growspaces = {
+        "dry": MagicMock(layout_revision=0),
+        "dry_overview_1": MagicMock(layout_revision=0),
+    }
 
     # Configure mock_coordinator.services.growspaces.get_growspace_plants to return mock plants
     mock_plant_1 = MagicMock(
@@ -376,10 +364,11 @@ async def test_handle_reset_dry_growspace_preserve_plants_with_plants(
     ) as mock_restore:
         await _handle_reset_dry_growspace(mock_hass, mock_coordinator, preserve_plants)
 
-        # Assert that growspaces were popped
-        mock_coordinator.growspaces.pop.assert_any_call("dry", None)
-        mock_coordinator.growspaces.pop.assert_any_call("dry_overview_1", None)
-        assert mock_coordinator.growspaces.pop.call_count == 2
+        # Assert that both growspaces were removed through the manager seam
+        remove = mock_coordinator._growspace_manager.remove_growspace
+        remove.assert_any_await("dry", delete_plants=False)
+        remove.assert_any_await("dry_overview_1", delete_plants=False)
+        assert remove.await_count == 2
 
         # Assert that ensure_special_growspace was called
         mock_coordinator._growspace_manager.ensure_special_growspace.assert_called_once_with(
@@ -403,12 +392,7 @@ async def test_handle_reset_cure_growspace_preserve_plants_no_plants(
     """Test _handle_reset_cure_growspace when preserve_plants is true but no plants are found."""
     preserve_plants = True
 
-    mock_coordinator.growspaces = MagicMock(spec=dict)
-    mock_coordinator.growspaces.keys.return_value = ["cure"]
-    mock_coordinator.growspaces.__contains__.side_effect = lambda x: x == "cure"
-    mock_coordinator.growspaces.__getitem__.side_effect = lambda x: MagicMock(
-        name="Cure", layout_revision=0
-    )
+    mock_coordinator.growspaces = {"cure": MagicMock(layout_revision=0)}
 
     mock_coordinator.services.growspaces.get_growspace_plants = MagicMock(
         return_value=[]
@@ -417,11 +401,12 @@ async def test_handle_reset_cure_growspace_preserve_plants_no_plants(
     mock_coordinator._growspace_manager.ensure_special_growspace = MagicMock(
         return_value="cure"
     )
-    # mock_coordinator.growspaces.pop is already a MagicMock from the fixture
 
     await _handle_reset_cure_growspace(mock_hass, mock_coordinator, preserve_plants)
 
-    mock_coordinator.growspaces.pop.assert_called_once_with("cure", None)
+    mock_coordinator._growspace_manager.remove_growspace.assert_awaited_once_with(
+        "cure", delete_plants=False
+    )
     mock_coordinator._growspace_manager.ensure_special_growspace.assert_called_once_with(
         "cure", "cure"
     )
@@ -440,18 +425,10 @@ async def test_handle_reset_cure_growspace_preserve_plants_with_plants(
     """Test _handle_reset_cure_growspace when preserve_plants is true and plants are found."""
     preserve_plants = True
 
-    mock_coordinator.growspaces = MagicMock(spec=dict)
-    mock_coordinator.growspaces.keys.return_value = ["cure", "cure_overview_1"]
-    mock_coordinator.growspaces.__contains__.side_effect = lambda x: (
-        x
-        in [
-            "cure",
-            "cure_overview_1",
-        ]
-    )
-    mock_coordinator.growspaces.__getitem__.side_effect = lambda x: MagicMock(
-        name="Cure", layout_revision=0
-    )
+    mock_coordinator.growspaces = {
+        "cure": MagicMock(layout_revision=0),
+        "cure_overview_1": MagicMock(layout_revision=0),
+    }
 
     # Configure mock_coordinator.services.growspaces.get_growspace_plants to return mock plants
     mock_plant_1 = MagicMock(
@@ -484,10 +461,11 @@ async def test_handle_reset_cure_growspace_preserve_plants_with_plants(
     ) as mock_restore:
         await _handle_reset_cure_growspace(mock_hass, mock_coordinator, preserve_plants)
 
-        # Assert that growspaces were popped
-        mock_coordinator.growspaces.pop.assert_any_call("cure", None)
-        mock_coordinator.growspaces.pop.assert_any_call("cure_overview_1", None)
-        assert mock_coordinator.growspaces.pop.call_count == 2
+        # Assert that both growspaces were removed through the manager seam
+        remove = mock_coordinator._growspace_manager.remove_growspace
+        remove.assert_any_await("cure", delete_plants=False)
+        remove.assert_any_await("cure_overview_1", delete_plants=False)
+        assert remove.await_count == 2
 
         # Assert that ensure_special_growspace was called
         mock_coordinator._growspace_manager.ensure_special_growspace.assert_called_once_with(
@@ -513,11 +491,9 @@ async def test_consolidate_plants_to_canonical_growspace_plant_not_in_coordinato
     canonical_id = "dry"
     log_prefix = "dry"
 
-    mock_coordinator.growspaces = MagicMock(spec=dict)
-    mock_coordinator.growspaces.keys.return_value = ["dry_1"]
-    mock_coordinator.growspaces.__contains__.side_effect = lambda x: x == "dry_1"
-    mock_coordinator.growspaces.__getitem__.side_effect = lambda x: MagicMock(
-        name="Dry", layout_revision=0
+    mock_coordinator.growspaces = {"dry_1": MagicMock(layout_revision=0)}
+    mock_coordinator.services.growspaces.get_growspace_plants = MagicMock(
+        return_value=[]
     )
 
     with patch(
@@ -527,9 +503,10 @@ async def test_consolidate_plants_to_canonical_growspace_plant_not_in_coordinato
             mock_coordinator, duplicate_ids, canonical_id, log_prefix
         )
         mock_warning.assert_not_called()  # No warning expected here
-        mock_coordinator.growspaces.pop.assert_called_once_with(
-            "dry_1", None
-        )  # Should still remove duplicate
+        # The empty duplicate is still removed
+        mock_coordinator._growspace_manager.remove_growspace.assert_awaited_once_with(
+            "dry_1", delete_plants=True
+        )
 
 
 @pytest.mark.asyncio
@@ -621,8 +598,10 @@ async def test_consolidate_routes_through_the_plant_manager(
     mock_plant = MagicMock(spec=Plant, plant_id="p1", growspace_id="dry_1")
     mock_coordinator.plants = {"p1": mock_plant}
     mock_coordinator.growspaces = {"dry_1": MagicMock(layout_revision=1)}
+    # The duplicate holds the plant when it is collected, and is empty once the
+    # relocation has moved it to the canonical growspace.
     mock_coordinator.services.growspaces.get_growspace_plants = MagicMock(
-        return_value=[mock_plant]
+        side_effect=[[mock_plant], []]
     )
 
     await _consolidate_plants_to_canonical_growspace(
@@ -632,4 +611,26 @@ async def test_consolidate_routes_through_the_plant_manager(
     mock_coordinator._plant_manager.relocate_plants_to_growspace.assert_awaited_once_with(
         "dry", ["p1"]
     )
-    assert "dry_1" not in mock_coordinator.growspaces
+    mock_coordinator._growspace_manager.remove_growspace.assert_awaited_once_with(
+        "dry_1", delete_plants=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_consolidate_keeps_a_duplicate_whose_plants_did_not_fit(
+    mock_coordinator,
+) -> None:
+    """A duplicate the relocation could not empty survives instead of losing plants."""
+    mock_plant = MagicMock(spec=Plant, plant_id="p1", growspace_id="dry_1")
+    mock_coordinator.plants = {"p1": mock_plant}
+    mock_coordinator.growspaces = {"dry_1": MagicMock(layout_revision=1)}
+    # The canonical growspace had no free cell, so the plant stayed put.
+    mock_coordinator.services.growspaces.get_growspace_plants = MagicMock(
+        return_value=[mock_plant]
+    )
+
+    await _consolidate_plants_to_canonical_growspace(
+        mock_coordinator, ["dry_1"], "dry", "dry"
+    )
+
+    mock_coordinator._growspace_manager.remove_growspace.assert_not_awaited()

--- a/tests/integration/test_facade_coverage.py
+++ b/tests/integration/test_facade_coverage.py
@@ -143,7 +143,9 @@ async def test_growspace_lifecycle_services(mock_coordinator) -> None:
     mock_coordinator.growspaces = {"gs1": gs}
 
     await facade.growspaces.remove_growspace("gs1")
-    mock_coordinator._growspace_manager.remove_growspace.assert_called_once_with("gs1")
+    mock_coordinator._growspace_manager.remove_growspace.assert_called_once_with(
+        "gs1", delete_plants=True
+    )
 
     await facade.growspaces.update_options({"opt": "val"})
     mock_coordinator.async_commit.assert_called()

--- a/tests/services/test_debug_coverage.py
+++ b/tests/services/test_debug_coverage.py
@@ -66,5 +66,5 @@ async def test_consolidate_plants_no_space(mock_coordinator) -> None:
     )
     assert mock_plant.growspace_id == "dry_1"
 
-    # Verify duplicate growspace was still removed (as per logic)
-    assert "dry_1" not in mock_coordinator.growspaces
+    # The plant had nowhere to go, so removing the duplicate would delete it.
+    mock_coordinator._growspace_manager.remove_growspace.assert_not_called()


### PR DESCRIPTION
Closes #594.

## What was wrong

`GrowspaceCoordinator.growspaces` rebuilds a fresh dict on every access, so the `coordinator.growspaces.pop(...)` calls in both repair services in `services/debug.py` mutated a throwaway snapshot and removed nothing from the store. The mock-based tests hid it because their `coordinator.growspaces` was a real dict.

## What changed

Both repairs now remove through `GrowspaceManager.remove_growspace`.

- **`remove_growspace` gains a `delete_plants` keyword** (default `True`, so every existing caller is unchanged). The reset uses `delete_plants=False` to detach the plants it preserves, remove and recreate the canonical growspace, and re-place them through `relocate_plants_to_growspace` — the same plant-manager seam #590 introduced.
- **Consolidation only removes a duplicate the relocation actually emptied.** The issue assumed duplicates are always empty by then; they are not — `relocate_plants_to_growspace` skips a plant the canonical has no room for. Removing the duplicate would then cascade-delete it. Such a duplicate is now kept, with a warning, for the next run.
- **The reset re-registers devices and sub-coordinators** after recreating the canonical. `remove_growspace` removes the growspace's device and `ensure_special_growspace` creates neither a device nor sub-coordinators, so without this the reset would leave `dry`/`cure` inert until a restart. Second commit also makes `remove_growspace` tear its sub-coordinators down — they used to survive any removal, holding the detached `Growspace` and driving actuators from wiped configuration. Nothing triggered that for special growspaces before, because the snapshot mutation never removed one.

## The `preserve_plants: false` decision

**With `preserve_plants: false`, the plants are now deleted along with the growspace.** Previously they survived and kept referencing the recreated canonical id. Deleting them is what the flag says, and the destructive path is strictly opt-in — the service defaults to `preserve_plants: True`. Covered by `test_reset_without_preserving_plants_deletes_them`; the preserving path is covered by `test_reset_preserving_plants_deletes_none_of_them`.

## Tests

New `tests/integration/test_debug_repair_removal.py` runs every removal assertion against a live coordinator (`init_integration`), never a mock dict:

- duplicates are gone from the store after consolidation
- a duplicate whose plants did not fit survives, with its plants
- the reset restores `DEFAULT_ROWS` / `DEFAULT_PLANTS_PER_ROW`
- a plant stranded outside the restored default grid is re-placed inside it, not dropped
- `<canonical>_overview_*` duplicates are folded in and removed
- `preserve_plants` true keeps every plant, false deletes them
- the canonical growspace still has a device afterwards

The mock-based tests in `test_debug_services.py` that asserted on `growspaces.pop` now assert on the `remove_growspace` seam instead.

Full suite: 5085 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)