### PR TITLE
docs: document fresh-workspace setup; fix prettier blocking every commit-msg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,13 @@ repos:
     rev: v3.6.2
     hooks:
       - id: prettier
+        # Without this, prek/pre-commit also runs prettier during the commit-msg
+        # stage — where "files" resolves to the commit message file itself — and
+        # errors out with "No matching files", hard-blocking every commit. Only
+        # surfaced once commit-msg was actually installed (see CLAUDE.md's fresh
+        # workspace setup note); default_install_hook_types declares the stage,
+        # each hook still needs its own restriction.
+        stages: [pre-commit]
         additional_dependencies:
           - prettier@3.6.2
           - prettier-plugin-sort-json@4.2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Tests run against the **repo-local** venv at `.venv` in the main checkout (Python 3.14+, built from `requirements.txt`). Worktrees share that one venv — they do not get their own:
 
-| Running from | Path |
-| --- | --- |
-| the main checkout | `.venv/bin/pytest` |
+| Running from                     | Path                                                              |
+| -------------------------------- | ----------------------------------------------------------------- |
+| the main checkout                | `.venv/bin/pytest`                                                |
 | a `.worktrees/<branch>` worktree | `../../.venv/bin/pytest` — the same path the pre-commit hooks use |
 
 **Never use the Home Assistant core venv at `/home/maxi/core/core/.venv`.** It is HA core's own test environment, so it carries HA core's syrupy rather than the version `pytest-homeassistant-custom-component` pins, and every test import then dies inside `pytest_homeassistant_custom_component/syrupy.py` on a symbol newer syrupy removed. It surfaces as a collection error, which reads like a broken test rather than a wrong interpreter.
@@ -62,6 +62,16 @@ uv pip install --python .venv/bin/python -r requirements.txt -c "$(
 ```
 
 Plain `pip install` works too — CI uses it — but the system `python3` is not 3.14, so create the venv with an explicit interpreter either way.
+
+#### Fresh workspace setup
+
+A fresh clone (or a fresh container hosting one, e.g. Home Assistant core's devcontainer with this repo cloned in as a sibling folder) has neither the venv above nor its git hooks wired up. After building `.venv`, install the hooks once from the main checkout — they're shared by every worktree, since hooks aren't per-worktree in git:
+
+```bash
+prek install                       # or: pre-commit install
+prek install --hook-type commit-msg  # not installed by the plain form above, despite
+                                      # default_install_hook_types in .pre-commit-config.yaml
+```
 
 **CRITICAL:** After completing any task involving code changes, ALWAYS run the relevant tests to ensure no regressions. For bug fixes, run the related test file. For features, run all affected test files. Before marking work complete, run the full test suite.
 


### PR DESCRIPTION
## Summary

- Documents the fresh-workspace bootstrap (`.venv` build + `prek install` for both hook types) next to the venv section it belongs to in `CLAUDE.md`. Neither the venv nor the git hooks survive this repo being cloned in as a sibling folder inside a container that only provisions Home Assistant core's own devcontainer.
- Installing `commit-msg` for the first time (to make that documented step actually do something) immediately exposed a real bug: `prettier` has no `stages` restriction, so prek/pre-commit also runs it during the `commit-msg` invocation — where "files" resolves to the commit-message file itself — and it hard-fails with `No matching files`, blocking every commit outright regardless of content. Scoped it to `stages: [pre-commit]`, mirroring how the card repo's `commitlint` hook already restricts itself to `stages: [commit-msg]` in reverse.

## Test plan

- [x] Reproduced the failure: committing with both hook types installed and no `stages` fix failed on `prettier` during `commit-msg` with `No matching files`
- [x] After the fix, this PR's own commit went through cleanly with commit-msg's prettier step no longer running (other commit-msg-stage hooks like `codespell` still run and pass, confirming this isn't over-broadly disabling the stage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)