### PR TITLE
mypy: fix remaining errors in services/ (excluding seedfinder_scraper.py)

### DIFF
--- a/custom_components/growspace_manager/managers/plant.py
+++ b/custom_components/growspace_manager/managers/plant.py
@@ -1044,9 +1044,14 @@ class PlantManager(BaseService):
         await self.transition_plant_stage(plant_id, PlantStage.FLOWER)
         return self.repository.require_plant(plant_id)
 
-    async def start_drying(self, plant_id: str) -> Plant:
+    async def start_drying(
+        self, plant_id: str, transition_date: DateInput = None
+    ) -> Plant:
         """Transition a plant to the 'drying' stage, starting now."""
-        await self.transition_plant_stage(plant_id, PlantStage.DRY)
+        if transition_date is None:
+            await self.transition_plant_stage(plant_id, PlantStage.DRY)
+        else:
+            await self.transition_plant_stage(plant_id, PlantStage.DRY, transition_date)
         return self.repository.require_plant(plant_id)
 
     async def start_curing(self, plant_id: str) -> Plant:
@@ -1054,9 +1059,9 @@ class PlantManager(BaseService):
         await self.transition_plant_stage(plant_id, PlantStage.CURE)
         return self.repository.require_plant(plant_id)
 
-    async def harvest(self, plant_id: str) -> Plant:
+    async def harvest(self, plant_id: str, transition_date: DateInput = None) -> Plant:
         """Quick harvest."""
