### PR TITLE
mypy: remove stale unused type: ignore[misc] comments

### DIFF
--- a/custom_components/growspace_manager/binary_sensor.py
+++ b/custom_components/growspace_manager/binary_sensor.py
@@ -358,13 +358,13 @@ class BayesianEnvironmentSensor(
         self.trend_analyzer: TrendAnalyzer | None = None
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def is_on(self) -> bool:
         """Return true if the sensor is on (probability > threshold)."""
         return self._probability >= self.threshold
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         attrs = {

--- a/custom_components/growspace_manager/calendar.py
+++ b/custom_components/growspace_manager/calendar.py
@@ -48,7 +48,7 @@ async def async_setup_entry(
     async_add_entities(calendars, True)
 
 
-class GrowspaceCalendar(CalendarEntity):  # type: ignore[misc]
+class GrowspaceCalendar(CalendarEntity):
     """A calendar entity for a growspace.
 
     This calendar displays events that are generated from the user-configured

--- a/custom_components/growspace_manager/config_flow.py
+++ b/custom_components/growspace_manager/config_flow.py
@@ -62,7 +62,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     MINOR_VERSION = 1
     integration_name = "Growspace Manager"
 
-    @override  # type: ignore[misc]
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -293,7 +293,7 @@ class OptionsFlowHandler(OptionsFlow):
             self._strain_handler = StrainConfigHandler(self)
         return self._strain_handler
 
-    @override  # type: ignore[misc]
+    @override
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -443,37 +443,49 @@ class OptionsFlowHandler(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Delegate dehumidifier configuration to the handler."""
-        return await self.dehumidifier_handler.async_step_configure_dehumidifier(user_input)
+        return await self.dehumidifier_handler.async_step_configure_dehumidifier(
+            user_input
+        )
 
     async def async_step_configure_fan_controller(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Delegate fan controller configuration to the handler."""
-        return await self.fan_controller_handler.async_step_configure_fan_controller(user_input)
+        return await self.fan_controller_handler.async_step_configure_fan_controller(
+            user_input
+        )
 
     async def async_step_configure_fan_vpd(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Delegate fan VPD configuration to the handler."""
-        return await self.fan_controller_handler.async_step_configure_fan_vpd(user_input)
+        return await self.fan_controller_handler.async_step_configure_fan_vpd(
+            user_input
+        )
 
     async def async_step_configure_fan_humidity(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Delegate fan humidity configuration to the handler."""
-        return await self.fan_controller_handler.async_step_configure_fan_humidity(user_input)
+        return await self.fan_controller_handler.async_step_configure_fan_humidity(
+            user_input
+        )
 
     async def async_step_configure_fan_temperature(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Delegate fan temperature configuration to the handler."""
-        return await self.fan_controller_handler.async_step_configure_fan_temperature(user_input)
+        return await self.fan_controller_handler.async_step_configure_fan_temperature(
+            user_input
+        )
 
     async def async_step_configure_fan_wind(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Delegate fan wind configuration to the handler."""
-        return await self.fan_controller_handler.async_step_configure_fan_wind(user_input)
+        return await self.fan_controller_handler.async_step_configure_fan_wind(
+            user_input
+        )
 
     async def async_step_configure_advanced_bayesian(
         self, user_input: dict[str, Any] | None = None
@@ -485,7 +497,11 @@ class OptionsFlowHandler(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Delegate sensor placement configuration to the handler."""
-        return await self.bayesian_advanced_handler.async_step_configure_sensor_placement(user_input)
+        return (
+            await self.bayesian_advanced_handler.async_step_configure_sensor_placement(
+                user_input
+            )
+        )
 
     async def async_step_save_and_finish(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/growspace_manager/config_handlers/__init__.py
+++ b/custom_components/growspace_manager/config_handlers/__init__.py
@@ -86,7 +86,7 @@ class BaseConfigHandler(ABC, Generic[T]):
         coordinator = self.config_entry.runtime_data
         if coordinator is None:
             raise AbortFlow("setup_error")
-        return coordinator  # type: ignore[return-value]
+        return coordinator
 
     async def websocket_get_event_log(
         self, hass: HomeAssistant, connection: Any, msg: dict[str, Any]

--- a/custom_components/growspace_manager/models/ipm.py
+++ b/custom_components/growspace_manager/models/ipm.py
@@ -23,9 +23,9 @@ class IPMType(StrEnum):
 class IPMPresetItem(TypedDict, total=False):
     """A single item in an IPM preset recipe."""
 
-    name: str  # type: ignore[assignment]
-    dose_amount: float  # type: ignore[assignment]
-    dose_unit: str  # type: ignore[assignment]
+    name: str
+    dose_amount: float
+    dose_unit: str
     phi_days: int  # Pre-harvest interval in days, default 0
 
 

--- a/custom_components/growspace_manager/sensor/crop_steering.py
+++ b/custom_components/growspace_manager/sensor/crop_steering.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 
-class CropSteeringSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type: ignore[misc]
+class CropSteeringSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """Sensor calculating a vegetative-to-generative crop steering score."""
 
     _attr_has_entity_name = True
@@ -39,14 +39,14 @@ class CropSteeringSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
         )
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> float | None:
         """Return the crop steering score (-1.0 to 1.0)."""
         state = get_crop_steering_state(self.coordinator, self._growspace_id)
         return round(state.score, 2) if state else None
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return crop steering details."""
         state = get_crop_steering_state(self.coordinator, self._growspace_id)

--- a/custom_components/growspace_manager/sensor/drying.py
+++ b/custom_components/growspace_manager/sensor/drying.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 
-class DryingWeightSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type: ignore[misc]
+class DryingWeightSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """Sensor tracking daily drying weight for a plant."""
 
     _attr_has_entity_name = True
@@ -45,7 +45,7 @@ class DryingWeightSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
         return self.coordinator.services.plants.get_plant(self._plant_id)
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> float | None:
         """Return the latest logged weight in grams."""
         plant = self._get_plant()
@@ -54,7 +54,7 @@ class DryingWeightSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
         return plant.drying_data.weight_log[-1].weight_grams
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return weight_lost_pct and days_to_target."""
         plant = self._get_plant()
@@ -64,12 +64,14 @@ class DryingWeightSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
         log = plant.drying_data.weight_log
         current = log[-1].weight_grams if log else None
         return {
-            "weight_lost_pct": compute_weight_lost_pct(wet_weight, current) if current is not None else None,
+            "weight_lost_pct": compute_weight_lost_pct(wet_weight, current)
+            if current is not None
+            else None,
             "days_to_target": compute_days_to_target(wet_weight, log),
         }
 
 
-class DryingMoistureSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type: ignore[misc]
+class DryingMoistureSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """Sensor tracking daily moisture meter readings for a plant."""
 
     _attr_has_entity_name = True
@@ -97,7 +99,7 @@ class DryingMoistureSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity
         return self.coordinator.services.plants.get_plant(self._plant_id)
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> float | None:
         """Return the latest logged moisture percent."""
         plant = self._get_plant()
@@ -106,7 +108,9 @@ class DryingMoistureSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity
         return plant.drying_data.moisture_log[-1].moisture_percent
 
 
-class DryingReadyForCureSensor(CoordinatorEntity[GrowspaceCoordinator], BinarySensorEntity):  # type: ignore[misc]
+class DryingReadyForCureSensor(
+    CoordinatorEntity[GrowspaceCoordinator], BinarySensorEntity
+):
     """Binary sensor that is on when a plant's moisture is at or below the cure threshold."""
 
     _attr_has_entity_name = True
@@ -130,7 +134,7 @@ class DryingReadyForCureSensor(CoordinatorEntity[GrowspaceCoordinator], BinarySe
         )
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def is_on(self) -> bool:
         """Return True when the latest moisture reading is at or below the cure threshold."""
         plant = self._get_plant(self._plant_id)

--- a/custom_components/growspace_manager/sensor/environment.py
+++ b/custom_components/growspace_manager/sensor/environment.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 
-class AirExchangeSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type: ignore[misc]
+class AirExchangeSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """A sensor that provides an air exchange recommendation for a growspace."""
 
     _attr_has_entity_name = True
@@ -39,7 +39,7 @@ class AirExchangeSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity): 
         )
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> str:
         """Return the current recommended air exchange action."""
         return self.coordinator.data.get("air_exchange_recommendations", {}).get(  # type: ignore[no-any-return]
@@ -47,7 +47,7 @@ class AirExchangeSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity): 
         )
 
 
-class DLISensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type: ignore[misc]
+class DLISensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """Sensor tracking Daily Light Integral (mol/m2/day) for a growspace."""
 
     _attr_has_entity_name = True
@@ -93,13 +93,13 @@ class DLISensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type:
         return None
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> float | None:
         """Return current day's accumulated DLI."""
         return round(self._accumulated_mol, 1) if self._accumulated_mol > 0 else 0.0
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return DLI attributes."""
         growspace = self.coordinator.growspaces.get(self._growspace_id)
@@ -152,7 +152,7 @@ class DLISensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type:
         super()._handle_coordinator_update()
 
 
-class ECTargetSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type: ignore[misc]
+class ECTargetSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """Sensor showing current EC target from an EC ramp curve."""
 
     _attr_has_entity_name = True
@@ -216,7 +216,7 @@ class ECTargetSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # 
         return week
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> float | None:
         """Return current target EC midpoint."""
         curve = self._get_active_curve()
@@ -228,7 +228,7 @@ class ECTargetSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # 
         return round((band[0] + band[1]) / 2, 2)
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return EC target details."""
         curve = self._get_active_curve()

--- a/custom_components/growspace_manager/sensor/overview.py
+++ b/custom_components/growspace_manager/sensor/overview.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 
-class GrowspaceOverviewSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type: ignore[misc]
+class GrowspaceOverviewSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """A sensor that provides an overview of a single growspace.
 
     The state of this sensor is the number of plants in the growspace. Its
@@ -66,7 +66,7 @@ class GrowspaceOverviewSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEnt
             manufacturer="Growspace Manager",
         )
 
-    @override  # type: ignore[misc]
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks when the entity is added to Home Assistant."""
         await super().async_added_to_hass()
@@ -103,14 +103,16 @@ class GrowspaceOverviewSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEnt
         self.async_write_ha_state()
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> int:
         """Return the number of plants in the growspace."""
-        plants = self.coordinator.services.growspaces.get_growspace_plants(self.growspace_id)
+        plants = self.coordinator.services.growspaces.get_growspace_plants(
+            self.growspace_id
+        )
         return len(plants)
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the detailed state attributes for the growspace."""
         if not self.coordinator.data:
@@ -127,7 +129,7 @@ class GrowspaceOverviewSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEnt
         return attributes  # type: ignore[no-any-return]
 
 
-class GrowspaceListSensor(SensorEntity):  # type: ignore[misc]
+class GrowspaceListSensor(SensorEntity):
     """A sensor that exposes the list of all configured growspaces."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -163,14 +165,14 @@ class GrowspaceListSensor(SensorEntity):  # type: ignore[misc]
         }
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> int:
         """Return the total number of growspaces."""
         self._update_growspaces()
         return len(self._growspaces)
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def extra_state_attributes(self) -> dict[str, dict[str, Any]]:
         """Return the list of growspaces as a state attribute."""
         return {"growspaces": self._growspaces}

--- a/custom_components/growspace_manager/sensor/plant.py
+++ b/custom_components/growspace_manager/sensor/plant.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 
-class PlantEntity(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type: ignore[misc]
+class PlantEntity(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """A sensor representing a single plant in a growspace.
 
     The state of this sensor is the plant's current growth stage (e.g., 'veg',
@@ -46,7 +46,7 @@ class PlantEntity(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # typ
         )
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> str:
         """Return the current growth stage of the plant."""
         plant = self.coordinator.plants.get(self._plant.plant_id)
@@ -60,7 +60,7 @@ class PlantEntity(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # typ
         return stage
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the detailed state attributes for the plant."""
         plant = self.coordinator.plants.get(self._plant.plant_id)
@@ -69,7 +69,7 @@ class PlantEntity(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # typ
 
         return PlantViewModelBuilder.build_attributes(plant)
 
-    @override  # type: ignore[misc]
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks when the entity is added to Home Assistant."""
         await super().async_added_to_hass()

--- a/custom_components/growspace_manager/sensor/strain.py
+++ b/custom_components/growspace_manager/sensor/strain.py
@@ -21,7 +21,7 @@ STRAIN_LIBRARY_DEVICE_INFO = DeviceInfo(
 )
 
 
-class StrainLibrarySensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type: ignore[misc]
+class StrainLibrarySensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """A sensor that provides analytics from the user's strain library."""
 
     _attr_has_entity_name = True
@@ -49,7 +49,7 @@ class StrainLibrarySensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity)
         return total_count - ancestor_count, ancestor_count, total_count
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> int:
         """Return the number of catalogued strains in the library."""
         strains = self.coordinator.services.config.strain_library.get_all()
@@ -57,7 +57,7 @@ class StrainLibrarySensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity)
         return catalogued_count
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return strain analytics as state attributes."""
         analytics = self.coordinator.services.config.strain_library.get_analytics()
@@ -83,7 +83,7 @@ class StrainLibrarySensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity)
         }
 
 
-class SeedInventorySensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type: ignore[misc]
+class SeedInventorySensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """Sensor exposing the total seed count across all batches."""
 
     _attr_has_entity_name = True
@@ -98,13 +98,13 @@ class SeedInventorySensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity)
         self._attr_device_info = STRAIN_LIBRARY_DEVICE_INFO
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> int:
         """Return total number of seeds across all batches."""
         return self.coordinator.services.genetics.get_total_seed_count()
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return each seed batch as a list of dicts."""
         return {

--- a/custom_components/growspace_manager/sensor/usage.py
+++ b/custom_components/growspace_manager/sensor/usage.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from custom_components.growspace_manager.models import Growspace
 
 
-class EnergyUsageSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type: ignore[misc]
+class EnergyUsageSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """Sensor tracking electricity consumption per growspace."""
 
     _attr_has_entity_name = True
@@ -61,12 +61,12 @@ class EnergyUsageSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity): 
             if state and state.state not in ("unknown", "unavailable"):
                 try:
                     total += float(state.state)
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     continue
         return total
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> float | None:
         """Return total kWh for current grow cycle."""
         growspace = self.coordinator.growspaces.get(self._growspace_id)
@@ -77,7 +77,7 @@ class EnergyUsageSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity): 
         return round(max(0.0, current_kwh - cycle_start), 2)
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return energy details."""
         growspace = self.coordinator.growspaces.get(self._growspace_id)
@@ -91,7 +91,7 @@ class EnergyUsageSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity): 
         }
 
 
-class PowerUsageSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type: ignore[misc]
+class PowerUsageSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """Sensor tracking current power draw per growspace."""
 
     _attr_has_entity_name = True
@@ -120,7 +120,7 @@ class PowerUsageSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  
         )
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> float | None:
         """Return total current wattage across all configured power sensors."""
         growspace = self.coordinator.growspaces.get(self._growspace_id)
@@ -134,12 +134,12 @@ class PowerUsageSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  
                 try:
                     total += float(state.state)
                     any_valid = True
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     continue
         return round(total, 1) if any_valid else None
 
 
-class WaterUsageSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type: ignore[misc]
+class WaterUsageSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """Sensor tracking water consumption per growspace."""
 
     _attr_has_entity_name = True
@@ -179,7 +179,7 @@ class WaterUsageSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  
         return compute_growspace_water(growspace, trackers)
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> float | None:
         """Return total liters used in current cycle (since cycle_start_date)."""
         growspace = self.coordinator.growspaces.get(self._growspace_id)
@@ -188,7 +188,7 @@ class WaterUsageSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  
         return self._compute_water(growspace).cycle
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return water usage details, exposing both today and cycle figures."""
         growspace = self.coordinator.growspaces.get(self._growspace_id)
@@ -210,7 +210,7 @@ class WaterUsageSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  
             try:
                 start = date_cls.fromisoformat(usage.cycle_start_date)
                 days = max(1, (date_cls.today() - start).days)
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 pass
 
         liters_per_plant = (

--- a/custom_components/growspace_manager/sensor/vision.py
+++ b/custom_components/growspace_manager/sensor/vision.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 
-class VisionCheckupSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):  # type: ignore[misc]
+class VisionCheckupSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """Sensor showing the latest AI vision checkup result for a growspace."""
 
     _attr_has_entity_name = True
@@ -50,14 +50,14 @@ class VisionCheckupSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity)
         return None
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> str | None:
         """Return the severity of the latest checkup."""
         result = self._latest_result
         return result.severity if result else None
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return detailed attributes from the latest checkup."""
         result = self._latest_result

--- a/custom_components/growspace_manager/sensor/vpd.py
+++ b/custom_components/growspace_manager/sensor/vpd.py
@@ -18,13 +18,13 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.event import async_track_state_change_event
 
 
-class BaseVpdSensor(SensorEntity):  # type: ignore[misc]
+class BaseVpdSensor(SensorEntity):
     """Base class for VPD sensors providing common functionality."""
 
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "kPa"
 
-    @override  # type: ignore[misc]
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks when the entity is added to Home Assistant."""
         if self.entities_to_track:
@@ -52,7 +52,7 @@ class BaseVpdSensor(SensorEntity):  # type: ignore[misc]
         if state and state.state not in ["unknown", "unavailable"]:
             try:
                 return float(state.state)
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 pass
         return None
 
@@ -106,7 +106,7 @@ class VpdSensor(BaseVpdSensor):
         return tracking
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> float | None:
         """Return the calculated VPD value in kPa."""
         temp = None
@@ -184,7 +184,7 @@ class CalculatedVpdSensor(BaseVpdSensor):
         return lst_offset
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def native_value(self) -> float | None:
         """Return the calculated VPD value in kPa."""
         temp = self._get_float_state(self._temp_sensor)
@@ -197,7 +197,7 @@ class CalculatedVpdSensor(BaseVpdSensor):
         return None
 
     @property
-    @override  # type: ignore[misc]
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
         return {

--- a/custom_components/growspace_manager/services/growspace_facade.py
+++ b/custom_components/growspace_manager/services/growspace_facade.py
@@ -675,7 +675,7 @@ class GrowspaceFacade:
         registry: er.EntityRegistry = er.async_get(self._coordinator.hass)
         entity_id = registry.async_get_entity_id("sensor", DOMAIN, unique_id)
         if entity_id:
-            return entity_id  # type: ignore[no-any-return]
+            return entity_id
         for special_def in SPECIAL_GROWSPACES.values():
             canonical_id = special_def["canonical_id"]
             if growspace_id == canonical_id or growspace_id in special_def.get(

--- a/custom_components/growspace_manager/services/plant_facade.py
+++ b/custom_components/growspace_manager/services/plant_facade.py
@@ -620,7 +620,7 @@ class PlantFacade:
                     phenotype=call.data.get(ATTR_PHENOTYPE, ""),
                     seed_batch_id=seed_batch_id,
                     generation=batch.generation if batch else "",
-                    **parsed_dates,  # type: ignore[arg-type]
+                    **parsed_dates,
                 )
                 plant_id = plant.plant_id
             except GrowspaceError as err:
@@ -728,7 +728,7 @@ class PlantFacade:
                         phenotype=phenotype,
                         seed_batch_id=seed_batch_id,
                         generation=batch_generation,
-                        **parsed_dates,  # type: ignore[arg-type]
+                        **parsed_dates,
                     )
                     plants_added_count += 1
                 except GrowspaceError as err:

--- a/custom_components/growspace_manager/services/report.py
+++ b/custom_components/growspace_manager/services/report.py
@@ -69,7 +69,7 @@ async def handle_export_grow_report(
         else:
             report_data = await _aggregate_growspace_data(
                 hass, coordinator, growspace_id
-            )  # type: ignore[arg-type]
+            )
 
         output_dir = Path(hass.config.path("www", "growspace_manager", "reports"))
         await hass.async_add_executor_job(output_dir.mkdir, 511, True, True)
@@ -291,7 +291,7 @@ async def _get_plant_environmental_stats(
                         if s_start.isoformat() <= p["lu"] <= s_end.isoformat()
                     ]
                     if points:
-                        stage_stats[key] = round(sum(points) / len(points), 2)  # type: ignore[reassigned]
+                        stage_stats[key] = round(sum(points) / len(points), 2)
 
             averages[stage_name] = stage_stats
 

--- a/custom_components/growspace_manager/switch.py
+++ b/custom_components/growspace_manager/switch.py
@@ -27,7 +27,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class GrowspaceSwitchDescription(SwitchEntityDescription):  # type: ignore[misc]  # HA base class
+class GrowspaceSwitchDescription(SwitchEntityDescription):  # HA base class
     """Class describing Growspace Manager switch entities."""
 
     has_entity_name: bool = True
@@ -65,7 +65,7 @@ async def async_setup_entry(
         _LOGGER.debug("Added %d switches", len(entities))
 
 
-class GrowspaceNotificationSwitch(SwitchEntity):  # type: ignore[misc]  # HA base class
+class GrowspaceNotificationSwitch(SwitchEntity):  # HA base class
     """A switch entity to control notifications for a specific growspace."""
 
     entity_description: GrowspaceSwitchDescription
@@ -95,14 +95,14 @@ class GrowspaceNotificationSwitch(SwitchEntity):  # type: ignore[misc]  # HA bas
         )
 
     @property
-    @override  # type: ignore[misc]  # SwitchEntity.is_on exists but not detected by mypy
+    @override  # SwitchEntity.is_on exists but not detected by mypy
     def is_on(self) -> bool:
         """Return true if notifications are enabled for the growspace."""
         return self._coordinator.services.notifications.is_notifications_enabled(
             self._growspace_id
         )
 
-    @override  # type: ignore[misc]  # SwitchEntity.async_turn_on exists but not detected by mypy
+    @override  # SwitchEntity.async_turn_on exists but not detected by mypy
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable notifications for the growspace."""
         await self._coordinator.services.notifications.set_notifications_enabled(
@@ -115,7 +115,7 @@ class GrowspaceNotificationSwitch(SwitchEntity):  # type: ignore[misc]  # HA bas
             self._growspace.name,
         )
 
-    @override  # type: ignore[misc]  # SwitchEntity.async_turn_off exists but not detected by mypy
+    @override  # SwitchEntity.async_turn_off exists but not detected by mypy
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable notifications for the growspace."""
         await self._coordinator.services.notifications.set_notifications_enabled(
@@ -128,7 +128,7 @@ class GrowspaceNotificationSwitch(SwitchEntity):  # type: ignore[misc]  # HA bas
             self._growspace.name,
         )
 
-    @override  # type: ignore[misc]  # Entity.async_added_to_hass exists but not detected by mypy
+    @override  # Entity.async_added_to_hass exists but not detected by mypy
     async def async_added_to_hass(self) -> None:
         """Register a listener when the entity is added to Home Assistant."""
         self.async_on_remove(

--- a/custom_components/growspace_manager/websocket/_common.py
+++ b/custom_components/growspace_manager/websocket/_common.py
@@ -186,7 +186,7 @@ def _extract_ts(state_obj: Any) -> datetime:
         return _EPOCH_SENTINEL
     if isinstance(ts_raw, str):
         parsed = dt_util.parse_datetime(ts_raw)
-        return parsed or _EPOCH_SENTINEL  # type: ignore[no-any-return]
+        return parsed or _EPOCH_SENTINEL
     if isinstance(ts_raw, datetime):
         return ts_raw
     return _EPOCH_SENTINEL
@@ -232,7 +232,7 @@ def _merge_logbook_event(
                             dict.fromkeys(last_evt["reasons"] + data_dict["reasons"])
                         )
                         last_evt["reasons"] = comb[:5]
-                    return True  # type: ignore[no-any-return]
+                    return True
         except ValueError, TypeError, KeyError:
             pass
     return False

--- a/custom_components/growspace_manager/websocket/environment.py
+++ b/custom_components/growspace_manager/websocket/environment.py
@@ -271,7 +271,7 @@ async def _get_history_with_binary_search_downsample(
 
         return result
 
-    return await hass.async_add_executor_job(_downsample_with_binary_search)  # type: ignore[no-any-return]
+    return await hass.async_add_executor_job(_downsample_with_binary_search)
 
 
 async def websocket_get_history_stats(


### PR DESCRIPTION
## Summary
- Removes all 74 `# type: ignore[...]` comments that mypy currently flags as `unused-ignore` (sensor/, services/, websocket/, models/, switch.py, config_flow.py, calendar.py, binary_sensor.py, config_handlers/__init__.py)
- Each comment was suppressing an error that no longer occurs, so removal is safe by construction

## Test plan
- [x] `mypy custom_components/growspace_manager` reports zero `unused-ignore` errors
- [x] Verified via `git stash` diff that total mypy error count dropped by exactly 74 (from the pre-existing baseline), confirming no still-needed ignores were removed and no new errors were introduced
- [x] `ruff check` / `ruff format` pass
- [x] Full test suite passes (5092 passed)

Fixes #603