### PR TITLE
fix(environment): restart the humidifier/dehumidifier coordinator on control-flag change

### DIFF
--- a/custom_components/growspace_manager/domain/environment_patch.py
+++ b/custom_components/growspace_manager/domain/environment_patch.py
@@ -105,6 +105,26 @@ _DICT_FIELDS = {
 } | {"dehumidifier_thresholds", "bayesian_options"}
 
 _CONTROLLER_RELEVANT_FIELDS: dict[str, frozenset[str]] = {
+    "dehumidifier": frozenset(
+        {
+            "control_dehumidifier",
+            "dehumidifier_entities",
+            "dehumidifier_ac_infinity_devices",
+            "dehumidifier_thresholds",
+            "vpd_sensor",
+            "light_sensors",
+        }
+    ),
+    "humidifier": frozenset(
+        {
+            "control_humidifier",
+            "humidifier_entities",
+            "humidifier_ac_infinity_devices",
+            "humidifier_thresholds",
+            "vpd_sensor",
+            "light_sensors",
+        }
+    ),
     "circulation_fan": frozenset(
         {
             "circulation_fan_config",

--- a/custom_components/growspace_manager/services/environment_patch_commit.py
+++ b/custom_components/growspace_manager/services/environment_patch_commit.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 _CONTROLLER_ACCESSORS = {
+    "dehumidifier": "get_dehumidifier_controller",
+    "humidifier": "get_humidifier_controller",
     "circulation_fan": "get_circulation_fan_controller",
     "exhaust_fan": "get_exhaust_fan_controller",
     "growlight": "get_growlight_controller",

--- a/custom_components/growspace_manager/vpd_on_off_controller.py
+++ b/custom_components/growspace_manager/vpd_on_off_controller.py
@@ -75,16 +75,35 @@ class VpdOnOffController:
             )
             return
 
+        self.vpd_sensor: str | None = None
+        self.light_sensors: list[str] = []
+        self.control_enabled: bool = False
+        self.user_thresholds: dict[str, Any] = {}
+        self.device_config: dict[str, Any] = {}
+        self._load_config()
+
+    def _load_config(self) -> None:
+        """(Re)read the fields this controller caches from the live environment config.
+
+        Split out of ``__init__`` so ``async_restart`` can refresh them after a
+        config-dialog edit — the controller instance is long-lived (constructed
+        once at entry setup) and otherwise never notices later changes to its
+        control flag, thresholds, or sensors.
+        """
+        if not self.growspace:
+            return
         env = self.growspace.environment_config or {}
-        self.vpd_sensor: str | None = getattr(env, "vpd_sensor", None)
-        self.light_sensors: list[str] = getattr(env, "light_sensors", []) or []
-        self.control_enabled: bool = getattr(env, self._CONTROL_FLAG_ATTR, False)
-        self.user_thresholds: dict[str, Any] = (
-            getattr(env, self._THRESHOLDS_ATTR, {}) or {}
-        )
-        self.device_config: dict[str, Any] = (
-            getattr(self.growspace, self._DEVICE_CONFIG_ATTR, {}) or {}
-        )
+        self.vpd_sensor = getattr(env, "vpd_sensor", None)
+        self.light_sensors = getattr(env, "light_sensors", []) or []
+        self.control_enabled = getattr(env, self._CONTROL_FLAG_ATTR, False)
+        self.user_thresholds = getattr(env, self._THRESHOLDS_ATTR, {}) or {}
+        self.device_config = getattr(self.growspace, self._DEVICE_CONFIG_ATTR, {}) or {}
+
+    async def async_restart(self) -> None:
+        """Restart after a config change: reload cached config and rebind listeners."""
+        self.unload()
+        self._load_config()
+        await self.async_setup()
 
     def _get_all_controlled_entities(self) -> list[str]:
         """Return all entity IDs managed by this controller. Subclasses implement."""

--- a/tests/config/test_config_flow.py
+++ b/tests/config/test_config_flow.py
@@ -65,6 +65,8 @@ def mock_coordinator(hass: HomeAssistant, tmp_path: Path):
     coordinator._subsystem_manager.get_circulation_fan_controller.return_value = None
     coordinator._subsystem_manager.get_exhaust_fan_controller.return_value = None
     coordinator._subsystem_manager.get_growlight_controller.return_value = None
+    coordinator._subsystem_manager.get_dehumidifier_controller.return_value = None
+    coordinator._subsystem_manager.get_humidifier_controller.return_value = None
 
     # --- growspaces sub-facade ---
     gs_facade = MagicMock()

--- a/tests/config/test_dehumidifier_config_flow.py
+++ b/tests/config/test_dehumidifier_config_flow.py
@@ -57,6 +57,8 @@ async def test_configure_dehumidifier_thresholds(
     )
     mock_coordinator._subsystem_manager.get_exhaust_fan_controller.return_value = None
     mock_coordinator._subsystem_manager.get_growlight_controller.return_value = None
+    mock_coordinator._subsystem_manager.get_dehumidifier_controller.return_value = None
+    mock_coordinator._subsystem_manager.get_humidifier_controller.return_value = None
 
     entry.runtime_data = mock_coordinator
     entry.add_to_hass(hass)

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -110,6 +110,16 @@ def mock_coordinator():
     coordinator._subsystem_manager.get_exhaust_fan_controller = MagicMock(
         return_value=_exhaust_coord_mock
     )
+    _dehumidifier_coord_mock = MagicMock()
+    _dehumidifier_coord_mock.async_restart = AsyncMock()
+    coordinator._subsystem_manager.get_dehumidifier_controller = MagicMock(
+        return_value=_dehumidifier_coord_mock
+    )
+    _humidifier_coord_mock = MagicMock()
+    _humidifier_coord_mock.async_restart = AsyncMock()
+    coordinator._subsystem_manager.get_humidifier_controller = MagicMock(
+        return_value=_humidifier_coord_mock
+    )
 
     # Initialize ServiceFacade AFTER all async mocks are set so the facade's
     # internal _coordinator reference sees the correct AsyncMock attributes.

--- a/tests/domain/test_environment_patch.py
+++ b/tests/domain/test_environment_patch.py
@@ -521,6 +521,28 @@ def test_controllers_to_restart_mapping(
 
 
 @pytest.mark.parametrize(
+    ("values", "expected_controllers"),
+    [
+        ({"control_dehumidifier": True}, {"dehumidifier"}),
+        ({"control_humidifier": True}, {"humidifier"}),
+        ({"dehumidifier_entities": ["switch.dehum"]}, {"dehumidifier"}),
+        ({"humidifier_entities": ["switch.hum"]}, {"humidifier"}),
+    ],
+)
+def test_control_flag_flips_mark_the_matching_controller_for_restart(
+    values: dict[str, Any], expected_controllers: set[str]
+) -> None:
+    """set_dehumidifier_control / set_humidifier_control's lone-key patch (the
+    shape ``handle_set_dehumidifier_control`` / ``handle_set_humidifier_control``
+    build) must restart the coordinator it flips — otherwise the long-lived
+    controller instance never notices the flag changed and keeps controlling
+    (or not controlling) the device with whatever it read at HA startup.
+    """
+    verdict = apply_environment_patch(_lived_in_config(), EnvironmentPatch(values=values))
+    assert verdict.controllers_to_restart == frozenset(expected_controllers)
+
+
+@pytest.mark.parametrize(
     ("payload", "expected"),
     [
         ({"control_dehumidifier": True}, True),

--- a/tests/integration/test_dehumidifier_coordinator.py
+++ b/tests/integration/test_dehumidifier_coordinator.py
@@ -324,6 +324,33 @@ async def test_unload(coordinator) -> None:
     assert len(coordinator._remove_listeners) == 0
 
 
+async def test_async_restart_picks_up_a_control_flag_flipped_after_construction(
+    mock_hass, mock_main_coordinator, mock_growspace, mock_track_state_change_event
+) -> None:
+    """The coordinator is constructed once at HA startup and caches
+    ``control_enabled`` from that snapshot. Toggling the config-dialog checkbox
+    later mutates the same live ``growspace.environment_config`` object, but
+    without ``async_restart`` the coordinator never re-reads it, so it never
+    starts controlling the device — this pins that gap closed.
+    """
+    mock_growspace.environment_config.control_dehumidifier = False
+    mock_main_coordinator.growspaces = {"gs1": mock_growspace}
+    coord = DehumidifierCoordinator(
+        mock_hass, mock_track_state_change_event, "gs1", mock_main_coordinator
+    )
+    await coord.async_setup()
+    assert coord.control_enabled is False
+    assert len(coord._remove_listeners) == 0
+
+    # The equivalent of set_dehumidifier_control(enabled=True): the backend
+    # patch seam mutates the live environment_config in place.
+    mock_growspace.environment_config.control_dehumidifier = True
+    await coord.async_restart()
+
+    assert coord.control_enabled is True
+    assert len(coord._remove_listeners) > 0
+
+
 async def test_min_runtime_prevents_early_turnoff(coordinator, mock_hass) -> None:
     """Test that min runtime prevents turning off too early."""
     # Simulate: Dehumidifier is ON, was turned on 60 seconds ago

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -33,6 +33,12 @@ def mock_coordinator():
     coordinator._subsystem_manager.get_growlight_controller = MagicMock(
         return_value=None
     )
+    coordinator._subsystem_manager.get_dehumidifier_controller = MagicMock(
+        return_value=None
+    )
+    coordinator._subsystem_manager.get_humidifier_controller = MagicMock(
+        return_value=None
+    )
     return coordinator
 
 

--- a/tests/services/test_environment_config.py
+++ b/tests/services/test_environment_config.py
@@ -36,6 +36,12 @@ def mock_coordinator():
     coordinator._subsystem_manager.get_growlight_controller = MagicMock(
         return_value=None
     )
+    coordinator._subsystem_manager.get_dehumidifier_controller = MagicMock(
+        return_value=None
+    )
+    coordinator._subsystem_manager.get_humidifier_controller = MagicMock(
+        return_value=None
+    )
     return coordinator
 
 


### PR DESCRIPTION
## Summary

- `DehumidifierCoordinator` / `HumidifierCoordinator` (`VpdOnOffController` subclasses) are constructed once at entry setup and cache `control_enabled` from that snapshot in `__init__`. Unlike `circulation_fan`/`exhaust_fan`/`growlight`, they had no `async_restart()` and weren't listed in `_CONTROLLER_RELEVANT_FIELDS`.
- Result: `set_dehumidifier_control` / `set_humidifier_control` correctly persisted `control_dehumidifier` / `control_humidifier` to the growspace's `environment_config`, but never told the running coordinator to re-check it. The config-dialog checkbox saved successfully, but the dehumidifier/humidifier was never actually controlled until the integration reloaded (or HA restarted).
- Adds `VpdOnOffController.async_restart()` (unload → reload cached config from the live `environment_config` → `async_setup()` again), and wires `"dehumidifier"`/`"humidifier"` into `_CONTROLLER_RELEVANT_FIELDS` (`domain/environment_patch.py`) and `_CONTROLLER_ACCESSORS` (`services/environment_patch_commit.py`) so the environment-patch commit seam restarts the right coordinator when its control flag, entities, thresholds, or shared `vpd_sensor`/`light_sensors` change.
- Companion card-side fix: [Venosta-web/lovelace-growspace-manager-card#668](https://github.com/Venosta-web/lovelace-growspace-manager-card/pull/668) — the config dialog had no optimistic update for the toggle, which could show it as off after a fast reopen. That's a separate, secondary issue from this one.

## Test plan

- [x] `pytest tests/domain/test_environment_patch.py tests/integration/test_dehumidifier_coordinator.py` (all pass; pre-existing unrelated teardown-fixture errors in this sandbox's Python 3.14 env, confirmed present on `origin/prerelease` too)
- [x] `ruff check` on touched files — 1 pre-existing warning, unrelated to this change, confirmed present before this diff
- [x] `mypy` on touched files — confirmed zero new errors vs. `origin/prerelease` (same 7 pre-existing errors, unchanged)
- [x] New tests: `test_control_flag_flips_mark_the_matching_controller_for_restart` (domain) and `test_async_restart_picks_up_a_control_flag_flipped_after_construction` (integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)