-        return await self.start_drying(plant_id)
+        return await self.start_drying(plant_id, transition_date)
 
     async def promote_clone(
         self,

--- a/custom_components/growspace_manager/services/_definition.py
+++ b/custom_components/growspace_manager/services/_definition.py
@@ -6,10 +6,9 @@ from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any
 
-import voluptuous as vol
-
 from custom_components.growspace_manager.const import GrowspaceService
 from homeassistant.core import SupportsResponse
+from homeassistant.helpers.typing import VolSchemaType
 
 
 @dataclass
@@ -18,6 +17,6 @@ class ServiceDefinition:
 
     name: GrowspaceService
     handler: Callable[..., Coroutine[Any, Any, Any]]
-    schema: vol.Schema | None = None
+    schema: VolSchemaType | None = None
     needs_strain_lib: bool = False
     supports_response: SupportsResponse | None = None

--- a/custom_components/growspace_manager/services/ec_ramp.py
+++ b/custom_components/growspace_manager/services/ec_ramp.py
@@ -52,7 +52,9 @@ async def handle_save_ec_ramp_curve(
         curve_id=curve_id,
     )
 
-    _LOGGER.info("Saved EC ramp curve '%s' for stage %s with %d points", name, stage, len(points))
+    _LOGGER.info(
+        "Saved EC ramp curve '%s' for stage %s with %d points", name, stage, len(points)
+    )
 
 
 @handle_service_errors
@@ -70,7 +72,9 @@ async def handle_remove_ec_ramp_curve(
     """
     curve_id: str = call.data[ATTR_CURVE_ID]
 
-    await coordinator.services.config.remove_ec_ramp_curve(curve_id=curve_id)
+    await coordinator.services.config.remove_ec_ramp_curve(
+        growspace_id=None, curve_id=curve_id
+    )
 
     _LOGGER.info("Removed EC ramp curve %s", curve_id)
 

--- a/custom_components/growspace_manager/services/plant_facade.py
+++ b/custom_components/growspace_manager/services/plant_facade.py
@@ -342,7 +342,7 @@ class PlantFacade:
 
     async def apply_ipm(
         self,
-        preset_id: str | None = None,
+        preset_id: str,
         growspace_id: str | None = None,
         plant_ids: list[str] | None = None,
         notes: str | None = None,

--- a/custom_components/growspace_manager/services/report.py
+++ b/custom_components/growspace_manager/services/report.py
@@ -65,8 +65,10 @@ async def handle_export_grow_report(
     try:
         report_data: dict[str, Any]
         if plant_id:
+            assert plant is not None
             report_data = await _aggregate_plant_data(hass, coordinator, plant)
         else:
+            assert growspace_id is not None
             report_data = await _aggregate_growspace_data(
                 hass, coordinator, growspace_id
             )
@@ -269,12 +271,17 @@ async def _get_plant_environmental_stats(
             s_start = dt_util.as_utc(parsed_start)
 
             s_end = end_time
-            if stage.get("end"):
-                parsed_end = dt_util.parse_datetime(stage["end"])
+            stage_end = stage.get("end")
+            if stage_end:
+                parsed_end = dt_util.parse_datetime(stage_end)
                 if parsed_end:
                     s_end = dt_util.as_utc(parsed_end)
 
-            stage_stats = {"temperature": None, "humidity": None, "vpd": None}
+            stage_stats: dict[str, float | None] = {
+                "temperature": None,
+                "humidity": None,
+                "vpd": None,
+            }
 
             # Map sensors to keys
             sensor_map = {

--- a/custom_components/growspace_manager/services/strain_library.py
+++ b/custom_components/growspace_manager/services/strain_library.py
@@ -84,7 +84,7 @@ def _downscale_logo_if_needed(logo_data: str | None) -> str | None:
         image_data = base64.b64decode(encoded)
 
         # Load image
-        img = Image.open(BytesIO(image_data))
+        img: Image.Image = Image.open(BytesIO(image_data))
 
         # Size constraint for Niimbot print label (100x100)
         img.thumbnail((100, 100))
@@ -209,7 +209,7 @@ async def handle_import_strain_library(
                 temp_file_path = tmp.name
                 file_path = tmp.name  # Use this temp path for import
 
-        except (binascii.Error, OSError):
+        except binascii.Error, OSError:
             _LOGGER.exception("Failed to process uploaded zip file")
             create_notification(
                 hass, "Failed to process uploaded file.", title="Import Error"
@@ -481,7 +481,7 @@ async def handle_print_label(
     coordinator: GrowspaceCoordinator,
     strain_library: StrainLibrary,
     call: ServiceCall,
-) -> None:
+) -> dict[str, Any] | None:
     """Handle the print_label service call."""
     plant_id = call.data.get("plant_id")
     device_id = call.data.get("device_id")
@@ -532,7 +532,7 @@ async def handle_print_label(
     breeder_logo = breeder_logo or strain_meta.get(ATTR_BREEDER_LOGO)
 
     # Construct Niimbot payload based on the "Perfect Label" mockup
-    payload = []
+    payload: list[dict[str, Any]] = []
 
     # 1. Main Header: Strain Name (Large and Bold)
     payload.append(
@@ -564,7 +564,11 @@ async def handle_print_label(
 
     # 3. Multiline Info (Pheno, Breeder, Lineage) — each line respects its field flag
     info_lines = []
-    if fields.get("phenotype", True) and phenotype_name and phenotype_name not in ("-", "–"):
+    if (
+        fields.get("phenotype", True)
+        and phenotype_name
+        and phenotype_name not in ("-", "–")
+    ):
         info_lines.append(phenotype_name)
     if fields.get("breeder", True) and breeder and breeder not in ("-", "–"):
         info_lines.append(breeder)

--- a/custom_components/growspace_manager/services/utils.py
+++ b/custom_components/growspace_manager/services/utils.py
@@ -26,7 +26,9 @@ WS_ERR_INTERNAL_ERROR = "internal_error"
 WS_ERR_RATE_LIMITED = "rate_limited"
 
 
-def get_validated_coordinator(config_entry: ConfigEntry) -> GrowspaceCoordinator:
+def get_validated_coordinator(
+    config_entry: ConfigEntry[GrowspaceCoordinator],
+) -> GrowspaceCoordinator:
     """Get and validate coordinator from config entry.
 
     Args:
@@ -98,7 +100,7 @@ def invalidates_cache(growspace_id_kwarg: str = "growspace_id") -> Callable[...,
             if growspace_id:
                 try:
                     coordinator: GrowspaceCoordinator = args[0]
-                    coordinator.cache.pop(growspace_id, None)
+                    coordinator.cache.invalidate(growspace_id)
                 except AttributeError, IndexError:
                     pass
             return result

--- a/tests/services/test_ec_ramp.py
+++ b/tests/services/test_ec_ramp.py
@@ -79,5 +79,6 @@ async def test_handle_remove_ec_ramp_curve(coordinator) -> None:
     await handle_remove_ec_ramp_curve(MagicMock(), coordinator, call)
 
     coordinator.services.config.remove_ec_ramp_curve.assert_awaited_once_with(
+        growspace_id=None,
         curve_id="curve-xyz-456",
     )

--- a/tests/services/test_service_utils.py
+++ b/tests/services/test_service_utils.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.growspace_manager.cache.cache_manager import CacheManager
 from custom_components.growspace_manager.exceptions import GrowspaceError
 from custom_components.growspace_manager.services.utils import (
     get_validated_coordinator,
@@ -86,7 +87,8 @@ async def test_handle_service_errors_generic_exception(
 async def test_invalidates_cache_kwarg() -> None:
     """Test invalidates_cache with growspace_id in kwargs."""
     mock_coordinator = MagicMock()
-    mock_coordinator.cache = {"growspace_1": "data"}
+    mock_coordinator.cache = CacheManager()
+    mock_coordinator.cache.set("growspace_1", {"data": "data"})
 
     @invalidates_cache()
     async def mock_mutation(coordinator: Any, growspace_id: str | None = None) -> str:
@@ -100,7 +102,8 @@ async def test_invalidates_cache_kwarg() -> None:
 async def test_invalidates_cache_args_dict() -> None:
     """Test invalidates_cache with growspace_id in args[1] dictionary."""
     mock_coordinator = MagicMock()
-    mock_coordinator.cache = {"growspace_1": "data"}
+    mock_coordinator.cache = CacheManager()
+    mock_coordinator.cache.set("growspace_1", {"data": "data"})
 
     @invalidates_cache()
     async def mock_mutation(coordinator: Any, call_data: dict[str, Any]) -> str:
@@ -114,7 +117,8 @@ async def test_invalidates_cache_args_dict() -> None:
 async def test_invalidates_cache_custom_kwarg() -> None:
     """Test invalidates_cache with a custom kwarg name."""
     mock_coordinator = MagicMock()
-    mock_coordinator.cache = {"growspace_1": "data"}
+    mock_coordinator.cache = CacheManager()
+    mock_coordinator.cache.set("growspace_1", {"data": "data"})
 
     @invalidates_cache("custom_id")
     async def mock_mutation(coordinator: Any, custom_id: str | None = None) -> str:
@@ -128,7 +132,8 @@ async def test_invalidates_cache_custom_kwarg() -> None:
 async def test_invalidates_cache_missing_id() -> None:
     """Test invalidates_cache when no growspace_id is provided."""
     mock_coordinator = MagicMock()
-    mock_coordinator.cache = {"growspace_1": "data"}
+    mock_coordinator.cache = CacheManager()
+    mock_coordinator.cache.set("growspace_1", {"data": "data"})
 
     @invalidates_cache()
     async def mock_mutation(coordinator: Any) -> str:


### PR DESCRIPTION
## Summary

Fixes the remaining mypy errors in `strain_library.py`, `report.py`, `plant_facade.py`, `utils.py`, `irrigation.py`, `growspace_facade.py`, and `ec_ramp.py` under `services/`, per #606 (blocked by #603, which is merged).

Most fixes are type narrowing:
- `Image.Image` annotation for the PIL image variable in `strain_library.py` so `.convert()`/reassignment stays typed correctly.
- `ServiceDefinition.schema` widened from `vol.Schema | None` to `VolSchemaType` (`vol.Schema | vol.All | vol.Any`), matching HA core's real `async_register(schema: VolSchemaType | None)` contract — `vol.All`-wrapped schemas (with validators like `_validate_genetic_percentages`) were never actually assignable to the old annotation.
- `dict`/`TypedDict` key access narrowing in `report.py` (`assert` after a prior None-check the two-branch structure obscured from mypy, capturing `stage.get("end")` into a local instead of re-indexing, typing `stage_stats` as `dict[str, float | None]`).
- `get_validated_coordinator` now takes `ConfigEntry[GrowspaceCoordinator]` instead of unparameterized `ConfigEntry`.

Three real bugs turned up during the narrowing and are fixed at the root rather than papered over:

- **`services/utils.py`**: `invalidates_cache` called `coordinator.cache.pop(growspace_id, None)`, but `coordinator.cache` is a `CacheManager`, which has no `pop` — every other call site in the codebase uses `cache.invalidate(growspace_id)`. The decorator's `except AttributeError` was silently swallowing this every time, so cache invalidation after a mutation never actually ran.
- **`managers/plant.py`**: `PlantManager.harvest()` took no `transition_date`, so `_async_auto_harvest`'s explicit `transition_date=today` was silently dropped and every auto-harvest was stamped with `now()` instead of the intended date. Threaded `transition_date` through `harvest()` → `start_drying()` → `transition_plant_stage()`, keeping the no-arg call shape when `None` (preserves the ADR-0013 "no explicit date" convenience-method contract asserted in `test_convenience_methods`).
- **`services/config_facade.py`**: `remove_ec_ramp_curve(growspace_id: str | None, curve_id: str)` had `growspace_id` required-but-unused (the body ignores it) while its only real caller never had a `growspace_id` to pass (the service schema doesn't collect one). Fixed the call site in `ec_ramp.py` to pass `growspace_id=None` explicitly, matching the sibling `save_ec_ramp_curve`'s already-optional pattern, rather than fabricating a value.

Also widened `PlantFacade.apply_ipm`'s `preset_id` from `str | None = None` to a required `str` — every call site (the schema-validated service call and all test callers) already supplies it; `IPMService.async_apply_ipm` requires it.

## Test plan

- [x] `../../.venv/bin/mypy custom_components/growspace_manager/services/{strain_library,report,plant_facade,utils,irrigation,growspace_facade,ec_ramp}.py` — zero errors originating in these 7 files (acceptance criteria)
- [x] `../../.venv/bin/pytest tests/ -q` — 5092 passed
- [x] `../../.venv/bin/ruff check` / `ruff format --check` on changed files — clean
- [x] `prek run --files <changed>` — all hooks pass except the repo-wide `mypy` hook (pre-existing baseline outside these 7 files — CI's own mypy job is `continue-on-error: true` per ADR-0020 while that's burned down; skipped per #612/#613/#614 precedent)

Fixes #606