### PR TITLE
Fix vision checkup scheduling using stale plant.stage on flower flip

### DIFF
--- a/custom_components/growspace_manager/vision_checkup_scheduler.py
+++ b/custom_components/growspace_manager/vision_checkup_scheduler.py
@@ -18,7 +18,7 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import now as ha_now, utcnow
 
-from .const import PlantStage
+from .domain.light_schedule import resolve_photoperiod_hours
 from .image_processor import GrowspaceImageProcessor
 from .models import VisionCheckupResult
 
@@ -100,14 +100,18 @@ class VisionCheckupScheduler:
     def _get_active_day_hours(self, growspace: Growspace) -> int:
         """Determine active light hours based on dominant plant stage.
 
-        Uses flower hours if any plant is in flower stage, otherwise veg hours.
+        Uses the same ``flower_start``-based resolution as the grow light
+        controller (see ``grow_light_coordinator._photoperiod_hours``) rather
+        than the cached ``plant.stage`` attribute, which is only set once at
+        plant creation and does not update when a plant flips to flower.
         """
         plants = self.coordinator.services.growspaces.get_growspace_plants(growspace.id)
         env = growspace.environment_config
-        for plant in plants:
-            if getattr(plant, "stage", None) in (PlantStage.FLOWER, "flower"):
-                return env.flower_day_hours
-        return env.veg_day_hours
+        return int(
+            resolve_photoperiod_hours(
+                plants, env.veg_day_hours, env.flower_day_hours, ha_now().date()
+            )
+        )
 
     def _get_lights_on_time(self, growspace: Growspace) -> time:
         """Parse the lights_on_time from the irrigation strategy."""

--- a/tests/test_vision_checkup_scheduler.py
+++ b/tests/test_vision_checkup_scheduler.py
@@ -451,14 +451,39 @@ def test_async_stop_cancels_all_timers(mock_hass, mock_coordinator):
 
 @pytest.mark.asyncio
 async def test_get_active_day_hours_flower(mock_hass, mock_coordinator):
-    """Test getting active day hours when a plant is in flower."""
+    """Test getting active day hours when a plant has entered flower.
+
+    Resolution must key off ``flower_start`` (like the grow light
+    controller), not the cached ``plant.stage`` attribute, since the latter
+    is only set once at plant creation and never updated on flip.
+    """
+
+    gs = _make_mock_growspace()
+    plant = MagicMock()
+    plant.flower_start = "2000-01-01"
+    mock_coordinator.services.growspaces.get_growspace_plants.return_value = [plant]
+    scheduler = VisionCheckupScheduler(mock_hass, mock_coordinator)
+    assert scheduler._get_active_day_hours(gs) == 12
+
+
+@pytest.mark.asyncio
+async def test_get_active_day_hours_stale_stage_ignored(mock_hass, mock_coordinator):
+    """A stale ``plant.stage`` of "flower" must not override flower_start.
+
+    Regression test: the vision scheduler previously trusted the cached
+    ``plant.stage`` attribute, which desynced from the actual grow light
+    schedule (driven by ``flower_start``) once a plant had been created,
+    producing checkup times that landed hours after lights had already
+    turned off.
+    """
 
     gs = _make_mock_growspace()
     plant = MagicMock()
     plant.stage = "flower"
+    plant.flower_start = None
     mock_coordinator.services.growspaces.get_growspace_plants.return_value = [plant]
     scheduler = VisionCheckupScheduler(mock_hass, mock_coordinator)
-    assert scheduler._get_active_day_hours(gs) == 12
+    assert scheduler._get_active_day_hours(gs) == 18
 
 
 def test_get_lights_on_time_fallback(mock_hass, mock_coordinator):


### PR DESCRIPTION
## Summary
- `VisionCheckupScheduler._get_active_day_hours` picked veg/flower day-length off the cached `plant.stage` attribute, which is set once at plant creation (`managers/plant.py`) and never updated when a plant later flips into flower.
- The grow light controller (`grow_light_coordinator.py`) resolves day-length live from `flower_start` via `resolve_photoperiod_hours()`. Once a plant actually entered flower, the two diverged: the light correctly shortened to the flower photoperiod, but vision checkups kept computing against the longer veg day-length — pushing the "late" checkup hours past the real lights-off time and capturing a dark snapshot.
- Reuse the same `resolve_photoperiod_hours()` domain helper in the vision scheduler so both stay in sync off `flower_start`.

## Test plan
- [x] `test_get_active_day_hours_flower` updated to assert against `flower_start` instead of the stale `plant.stage`
- [x] Added `test_get_active_day_hours_stale_stage_ignored` regression test — a stale `plant.stage == "flower"` with no `flower_start` no longer forces flower hours
- [x] `.venv/bin/pytest tests/test_vision_checkup_scheduler.py tests/test_vision_coordinator_integration.py tests/integration/test_ai_moisture_context.py` — 55 passed
- [x] Confirmed no new mypy errors introduced (446 errors in 73 files, identical before/after; mypy is non-blocking per ADR 0020 pending baseline burn-down)

🤖 Generated with [Claude Code](https://claude.com/claude-code)