### PR TITLE
mypy: finish typing config_handlers/ (remaining errors)

### DIFF
--- a/custom_components/growspace_manager/config_handlers/__init__.py
+++ b/custom_components/growspace_manager/config_handlers/__init__.py
@@ -6,10 +6,10 @@ from abc import ABC
 import logging
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 if TYPE_CHECKING:
+    from custom_components.growspace_manager import GrowspaceConfigEntry
     from custom_components.growspace_manager.config_flow import OptionsFlowHandler
     from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 
@@ -33,7 +33,7 @@ class AbortFlow(Exception):
 class BaseConfigHandler(ABC, Generic[T]):
     """Base class for configuration handlers."""
 
-    config_entry: ConfigEntry | None = None
+    config_entry: GrowspaceConfigEntry | None = None
     _flow: OptionsFlowHandler | None = None
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/custom_components/growspace_manager/config_handlers/ai_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/ai_config_handler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import Any
 
 import voluptuous as vol
 
@@ -129,9 +129,7 @@ class AIConfigHandler(BaseConfigHandler[dict[str, Any]]):
                 CONF_BRIEFING_TRIGGER_ENTITIES,
                 default=current_settings.get(CONF_BRIEFING_TRIGGER_ENTITIES, []),
             )
-        ] = selector.EntitySelector(
-            selector.EntitySelectorConfig(multiple=True)
-        )
+        ] = selector.EntitySelector(selector.EntitySelectorConfig(multiple=True))
 
         return vol.Schema(schema)
 
@@ -189,4 +187,4 @@ class AIConfigHandler(BaseConfigHandler[dict[str, Any]]):
         # Save to storage
         await coordinator.services.save()
 
-        return cast(dict[str, Any], new_options)
+        return new_options

--- a/custom_components/growspace_manager/config_handlers/bayesian_advanced_handler.py
+++ b/custom_components/growspace_manager/config_handlers/bayesian_advanced_handler.py
@@ -66,13 +66,15 @@ class BayesianAdvancedHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
             return self.flow.async_abort(reason="growspace_not_found")
 
         if user_input is not None:
-            env_config = self.flow.env_config_step1.copy()
+            env_config = dict(self.flow.env_config_step1 or {})
             env_config.pop("configure_advanced", None)
 
             try:
@@ -92,12 +94,12 @@ class BayesianAdvancedHandler(BaseConfigHandler[dict[str, Any]]):
 
                 self.flow.env_config_step1 = env_config
 
-            except (ValueError, SyntaxError, TypeError):
+            except ValueError, SyntaxError, TypeError:
                 _LOGGER.warning("Invalid tuple format submitted", exc_info=True)
                 return self.flow.async_show_form(
                     step_id="configure_advanced_bayesian",
                     data_schema=self.get_advanced_bayesian_schema(
-                        self.flow.env_config_step1
+                        self.flow.env_config_step1 or {}
                     ),
                     errors={"base": "invalid_tuple_format"},
                     description_placeholders={"growspace_name": growspace.name},
@@ -107,7 +109,9 @@ class BayesianAdvancedHandler(BaseConfigHandler[dict[str, Any]]):
 
         return self.flow.async_show_form(
             step_id="configure_advanced_bayesian",
-            data_schema=self.get_advanced_bayesian_schema(self.flow.env_config_step1),
+            data_schema=self.get_advanced_bayesian_schema(
+                self.flow.env_config_step1 or {}
+            ),
             description_placeholders={"growspace_name": growspace.name},
         )
 
@@ -120,12 +124,16 @@ class BayesianAdvancedHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
             return self.flow.async_abort(reason="growspace_not_found")
 
         env_config = self.flow.env_config_step1
+        if env_config is None:
+            return self.flow.async_abort(reason="setup_error")
 
         sensors_to_configure, sensors_allowed_outside = (
             self._collect_sensors_to_configure(env_config, growspace)

--- a/custom_components/growspace_manager/config_handlers/dehumidifier_handler.py
+++ b/custom_components/growspace_manager/config_handlers/dehumidifier_handler.py
@@ -40,6 +40,8 @@ class DehumidifierHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
@@ -52,7 +54,7 @@ class DehumidifierHandler(BaseConfigHandler[dict[str, Any]]):
         )
 
         if user_input is not None:
-            env_config = self.flow.env_config_step1.copy()
+            env_config = dict(self.flow.env_config_step1 or {})
             env_config["dehumidifier_thresholds"] = parse_stage_thresholds(user_input)
 
             if env_config.get("configure_advanced"):

--- a/custom_components/growspace_manager/config_handlers/environment_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/environment_config_handler.py
@@ -160,6 +160,8 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
@@ -318,6 +320,8 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
@@ -330,7 +334,7 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
         )
 
         if user_input is not None:
-            env_config = self.flow.env_config_step1.copy()
+            env_config = dict(self.flow.env_config_step1 or {})
             env_config["humidifier_thresholds"] = parse_stage_thresholds(user_input)
 
             if env_config.get("configure_advanced"):
@@ -362,6 +366,8 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
@@ -375,7 +381,7 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
         )
 
         if user_input is not None:
-            env_config = self.flow.env_config_step1.copy()
+            env_config = dict(self.flow.env_config_step1 or {})
             env_config["dehumidifier_thresholds"] = parse_stage_thresholds(user_input)
 
             if env_config.get("configure_advanced"):
@@ -403,13 +409,15 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
             return self.flow.async_abort(reason="growspace_not_found")
 
         if user_input is not None:
-            env_config = self.flow.env_config_step1.copy()
+            env_config = dict(self.flow.env_config_step1 or {})
             env_config.pop("configure_advanced", None)
 
             try:
