### PR TITLE
Fix empty snapshot response shape

### DIFF
--- a/custom_components/growspace_manager/websocket/vision.py
+++ b/custom_components/growspace_manager/websocket/vision.py
@@ -132,7 +132,7 @@ async def websocket_get_snapshots(
     )
 
     if not snapshot_dir.exists():
-        return {"snapshots": [], "total": 0}
+        return {"growspace_id": growspace_id, "snapshots": [], "total": 0}
 
     all_files = sorted(
         snapshot_dir.glob("*.jpg"),

--- a/tests/integration/test_websocket_camera_coverage.py
+++ b/tests/integration/test_websocket_camera_coverage.py
@@ -161,7 +161,7 @@ async def test_get_snapshots_directory_not_exists(
     with patch.object(hass.config, "path", return_value=str(tmp_path)):
         result = await websocket_get_snapshots(hass, MagicMock(), msg)
 
-    assert result == {"snapshots": [], "total": 0}
+    assert result == {"growspace_id": "gs_no_dir", "snapshots": [], "total": 0}
 
 
 async def test_get_snapshots_with_files(


### PR DESCRIPTION
## Summary

- Include `growspace_id` when `get_snapshots` returns an empty directory.
- Update the regression test to enforce the response contract.

## Root cause

The empty-directory branch returned `{snapshots, total}` while the card validates `growspace_id` as a required string. This caused the snapshots dialog to report a response schema mismatch.

## Validation

- `uv run --no-sync pytest tests/core/test_services_strain_library.py tests/integration/test_strain_library_services.py tests/integration/test_websocket_camera_coverage.py -q` (55 passed)
- Repository pre-commit checks passed except the existing mypy duplicate-module error for `homeassistant/util/event_type.py` and `event_type.pyi`.