@@ -437,7 +445,7 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
                 return self.flow.async_show_form(
                     step_id="configure_advanced_bayesian",
                     data_schema=self.get_advanced_bayesian_schema(
-                        self.flow.env_config_step1
+                        self.flow.env_config_step1 or {}
                     ),
                     errors={"base": "invalid_tuple_format"},
                     description_placeholders={"growspace_name": growspace.name},
@@ -447,7 +455,9 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
 
         return self.flow.async_show_form(
             step_id="configure_advanced_bayesian",
-            data_schema=self.get_advanced_bayesian_schema(self.flow.env_config_step1),
+            data_schema=self.get_advanced_bayesian_schema(
+                self.flow.env_config_step1 or {}
+            ),
             description_placeholders={"growspace_name": growspace.name},
         )
 
@@ -460,12 +470,16 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
             return self.flow.async_abort(reason="growspace_not_found")
 
         env_config = self.flow.env_config_step1
+        if env_config is None:
+            return self.flow.async_abort(reason="setup_error")
 
         # Collect sensors that need coordinate configuration
         sensors_to_configure, sensors_allowed_outside = (
@@ -652,8 +666,12 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
 
         return schema_dict
 
-    async def _async_save_and_finish(self, growspace, env_config):
+    async def _async_save_and_finish(
+        self, growspace: Any, env_config: dict[str, Any]
+    ) -> ConfigFlowResult:
         """Apply the assembled form dict through the Environment Patch seam."""
+        if self.config_entry is None:
+            return self.flow.async_abort(reason="setup_error")
         coordinator = self.config_entry.runtime_data
 
         await async_commit_environment_patch(
@@ -1124,27 +1142,22 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
         )
 
         # Trend analysis settings
-        trend_configs = {
-            "vpd": {
-                "threshold": CONF_TREND_VPD_THRESHOLD,
-                "duration": CONF_TREND_VPD_DURATION,
-                "sensitivity": CONF_TREND_VPD_SENSITIVITY,
-                "default": 1.2,
-            },
-            "temperature": {
-                "threshold": CONF_TREND_TEMPERATURE_THRESHOLD,
-                "duration": CONF_TREND_TEMPERATURE_DURATION,
-                "sensitivity": CONF_TREND_TEMPERATURE_SENSITIVITY,
-                "default": 26.0,
-            },
-        }
+        trend_configs: list[tuple[str, str, str, float]] = [
+            (
+                CONF_TREND_VPD_THRESHOLD,
+                CONF_TREND_VPD_DURATION,
+                CONF_TREND_VPD_SENSITIVITY,
+                1.2,
+            ),
+            (
+                CONF_TREND_TEMPERATURE_THRESHOLD,
+                CONF_TREND_TEMPERATURE_DURATION,
+                CONF_TREND_TEMPERATURE_SENSITIVITY,
+                26.0,
+            ),
+        ]
 
-        for config in trend_configs.values():
-            threshold_key = config["threshold"]
-            duration_key = config["duration"]
-            sensitivity_key = config["sensitivity"]
-            default_val = config["default"]
-
+        for threshold_key, duration_key, sensitivity_key, default_val in trend_configs:
             schema_dict[
                 vol.Optional(
                     threshold_key,
@@ -1298,11 +1311,12 @@ class EnvironmentConfigHandler(BaseConfigHandler[dict[str, Any]]):
             (CONF_ENERGY_SENSORS, "energy"),
         ]:
             suggested_val = growspace_options.get(key, [])
-            selector_config = selector.EntitySelectorConfig(
-                domain=["sensor", "input_number", "number"],
-                multiple=True,
-                device_class=device_class or None,
-            )
+            selector_config: selector.EntitySelectorConfig = {
+                "domain": ["sensor", "input_number", "number"],
+                "multiple": True,
+            }
+            if device_class:
+                selector_config["device_class"] = device_class
 
             schema_dict[
                 vol.Optional(key, description={"suggested_value": suggested_val})

--- a/custom_components/growspace_manager/config_handlers/environment_sensors_handler.py
+++ b/custom_components/growspace_manager/config_handlers/environment_sensors_handler.py
@@ -110,6 +110,8 @@ class EnvironmentSensorsHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
@@ -245,6 +247,8 @@ class EnvironmentSensorsHandler(BaseConfigHandler[dict[str, Any]]):
         self, growspace: Any, env_config: dict[str, Any]
     ) -> ConfigFlowResult:
         """Apply the assembled form dict through the Environment Patch seam."""
+        if self.config_entry is None:
+            return self.flow.async_abort(reason="setup_error")
         coordinator = self.config_entry.runtime_data
 
         await async_commit_environment_patch(
@@ -699,27 +703,22 @@ class EnvironmentSensorsHandler(BaseConfigHandler[dict[str, Any]]):
             )
         )
 
-        trend_configs = {
-            "vpd": {
-                "threshold": CONF_TREND_VPD_THRESHOLD,
-                "duration": CONF_TREND_VPD_DURATION,
-                "sensitivity": CONF_TREND_VPD_SENSITIVITY,
-                "default": 1.2,
-            },
-            "temperature": {
-                "threshold": CONF_TREND_TEMPERATURE_THRESHOLD,
-                "duration": CONF_TREND_TEMPERATURE_DURATION,
-                "sensitivity": CONF_TREND_TEMPERATURE_SENSITIVITY,
-                "default": 26.0,
-            },
-        }
+        trend_configs: list[tuple[str, str, str, float]] = [
+            (
+                CONF_TREND_VPD_THRESHOLD,
+                CONF_TREND_VPD_DURATION,
+                CONF_TREND_VPD_SENSITIVITY,
+                1.2,
+            ),
+            (
+                CONF_TREND_TEMPERATURE_THRESHOLD,
+                CONF_TREND_TEMPERATURE_DURATION,
+                CONF_TREND_TEMPERATURE_SENSITIVITY,
+                26.0,
+            ),
+        ]
 
-        for config in trend_configs.values():
-            threshold_key = config["threshold"]
-            duration_key = config["duration"]
-            sensitivity_key = config["sensitivity"]
-            default_val = config["default"]
-
+        for threshold_key, duration_key, sensitivity_key, default_val in trend_configs:
             schema_dict[
                 vol.Optional(
                     threshold_key,
@@ -807,11 +806,12 @@ class EnvironmentSensorsHandler(BaseConfigHandler[dict[str, Any]]):
             (CONF_ENERGY_SENSORS, "energy"),
         ]:
             suggested_val = growspace_options.get(key, [])
-            selector_config = selector.EntitySelectorConfig(
-                domain=["sensor", "input_number", "number"],
-                multiple=True,
-                device_class=device_class or None,
-            )
+            selector_config: selector.EntitySelectorConfig = {
+                "domain": ["sensor", "input_number", "number"],
+                "multiple": True,
+            }
+            if device_class:
+                selector_config["device_class"] = device_class
 
             schema_dict[
                 vol.Optional(key, description={"suggested_value": suggested_val})

--- a/custom_components/growspace_manager/config_handlers/fan_controller_handler.py
+++ b/custom_components/growspace_manager/config_handlers/fan_controller_handler.py
@@ -30,6 +30,8 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
@@ -75,6 +77,8 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
@@ -87,13 +91,17 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
         ) or CirculationFanConfig()
 
         if user_input is not None:
-            stage_vpd_enabled = user_input.get("stage_vpd_enabled", current_cfg.stage_vpd_enabled)
+            stage_vpd_enabled = user_input.get(
+                "stage_vpd_enabled", current_cfg.stage_vpd_enabled
+            )
             # When stage mode is off the user must supply vpd_target; re-render if missing.
             if not stage_vpd_enabled and "vpd_target" not in user_input:
                 self.flow.fan_config_step1.update(user_input)
                 return self.flow.async_show_form(
                     step_id="configure_fan_vpd",
-                    data_schema=self.get_fan_vpd_schema(current_cfg, stage_vpd_enabled=False),
+                    data_schema=self.get_fan_vpd_schema(
+                        current_cfg, stage_vpd_enabled=False
+                    ),
                     description_placeholders={"growspace_name": growspace.name},
                 )
             # Preserve existing vpd_target when stage mode is on and no value was submitted.
@@ -120,6 +128,8 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
@@ -152,6 +162,8 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
@@ -184,6 +196,8 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
@@ -205,7 +219,9 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
             description_placeholders={"growspace_name": growspace.name},
         )
 
-    async def _async_save_fan_config_and_continue(self, growspace: Any) -> ConfigFlowResult:
+    async def _async_save_fan_config_and_continue(
+        self, growspace: Any
+    ) -> ConfigFlowResult:
         """Persist the assembled fan config onto the growspace and continue the flow."""
         fan_data = self.flow.fan_config_step1
         fan_cfg = CirculationFanConfig(
@@ -223,7 +239,9 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
             vpd_tolerance=float(fan_data.get("vpd_tolerance", 0.2)),
             critical_temp_low=fan_data.get("critical_temp_low"),
             critical_temp_high=fan_data.get("critical_temp_high"),
-            critical_temp_hysteresis=float(fan_data.get("critical_temp_hysteresis", 1.0)),
+            critical_temp_hysteresis=float(
+                fan_data.get("critical_temp_hysteresis", 1.0)
+            ),
             wind_enabled=bool(fan_data.get("wind_enabled", False)),
             wind_period_seconds=int(fan_data.get("wind_period_seconds", 60)),
             wind_amplitude_pct=int(fan_data.get("wind_amplitude_pct", 10)),
@@ -231,7 +249,7 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
             stage_vpd_overrides=fan_data.get("stage_vpd_overrides", {}),
         )
 
-        env_config = self.flow.env_config_step1.copy()
+        env_config = dict(self.flow.env_config_step1 or {})
         env_config["circulation_fan_config"] = asdict(fan_cfg)
         self.flow.env_config_step1 = env_config
 
@@ -241,11 +259,15 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
     # Schemas
     # -------------------------------------------------------------------------
 
-    def get_fan_controller_schema(self, current_cfg: CirculationFanConfig) -> vol.Schema:
+    def get_fan_controller_schema(
+        self, current_cfg: CirculationFanConfig
+    ) -> vol.Schema:
         """Schema for the base fan controller step."""
         return vol.Schema(
             {
-                vol.Required("enabled", default=current_cfg.enabled): selector.BooleanSelector(),
+                vol.Required(
+                    "enabled", default=current_cfg.enabled
+                ): selector.BooleanSelector(),
                 vol.Required(
                     "regulation_mode",
                     default=current_cfg.regulation_mode.value
@@ -255,22 +277,33 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
                     selector.SelectSelectorConfig(
                         options=[
                             selector.SelectOptionDict(
-                                value=mode.value, label=mode.value.replace("_", " ").title()
+                                value=mode.value,
+                                label=mode.value.replace("_", " ").title(),
                             )
                             for mode in FanRegulationMode
                         ],
                         mode=selector.SelectSelectorMode.DROPDOWN,
                     )
                 ),
-                vol.Required("min_speed", default=current_cfg.min_speed): selector.NumberSelector(
+                vol.Required(
+                    "min_speed", default=current_cfg.min_speed
+                ): selector.NumberSelector(
                     selector.NumberSelectorConfig(
-                        min=0, max=99, step=1, mode=selector.NumberSelectorMode.SLIDER,
+                        min=0,
+                        max=99,
+                        step=1,
+                        mode=selector.NumberSelectorMode.SLIDER,
                         unit_of_measurement="%",
                     )
                 ),
-                vol.Required("max_speed", default=current_cfg.max_speed): selector.NumberSelector(
+                vol.Required(
+                    "max_speed", default=current_cfg.max_speed
+                ): selector.NumberSelector(
                     selector.NumberSelectorConfig(
-                        min=1, max=100, step=1, mode=selector.NumberSelectorMode.SLIDER,
+                        min=1,
+                        max=100,
+                        step=1,
+                        mode=selector.NumberSelectorMode.SLIDER,
                         unit_of_measurement="%",
                     )
                 ),
@@ -303,7 +336,9 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
             schema[vol.Required("vpd_target", default=current_cfg.vpd_target)] = (
                 selector.NumberSelector(
                     selector.NumberSelectorConfig(
-                        min=0.1, max=3.0, step=0.05,
+                        min=0.1,
+                        max=3.0,
+                        step=0.05,
                         mode=selector.NumberSelectorMode.BOX,
                         unit_of_measurement="kPa",
                     )
@@ -313,35 +348,51 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
         schema[vol.Required("vpd_tolerance", default=current_cfg.vpd_tolerance)] = (
             selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=0.01, max=1.0, step=0.01,
+                    min=0.01,
+                    max=1.0,
+                    step=0.01,
                     mode=selector.NumberSelectorMode.BOX,
                     unit_of_measurement="kPa",
                 )
             )
         )
-        schema[vol.Optional("critical_temp_low", default=current_cfg.critical_temp_low)] = (
-            vol.Any(None, selector.NumberSelector(
+        schema[
+            vol.Optional("critical_temp_low", default=current_cfg.critical_temp_low)
+        ] = vol.Any(
+            None,
+            selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=10, max=40, step=0.5,
+                    min=10,
+                    max=40,
+                    step=0.5,
                     mode=selector.NumberSelectorMode.BOX,
                     unit_of_measurement="°C",
                 )
-            ))
+            ),
         )
-        schema[vol.Optional("critical_temp_high", default=current_cfg.critical_temp_high)] = (
-            vol.Any(None, selector.NumberSelector(
+        schema[
+            vol.Optional("critical_temp_high", default=current_cfg.critical_temp_high)
+        ] = vol.Any(
+            None,
+            selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=10, max=50, step=0.5,
+                    min=10,
+                    max=50,
+                    step=0.5,
                     mode=selector.NumberSelectorMode.BOX,
                     unit_of_measurement="°C",
                 )
-            ))
+            ),
         )
-        schema[vol.Required(
-            "critical_temp_hysteresis", default=current_cfg.critical_temp_hysteresis
-        )] = selector.NumberSelector(
+        schema[
+            vol.Required(
+                "critical_temp_hysteresis", default=current_cfg.critical_temp_hysteresis
+            )
+        ] = selector.NumberSelector(
             selector.NumberSelectorConfig(
-                min=0.1, max=5.0, step=0.1,
+                min=0.1,
+                max=5.0,
+                step=0.1,
                 mode=selector.NumberSelectorMode.BOX,
                 unit_of_measurement="°C",
             )
@@ -357,7 +408,9 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
                     "humidity_target", default=current_cfg.humidity_target
                 ): selector.NumberSelector(
                     selector.NumberSelectorConfig(
-                        min=20, max=90, step=1,
+                        min=20,
+                        max=90,
+                        step=1,
                         mode=selector.NumberSelectorMode.SLIDER,
                         unit_of_measurement="%",
                     )
@@ -366,7 +419,9 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
                     "humidity_tolerance", default=current_cfg.humidity_tolerance
                 ): selector.NumberSelector(
                     selector.NumberSelectorConfig(
-                        min=1, max=20, step=0.5,
+                        min=1,
+                        max=20,
+                        step=0.5,
                         mode=selector.NumberSelectorMode.BOX,
                         unit_of_measurement="%",
                     )
@@ -374,7 +429,9 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
             }
         )
 
-    def get_fan_temperature_schema(self, current_cfg: CirculationFanConfig) -> vol.Schema:
+    def get_fan_temperature_schema(
+        self, current_cfg: CirculationFanConfig
+    ) -> vol.Schema:
         """Schema for the temperature fan mode step."""
         return vol.Schema(
             {
@@ -382,7 +439,9 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
                     "temperature_target", default=current_cfg.temperature_target
                 ): selector.NumberSelector(
                     selector.NumberSelectorConfig(
-                        min=15, max=35, step=0.5,
+                        min=15,
+                        max=35,
+                        step=0.5,
                         mode=selector.NumberSelectorMode.SLIDER,
                         unit_of_measurement="°C",
                     )
@@ -391,7 +450,9 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
                     "temperature_tolerance", default=current_cfg.temperature_tolerance
                 ): selector.NumberSelector(
                     selector.NumberSelectorConfig(
-                        min=0.5, max=10, step=0.5,
+                        min=0.5,
+                        max=10,
+                        step=0.5,
                         mode=selector.NumberSelectorMode.BOX,
                         unit_of_measurement="°C",
                     )
@@ -407,7 +468,9 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
                     "wind_period_seconds", default=current_cfg.wind_period_seconds
                 ): selector.NumberSelector(
                     selector.NumberSelectorConfig(
-                        min=10, max=600, step=10,
+                        min=10,
+                        max=600,
+                        step=10,
                         mode=selector.NumberSelectorMode.BOX,
                         unit_of_measurement="seconds",
                     )
@@ -416,7 +479,9 @@ class FanControllerHandler(BaseConfigHandler[dict[str, Any]]):
                     "wind_amplitude_pct", default=current_cfg.wind_amplitude_pct
                 ): selector.NumberSelector(
                     selector.NumberSelectorConfig(
-                        min=5, max=50, step=5,
+                        min=5,
+                        max=50,
+                        step=5,
                         mode=selector.NumberSelectorMode.SLIDER,
                         unit_of_measurement="%",
                     )

--- a/custom_components/growspace_manager/config_handlers/growspace_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/growspace_config_handler.py
@@ -26,7 +26,9 @@ class GrowspaceConfigHandler(BaseConfigHandler[dict[str, Any]]):
         self, coordinator: GrowspaceCoordinator
     ) -> vol.Schema:
         """Build the schema for the growspace management menu."""
-        growspace_options = coordinator.services.growspaces.get_sorted_growspace_options()
+        growspace_options = (
+            coordinator.services.growspaces.get_sorted_growspace_options()
+        )
 
         schema: dict[Any, Any] = {
             vol.Required("action", default="add"): selector.SelectSelector(
@@ -219,6 +221,8 @@ class GrowspaceConfigHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
@@ -362,7 +366,11 @@ class GrowspaceConfigHandler(BaseConfigHandler[dict[str, Any]]):
         update_data = {k: v for k, v in user_input.items() if v}
 
         # Handle dimensions update if present
-        if "length" in update_data and "width" in update_data and "height" in update_data:
+        if (
+            "length" in update_data
+            and "width" in update_data
+            and "height" in update_data
+        ):
             dimensions = {
                 "length": update_data.pop("length"),
                 "width": update_data.pop("width"),
@@ -371,7 +379,9 @@ class GrowspaceConfigHandler(BaseConfigHandler[dict[str, Any]]):
             }
             update_data["dimensions"] = dimensions
 
-        await coordinator.services.growspaces.update_growspace(growspace_id, **update_data)
+        await coordinator.services.growspaces.update_growspace(
+            growspace_id, **update_data
+        )
 
     async def async_step_update_growspace(
         self, user_input: dict[str, Any] | None = None
@@ -382,6 +392,8 @@ class GrowspaceConfigHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
@@ -389,7 +401,9 @@ class GrowspaceConfigHandler(BaseConfigHandler[dict[str, Any]]):
 
         if user_input is not None:
             try:
-                await coordinator.services.growspaces.update_growspace(growspace_id, user_input)
+                await coordinator.services.growspaces.update_growspace(
+                    growspace_id, **user_input
+                )
                 return await self.async_step_manage_growspaces()
             except Exception:
                 _LOGGER.exception("Error updating growspace")

--- a/custom_components/growspace_manager/config_handlers/humidifier_handler.py
+++ b/custom_components/growspace_manager/config_handlers/humidifier_handler.py
@@ -31,6 +31,8 @@ class HumidifierHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
@@ -43,7 +45,7 @@ class HumidifierHandler(BaseConfigHandler[dict[str, Any]]):
         )
 
         if user_input is not None:
-            env_config = self.flow.env_config_step1.copy()
+            env_config = dict(self.flow.env_config_step1 or {})
             env_config["humidifier_thresholds"] = parse_stage_thresholds(user_input)
 
             if env_config.get(CONF_CONFIGURE_ADVANCED):

--- a/custom_components/growspace_manager/config_handlers/irrigation_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/irrigation_config_handler.py
@@ -68,9 +68,10 @@ class IrrigationConfigHandler(BaseConfigHandler[dict[str, Any]]):
             coordinator = self.get_coordinator()
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
-        growspace = coordinator.services.growspaces.get_growspace(
-            self.flow.selected_growspace_id
-        )
+        growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
+        growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
             return self.flow.async_abort(reason="growspace_not_found")
@@ -86,9 +87,10 @@ class IrrigationConfigHandler(BaseConfigHandler[dict[str, Any]]):
             coordinator = self.get_coordinator()
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
-        growspace = coordinator.services.growspaces.get_growspace(
-            self.flow.selected_growspace_id
-        )
+        growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
+        growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if not growspace:
             return self.flow.async_abort(reason="growspace_not_found")
@@ -109,13 +111,13 @@ class IrrigationConfigHandler(BaseConfigHandler[dict[str, Any]]):
             # helpers the set_irrigation_strategy service uses, so the form and the
             # service share one write path and one validation rule (ADR-0011).
             _build_substrate_profile_update(user_input)
-            _validate_volume_mode_selection(
-                coordinator, self.flow.selected_growspace_id, user_input
-            )
+            _validate_volume_mode_selection(coordinator, growspace_id, user_input)
             await coordinator.services.growspaces.update_irrigation_config(
-                self.flow.selected_growspace_id, user_input
+                growspace_id, user_input
             )
 
+            if self.config_entry is None:
+                return self.flow.async_abort(reason="setup_error")
             # This triggers async_update_listener in __init__.py, reloading the IrrigationCoordinator
             return self.flow.async_create_entry(
                 title="",
@@ -124,9 +126,7 @@ class IrrigationConfigHandler(BaseConfigHandler[dict[str, Any]]):
             )
 
         # Describe schema to pass ALL data to the Lovelace component
-        schema = self.get_irrigation_overview_schema(
-            irrigation_options, self.flow.selected_growspace_id
-        )
+        schema = self.get_irrigation_overview_schema(irrigation_options, growspace_id)
 
         return self.flow.async_show_form(
             step_id="irrigation_overview",

--- a/custom_components/growspace_manager/config_handlers/notification_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/notification_config_handler.py
@@ -88,6 +88,8 @@ class NotificationConfigHandler(BaseConfigHandler[dict[str, Any]]):
             return self.flow.async_abort(reason="setup_error")
         coordinator = self.config_entry.runtime_data
         notification_id = self.flow.selected_notification_id
+        if notification_id is None:
+            return self.flow.async_abort(reason="notification_not_found")
         notification = next(
             (
                 n
@@ -125,6 +127,8 @@ class NotificationConfigHandler(BaseConfigHandler[dict[str, Any]]):
             return self.flow.async_abort(reason="setup_error")
         coordinator = self.config_entry.runtime_data
         notification_id = self.flow.selected_notification_id
+        if notification_id is None:
+            return self.flow.async_abort(reason="notification_not_found")
 
         if user_input is not None:
             await coordinator.services.notifications.async_remove_timed_notification(

--- a/custom_components/growspace_manager/config_handlers/plant_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/plant_config_handler.py
@@ -105,6 +105,8 @@ class PlantConfigHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         growspace_id = self.flow.selected_growspace_id
+        if growspace_id is None:
+            return self.flow.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(growspace_id)
 
         if user_input is not None:
@@ -119,6 +121,8 @@ class PlantConfigHandler(BaseConfigHandler[dict[str, Any]]):
                     veg_start=user_input.get("veg_start"),
                     flower_start=user_input.get("flower_start"),
                 )
+                if self.config_entry is None:
+                    return self.flow.async_abort(reason="setup_error")
                 return self.flow.async_create_entry(
                     title="", data=self.config_entry.options
                 )
@@ -144,6 +148,8 @@ class PlantConfigHandler(BaseConfigHandler[dict[str, Any]]):
         except AbortFlow as e:
             return self.flow.async_abort(reason=e.reason)
         plant_id = self.flow.selected_plant_id
+        if plant_id is None:
+            return self.flow.async_abort(reason="plant_not_found")
         plant = coordinator.services.plants.get_plant(plant_id)
 
         if not plant:
@@ -154,6 +160,8 @@ class PlantConfigHandler(BaseConfigHandler[dict[str, Any]]):
                 # Filter out empty values
                 update_data = {k: v for k, v in user_input.items() if v}
                 await self.async_update_plant(plant_id, **update_data)
+                if self.config_entry is None:
+                    return self.flow.async_abort(reason="setup_error")
                 return self.flow.async_create_entry(
                     title="", data=self.config_entry.options
                 )
@@ -178,7 +186,7 @@ class PlantConfigHandler(BaseConfigHandler[dict[str, Any]]):
             selector.SelectOptionDict(
                 value=p_id, label=f"{p.strain} ({p.growspace_id} R{p.row}C{p.col})"
             )
-            for p_id, p in coordinator.services.plants.items()
+            for p_id, p in coordinator.plants.items()
         ]
 
         schema_dict: dict[vol.Optional | vol.Required, Any] = {
@@ -323,6 +331,7 @@ class PlantConfigHandler(BaseConfigHandler[dict[str, Any]]):
         ]
 
         # Use autocomplete selector if we have strains, otherwise text input
+        strain_selector: selector.Selector[Any]
         if strain_options:
             strain_selector = selector.SelectSelector(
                 selector.SelectSelectorConfig(

--- a/custom_components/growspace_manager/config_handlers/strain_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/strain_config_handler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
@@ -41,10 +41,16 @@ class StrainConfigHandler(BaseConfigHandler[dict[str, Any]]):
                 self.flow.selected_strain_id = user_input.get("strain_id")
                 return await self.async_step_edit_strain()
             if action == "delete_strain":
-                try:
-                    await coordinator.services.config.strain_library.remove_strain(
-                        user_input.get("strain_id")
+                strain_id = user_input.get("strain_id")
+                strain_library = coordinator.services.config.strain_library
+                if strain_id is None or strain_library is None:
+                    return self.flow.async_show_form(
+                        step_id="manage_strain_library",
+                        data_schema=self._get_strain_library_menu_schema(coordinator),
+                        errors={"base": "delete_failed"},
                     )
+                try:
+                    await strain_library.remove_strain(strain_id)
                 except StrainReferenceError as err:
                     return self.flow.async_show_form(
                         step_id="manage_strain_library",
@@ -91,16 +97,20 @@ class StrainConfigHandler(BaseConfigHandler[dict[str, Any]]):
             else:
                 try:
                     coordinator = self.config_entry.runtime_data
-                    file_path = user_input["file_path"]
+                    strain_library = coordinator.services.config.strain_library
+                    if strain_library is None:
+                        errors["base"] = "setup_error"
+                    else:
+                        file_path = user_input["file_path"]
 
-                    await coordinator.services.config.strain_library.import_library_from_zip(
-                        file_path, merge=True
-                    )
+                        await strain_library.import_library_from_zip(
+                            file_path, merge=True
+                        )
 
-                    # Reload strains to reflect changes
-                    await coordinator.services.config.strain_library.async_load()
+                        # Reload strains to reflect changes
+                        await strain_library.load()
 
-                    return await self.async_step_manage_strain_library()
+                        return await self.async_step_manage_strain_library()
                 except FileNotFoundError:
                     errors["base"] = "file_not_found"
                 except ValueError:
@@ -132,16 +142,15 @@ class StrainConfigHandler(BaseConfigHandler[dict[str, Any]]):
         if self.config_entry is None:
             return self.flow.async_abort(reason="setup_error")
         coordinator = self.config_entry.runtime_data
+        strain_library = coordinator.services.config.strain_library
+        if strain_library is None:
+            return self.flow.async_abort(reason="setup_error")
 
         # Default export location
         export_dir = self.flow.hass.config.path("exports")
 
         try:
-            zip_path = (
-                await coordinator.services.config.strain_library.export_library_to_zip(
-                    export_dir
-                )
-            )
+            zip_path = await strain_library.export_library_to_zip(export_dir)
             return self.flow.async_show_form(
                 step_id="export_strain_library",
                 description_placeholders={"path": zip_path},
@@ -211,21 +220,24 @@ class StrainConfigHandler(BaseConfigHandler[dict[str, Any]]):
         if self.config_entry is None:
             return self.flow.async_abort(reason="setup_error")
         coordinator = self.config_entry.runtime_data
+        strain_library = coordinator.services.config.strain_library
 
         if user_input is not None:
-            await coordinator.services.config.strain_library.async_add_strain(
-                name=user_input["strain"],
+            if strain_library is None:
+                return self.flow.async_abort(reason="setup_error")
+            await strain_library.add_strain(
+                strain=user_input["strain"],
                 breeder=user_input.get("breeder"),
                 strain_type=user_input.get("type"),
                 sex=user_input.get("sex"),
                 description=user_input.get("description"),
-                flowering_days=user_input.get("flower_days_max"),
+                flower_days_max=user_input.get("flower_days_max"),
             )
             return await self.async_step_manage_strain_library()
 
         return self.flow.async_show_form(
             step_id="add_strain",
-            data_schema=ADD_STRAIN_SCHEMA,
+            data_schema=cast("vol.Schema", ADD_STRAIN_SCHEMA),
         )
 
     async def async_step_edit_strain(
@@ -237,7 +249,7 @@ class StrainConfigHandler(BaseConfigHandler[dict[str, Any]]):
 
         return self.flow.async_show_form(
             step_id="edit_strain",
-            data_schema=ADD_STRAIN_SCHEMA,
+            data_schema=cast("vol.Schema", ADD_STRAIN_SCHEMA),
         )
 
     async def async_step_manage_breeder_blacklist(

--- a/tests/config/test_config_flow.py
+++ b/tests/config/test_config_flow.py
@@ -92,7 +92,7 @@ def mock_coordinator(hass: HomeAssistant, tmp_path: Path):
     # --- config sub-facade ---
     cfg_facade = MagicMock()
     cfg_facade.strain_library = MagicMock()
-    cfg_facade.strain_library.async_load = AsyncMock()
+    cfg_facade.strain_library.load = AsyncMock()
     cfg_facade.strain_library.import_library_from_zip = AsyncMock()
     cfg_facade.strain_library.export_library_to_zip = AsyncMock(
         return_value=str(tmp_path / "export.zip")
@@ -2442,7 +2442,7 @@ async def test_options_flow_add_strain_success(
     config_entry.add_to_hass(hass)
     config_entry.runtime_data = mock_coordinator
     config_entry.runtime_data = mock_coordinator
-    mock_coordinator.services.config.strain_library.async_add_strain = AsyncMock()
+    mock_coordinator.services.config.strain_library.add_strain = AsyncMock()
 
     flow = OptionsFlowHandler(config_entry)
     flow.hass = hass
@@ -2456,7 +2456,7 @@ async def test_options_flow_add_strain_success(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "manage_strain_library"
-    mock_coordinator.services.config.strain_library.async_add_strain.assert_called_once()
+    mock_coordinator.services.config.strain_library.add_strain.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -2607,7 +2607,7 @@ async def test_options_flow_import_strain_library_submit(
     config_entry.add_to_hass(hass)
 
     config_entry.runtime_data = mock_coordinator
-    mock_coordinator.services.config.strain_library.async_load = AsyncMock()
+    mock_coordinator.services.config.strain_library.load = AsyncMock()
     mock_coordinator.services.config.strain_library.import_library_from_zip = (
         AsyncMock()
     )

--- a/tests/config/test_config_flow_import_export.py
+++ b/tests/config/test_config_flow_import_export.py
@@ -23,7 +23,7 @@ def mock_coordinator(hass: HomeAssistant, tmp_path: Path):
     # Strain library in config sub-facade
     strain_lib = MagicMock()
     strain_lib.get_all.return_value = {"strain1": {}}
-    strain_lib.async_load = AsyncMock()
+    strain_lib.load = AsyncMock()
     strain_lib.get_all_strains.return_value = []
     strain_lib.import_library_from_zip = AsyncMock()
     strain_lib.export_library_to_zip = AsyncMock()
@@ -86,7 +86,7 @@ async def test_import_strain_library_success(
         assert result.get("step_id") == "manage_strain_library"
 
         mock_coordinator.services.config.strain_library.import_library_from_zip.assert_awaited_once()
-        mock_coordinator.services.config.strain_library.async_load.assert_awaited_once()
+        mock_coordinator.services.config.strain_library.load.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -99,9 +99,7 @@ async def test_import_strain_library_file_not_found(
     config_entry.runtime_data = MagicMock()
     config_entry.runtime_data = mock_coordinator
 
-    mock_coordinator.services.config.strain_library.import_library_from_zip.side_effect = (
-        FileNotFoundError
-    )
+    mock_coordinator.services.config.strain_library.import_library_from_zip.side_effect = FileNotFoundError
 
     flow = OptionsFlowHandler(config_entry)
     flow.hass = hass

--- a/tests/config/test_options_flow.py
+++ b/tests/config/test_options_flow.py
@@ -237,7 +237,9 @@ async def test_options_flow_manage_growspaces_remove_error(
 ) -> None:
     """Test error handling when removing growspace."""
     # Given
-    mock_coordinator.services.growspaces.remove_growspace.side_effect = Exception("Test error")
+    mock_coordinator.services.growspaces.remove_growspace.side_effect = Exception(
+        "Test error"
+    )
     mock_coordinator.growspaces = {"gs1": Mock(name="Test Growspace")}
     config_entry = await setup_test_environment(hass, mock_coordinator)
 
@@ -373,7 +375,9 @@ async def test_options_flow_add_growspace_error(
 ) -> None:
     """Test error handling when adding growspace."""
     # Given
-    mock_coordinator.services.growspaces.add_growspace.side_effect = Exception("Test error")
+    mock_coordinator.services.growspaces.add_growspace.side_effect = Exception(
+        "Test error"
+    )
     config_entry = await setup_test_environment(hass, mock_coordinator)
     hass.services = Mock()
     hass.services.async_services = Mock(return_value={"notify": {}})
@@ -446,7 +450,7 @@ async def test_options_flow_update_growspace_success(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "manage_growspaces"
     mock_coordinator.services.growspaces.update_growspace.assert_called_once_with(
-        "gs1", {"name": "New Name", "rows": 5}
+        "gs1", name="New Name", rows=5
     )
 
 
@@ -481,7 +485,9 @@ async def test_options_flow_update_growspace_error(
     mock_growspace.plants_per_row = 4
     mock_growspace.notification_target = None
     mock_coordinator.growspaces = {"gs1": mock_growspace}
-    mock_coordinator.services.growspaces.update_growspace.side_effect = Exception("Test error")
+    mock_coordinator.services.growspaces.update_growspace.side_effect = Exception(
+        "Test error"
+    )
     config_entry = await setup_test_environment(hass, mock_coordinator)
     hass.services = Mock()
     hass.services.async_services = Mock(return_value={"notify": {}})
@@ -531,7 +537,10 @@ async def test_options_flow_manage_plants_add(
     mock_coordinator.services.growspaces.get_sorted_growspace_options.return_value = [
         ("test_grow", "Test Growspace")
     ]
-    mock_coordinator.services.config.get_strain_options.return_value = ["Strain A", "Strain B"]
+    mock_coordinator.services.config.get_strain_options.return_value = [
+        "Strain A",
+        "Strain B",
+    ]
     config_entry = await setup_test_environment(hass, mock_coordinator)
     config_entry.runtime_data.store = mock_store
 
@@ -555,7 +564,10 @@ async def test_options_flow_manage_plants_update(
     """Test update plant action."""
     # Given
     mock_coordinator.growspaces = {"test_grow": Mock(name="Test Growspace")}
-    mock_coordinator.services.config.get_strain_options.return_value = ["Strain A", "Strain B"]
+    mock_coordinator.services.config.get_strain_options.return_value = [
+        "Strain A",
+        "Strain B",
+    ]
     config_entry = await setup_test_environment(hass, mock_coordinator)
     config_entry.runtime_data.store = mock_store
 

--- a/tests/integration/test_config_handlers_coverage.py
+++ b/tests/integration/test_config_handlers_coverage.py
@@ -371,7 +371,9 @@ async def test_plant_handler_async_operations(mock_hass, mock_config_entry) -> N
 
     # Harvest
     await handler.async_harvest_plant("p1", 50.0)
-    coordinator.services.plants.transition_plant.assert_awaited_with("p1", wet_weight=50.0)
+    coordinator.services.plants.transition_plant.assert_awaited_with(
+        "p1", wet_weight=50.0
+    )
 
     # Destroy
     await handler.async_destroy_plant("p1")
@@ -572,9 +574,8 @@ async def test_growspace_handler_flow_update_step(mock_hass, mock_config_entry) 
 
     await handler.async_step_update_growspace(user_input)
 
-    # FIX: Matches the actual call signature (id, dict_of_input)
     coordinator.services.growspaces.update_growspace.assert_awaited_with(
-        "gs1", user_input
+        "gs1", **user_input
     )
 
 

--- a/tests/integration/test_strain_config_handler_coverage.py
+++ b/tests/integration/test_strain_config_handler_coverage.py
@@ -44,8 +44,8 @@ def mock_coordinator():
     strain_service.remove_strain = AsyncMock()
     strain_service.import_library_from_zip = AsyncMock()
     strain_service.export_library_to_zip = AsyncMock()
-    strain_service.async_add_strain = AsyncMock()
-    strain_service.async_load = AsyncMock()
+    strain_service.add_strain = AsyncMock()
+    strain_service.load = AsyncMock()
 
     # Default data returns
     strain_service.get_all.return_value = {}
@@ -370,7 +370,7 @@ async def test_async_step_add_strain_success(handler: StrainConfigHandler) -> No
     }
     result = await handler.async_step_add_strain(user_input)
     assert result["type"] == FlowResultType.FORM
-    strain_service.async_add_strain.assert_awaited_once()
+    strain_service.add_strain.assert_awaited_once()
 
 
 async def test_async_step_add_strain_no_entry(mock_hass: MagicMock) -> None:


### PR DESCRIPTION
## Summary

- Narrows the `str | None` / `dict | None` values (`selected_growspace_id`, `selected_plant_id`, `env_config_step1`, `ConfigEntry`) that were flowing unguarded into facade calls across `config_handlers/*.py`, following the abort-on-None pattern already used throughout these handlers.
- Fixes a couple of `TypedDict`/overload issues from building trend-analysis and `device_class` selector configs off heterogeneous dict literals.
- Fixes two real bugs the narrowing uncovered: `strain_config_handler.py` was calling `strain_library.async_add_strain()`/`async_load()` (methods that don't exist — real names are `add_strain()`/`load()`), and `growspace_config_handler.py` was passing `update_growspace()` an extra positional dict when it only accepts `**kwargs`. Both would raise at runtime; both were masked by test mocks using the same wrong names/shape, so the tests passed despite the bugs. Updated the call sites and the mocks.

## Scope note

`mypy custom_components/growspace_manager/config_handlers` now reports **zero errors originating in files under that path**. Because `follow_imports = normal`, the same invocation still walks into `config_flow.py`, `coordinator.py`, and everything they transitively import, so it continues to report the pre-existing whole-codebase baseline in files outside `config_handlers/` (197 errors repo-wide now, down from 269 — none introduced by this change, tracked separately per ADR-0020).

Fixes #604

## Test plan

- [x] `../../.venv/bin/mypy custom_components/growspace_manager/config_handlers` — zero errors under `config_handlers/`
- [x] `../../.venv/bin/pytest tests/ -q` — 5092 passed
- [x] `../../.venv/bin/ruff check` / `ruff format --check` on changed files
- [x] `prek run --files <changed>` — all hooks pass except the repo-wide `mypy` hook (pre-existing baseline, skipped per #612/#613 precedent)