### PR TITLE
mypy: fix remaining errors in sensor/

### DIFF
--- a/custom_components/growspace_manager/sensor/_setup.py
+++ b/custom_components/growspace_manager/sensor/_setup.py
@@ -78,12 +78,7 @@ async def _async_create_derivative_sensors(
     }
 
     def get_val(key: str, default: Any = None) -> Any:
-        try:
-            if isinstance(growspace.environment_config, dict):
-                return growspace.environment_config.get(key, default)
-            return getattr(growspace.environment_config, key, default)
-        except AttributeError:
-            return default
+        return getattr(growspace.environment_config, key, default)
 
     for sensor_type, (singular_key, plural_key) in metric_map.items():
         raw_sensors = get_val(plural_key, [])
@@ -203,7 +198,11 @@ async def async_setup_entry(
                 calculated_subarea_vpd_ids,
             )
             await _update_plant_entities(
-                hass, coordinator, plant_entities, async_add_entities, initialized_drying_sensor_ids
+                hass,
+                coordinator,
+                plant_entities,
+                async_add_entities,
+                initialized_drying_sensor_ids,
             )
 
     def _listener_callback() -> None:
@@ -238,14 +237,16 @@ async def _create_initial_entities(
         vpd_entities = _check_calculated_vpd_sensor(coordinator, growspace)
         for vpd_entity in vpd_entities:
             initial_entities.append(vpd_entity)
-            calculated_vpd_growspace_ids.add(vpd_entity.unique_id)
+            if vpd_entity.unique_id:
+                calculated_vpd_growspace_ids.add(vpd_entity.unique_id)
 
         subarea_vpd_entities = _check_subarea_calculated_vpd_sensors(
             coordinator, growspace
         )
         for vpd_entity in subarea_vpd_entities:
             initial_entities.append(vpd_entity)
-            calculated_subarea_vpd_ids.add(vpd_entity.unique_id)
+            if vpd_entity.unique_id:
+                calculated_subarea_vpd_ids.add(vpd_entity.unique_id)
 
         env_config = getattr(growspace, "environment_config", None)
         if env_config:
@@ -378,7 +379,8 @@ async def _update_growspace_entities(
         if new_calculated_vpds:
             async_add_entities(new_calculated_vpds)
             for v in new_calculated_vpds:
-                calculated_vpd_growspace_ids.add(v.unique_id)
+                if v.unique_id:
+                    calculated_vpd_growspace_ids.add(v.unique_id)
             coordinator.config_entry.async_create_background_task(
                 hass, coordinator.async_request_refresh(), "coordinator_refresh"
             )
@@ -394,7 +396,8 @@ async def _update_growspace_entities(
         if new_subarea_vpds:
             async_add_entities(new_subarea_vpds)
             for v in new_subarea_vpds:
-                calculated_subarea_vpd_ids.add(v.unique_id)
+                if v.unique_id:
+                    calculated_subarea_vpd_ids.add(v.unique_id)
 
     for removed_gs_id in list(growspace_entities.keys()):
         if removed_gs_id not in coordinator.growspaces:
@@ -412,13 +415,16 @@ async def _update_plant_entities(
     initialized_drying_sensor_ids: set[str],
 ) -> None:
     """Update plant entities based on coordinator data."""
-    new_entities = []
+    new_entities: list[Entity] = []
     for plant_id, plant in coordinator.plants.items():
         if plant_id not in plant_entities:
             pe = PlantEntity(coordinator, plant)
             plant_entities[plant_id] = pe
             new_entities.append(pe)
-        if plant.dry_start is not None and plant_id not in initialized_drying_sensor_ids:
+        if (
+            plant.dry_start is not None
+            and plant_id not in initialized_drying_sensor_ids
+        ):
             new_entities.append(DryingWeightSensor(coordinator, plant))
             new_entities.append(DryingMoistureSensor(coordinator, plant))
             initialized_drying_sensor_ids.add(plant_id)
@@ -445,12 +451,7 @@ def _check_calculated_vpd_sensor(
         return []
 
     def get_val(key: str, default: Any = None) -> Any:
-        try:
-            if isinstance(env_config, dict):
-                return env_config.get(key, default)
-            return getattr(env_config, key, default)
-        except AttributeError:
-            return default
+        return getattr(env_config, key, default)
 
     temp_sensors = get_val("temperature_sensors", [])
     hum_sensors = get_val("humidity_sensors", [])
@@ -523,9 +524,13 @@ def _check_subarea_calculated_vpd_sensors(
         hum_sensors = _get_env_config_val(env_config, "humidity_sensors", [])
         vpd_sensors = _get_env_config_val(env_config, "vpd_sensors", [])
 
-        if not temp_sensors and (ts := _get_env_config_val(env_config, "temperature_sensor")):
+        if not temp_sensors and (
+            ts := _get_env_config_val(env_config, "temperature_sensor")
+        ):
             temp_sensors = [ts]
-        if not hum_sensors and (hs := _get_env_config_val(env_config, "humidity_sensor")):
+        if not hum_sensors and (
+            hs := _get_env_config_val(env_config, "humidity_sensor")
+        ):
             hum_sensors = [hs]
         if not vpd_sensors and (vs := _get_env_config_val(env_config, "vpd_sensor")):
             vpd_sensors = [vs]

--- a/custom_components/growspace_manager/sensor/overview.py
+++ b/custom_components/growspace_manager/sensor/overview.py
@@ -12,7 +12,7 @@ from custom_components.growspace_manager.utils import (
 )
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import EntityCategory
-from homeassistant.core import Event
+from homeassistant.core import Event, EventStateChangedData
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -97,7 +97,7 @@ class GrowspaceOverviewSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEnt
 
         return sensors
 
-    async def _handle_sensor_update(self, event: Event) -> None:
+    async def _handle_sensor_update(self, event: Event[EventStateChangedData]) -> None:
         """Handle updates from tracked environment sensors."""
         await self.coordinator.async_refresh_growspace_data(self.growspace_id)
         self.async_write_ha_state()

--- a/custom_components/growspace_manager/sensor/strain.py
+++ b/custom_components/growspace_manager/sensor/strain.py
@@ -52,7 +52,10 @@ class StrainLibrarySensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity)
     @override
     def native_value(self) -> int:
         """Return the number of catalogued strains in the library."""
-        strains = self.coordinator.services.config.strain_library.get_all()
+        strain_library = self.coordinator.services.config.strain_library
+        if strain_library is None:
+            return 0
+        strains = strain_library.get_all()
         catalogued_count, _, _ = self._strain_counts(strains)
         return catalogued_count
 
@@ -60,8 +63,11 @@ class StrainLibrarySensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity)
     @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return strain analytics as state attributes."""
-        analytics = self.coordinator.services.config.strain_library.get_analytics()
-        strains = self.coordinator.services.config.strain_library.get_all()
+        strain_library = self.coordinator.services.config.strain_library
+        if strain_library is None:
+            return {}
+        analytics = strain_library.get_analytics()
+        strains = strain_library.get_all()
         catalogued_count, ancestor_count, total_count = self._strain_counts(strains)
         catalogued_strains = {
             name

--- a/custom_components/growspace_manager/sensor/tank.py
+++ b/custom_components/growspace_manager/sensor/tank.py
@@ -7,6 +7,10 @@ from typing import Any
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from custom_components.growspace_manager.models import Growspace
+from custom_components.growspace_manager.tank_depletion_predictor import (
+    TankDepletionPredictor,
+)
+from custom_components.growspace_manager.tank_water_tracker import TankWaterTracker
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -17,7 +21,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 
-class TankDepletionSensor(CoordinatorEntity, SensorEntity):
+class TankDepletionSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """Sensor predicting time until tank needs refill.
 
     Uses sliding window linear regression to predict when an irrigation tank
@@ -35,7 +39,7 @@ class TankDepletionSensor(CoordinatorEntity, SensorEntity):
         coordinator: GrowspaceCoordinator,
         growspace_id: str,
         tank_name: str,
-        predictor: Any,  # TankDepletionPredictor
+        predictor: TankDepletionPredictor,
     ) -> None:
         """Initialize the tank depletion sensor."""
         super().__init__(coordinator)
@@ -45,10 +49,10 @@ class TankDepletionSensor(CoordinatorEntity, SensorEntity):
         self._attr_name = f"Tank Depletion {tank_name}"
         self._attr_unique_id = f"{DOMAIN}_{growspace_id}_tank_depletion_{tank_name}"
 
-        growspace = coordinator.growspaces.get(growspace_id, {})
+        growspace = coordinator.growspaces.get(growspace_id)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, growspace_id)},
-            name=getattr(growspace, "name", growspace_id),
+            name=growspace.name if growspace else growspace_id,
             model="Growspace",
             manufacturer="Growspace Manager",
         )
@@ -130,7 +134,7 @@ def _should_create_derived_water_sensor(
     )
 
 
-class TankDerivedWaterSensor(CoordinatorEntity, SensorEntity):
+class TankDerivedWaterSensor(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
     """Sensor reporting water consumption inferred from tank level changes.
 
     Used as a fallback when no dedicated irrigation flow or drain volume
@@ -159,7 +163,7 @@ class TankDerivedWaterSensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = f"{DOMAIN}_{growspace_id}_tank_derived_water_{tank_slug}"
 
     @property
-    def _tracker(self) -> Any:
+    def _tracker(self) -> TankWaterTracker | None:
         """Return the TankWaterTracker for this tank, or None."""
         return self.coordinator.services.growspaces.get_tank_tracker(
             self._growspace_id, self._tank.sensor_entity

--- a/custom_components/growspace_manager/sensor/vpd.py
+++ b/custom_components/growspace_manager/sensor/vpd.py
@@ -13,7 +13,7 @@ from custom_components.growspace_manager.utils import (
     generate_vpd_sensor_unique_id,
 )
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
-from homeassistant.core import Event
+from homeassistant.core import Event, EventStateChangedData
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.event import async_track_state_change_event
 
@@ -34,7 +34,7 @@ class BaseVpdSensor(SensorEntity):
                 )
             )
 
-    async def _handle_source_update(self, event: Event) -> None:
+    async def _handle_source_update(self, event: Event[EventStateChangedData]) -> None:
         """Handle updates from source sensors."""
         self.async_write_ha_state()
 

--- a/tests/components/test_sensor_coverage.py
+++ b/tests/components/test_sensor_coverage.py
@@ -12,7 +12,6 @@ from custom_components.growspace_manager.sensor import (
     ECTargetSensor,
     GrowspaceListSensor,
     _async_create_derivative_sensors,
-    _check_calculated_vpd_sensor,
     _check_subarea_calculated_vpd_sensors,
     _create_initial_entities,
     _get_env_config_val,
@@ -55,18 +54,24 @@ async def test_async_create_derivative_sensors_skips_none() -> None:
     growspace.id = "gs_test"
     growspace.name = "Test GS"
     # Provide a list with None to trigger Line 116
-    growspace.environment_config = {
-        "temperature_sensors": [None, "sensor.valid_temp"],
-        "humidity_sensors": [],
-        "vpd_sensors": [],
-    }
+    growspace.environment_config = Mock(
+        temperature_sensors=[None, "sensor.valid_temp"],
+        humidity_sensors=[],
+        vpd_sensors=[],
+        temperature_sensor=None,
+        humidity_sensor=None,
+        vpd_sensor=None,
+    )
 
-    with patch(
-        "custom_components.growspace_manager.sensor._setup.async_setup_trend_sensor",
-        new_callable=AsyncMock,
-    ) as mock_trend, patch(
-        "custom_components.growspace_manager.sensor._setup.async_setup_statistics_sensor",
-        new_callable=AsyncMock,
+    with (
+        patch(
+            "custom_components.growspace_manager.sensor._setup.async_setup_trend_sensor",
+            new_callable=AsyncMock,
+        ) as mock_trend,
+        patch(
+            "custom_components.growspace_manager.sensor._setup.async_setup_statistics_sensor",
+            new_callable=AsyncMock,
+        ),
     ):
         await _async_create_derivative_sensors(hass, config_entry, growspace)
 
@@ -96,74 +101,6 @@ def test_growspace_list_sensor_native_value(
 
     # native_value should call _update_growspaces and return 2
     assert sensor.native_value == 2
-
-
-@pytest.mark.asyncio
-async def test_get_val_attribute_error_derivative_sensors() -> None:
-    """Test AttributeError fallback in _async_create_derivative_sensors get_val helper (Lines 116-117)."""
-    hass = MagicMock()
-    config_entry = Mock()
-    config_entry.runtime_data = Mock()
-    config_entry.runtime_data.created_entity_ids = []
-
-    growspace = Mock()
-    growspace.id = "gs_test"
-    growspace.name = "Test GS"
-    growspace.environment_config = Mock()
-
-    orig_getattr = getattr
-
-    def mock_getattr(obj, name, default=None):
-        if name in (
-            "temperature_sensors",
-            "humidity_sensors",
-            "vpd_sensors",
-            "temperature_sensor",
-            "humidity_sensor",
-            "vpd_sensor",
-        ):
-            raise AttributeError("Simulated AttributeError")
-        return orig_getattr(obj, name, default)
-
-    with patch(
-        "custom_components.growspace_manager.sensor._setup.getattr", side_effect=mock_getattr
-    ), patch(
-        "custom_components.growspace_manager.sensor._setup.async_setup_trend_sensor",
-        new_callable=AsyncMock,
-    ) as mock_trend:
-        # This should complete without exception and return default, hitting line 116-117
-        await _async_create_derivative_sensors(hass, config_entry, growspace)
-        # Because of AttributeError, raw_sensors is [], so no setup is called
-        mock_trend.assert_not_called()
-
-
-def test_get_val_attribute_error_calculated_vpd_sensor(
-    mock_coordinator: MagicMock,
-) -> None:
-    """Test AttributeError fallback in _check_calculated_vpd_sensor get_val helper (Lines 503-504)."""
-    growspace = Mock()
-    growspace.environment_config = Mock()
-
-    orig_getattr = getattr
-
-    def mock_getattr(obj, name, default=None):
-        if name in (
-            "temperature_sensors",
-            "humidity_sensors",
-            "vpd_sensors",
-            "temperature_sensor",
-            "humidity_sensor",
-            "vpd_sensor",
-        ):
-            raise AttributeError("Simulated AttributeError")
-        return orig_getattr(obj, name, default)
-
-    with patch(
-        "custom_components.growspace_manager.sensor._setup.getattr", side_effect=mock_getattr
-    ):
-        # This should safely return empty list, hitting lines 503-504
-        result = _check_calculated_vpd_sensor(mock_coordinator, growspace)
-        assert result == []
 
 
 @pytest.mark.asyncio
@@ -290,7 +227,8 @@ def test_get_env_config_val_dict_and_attribute_error() -> None:
         return orig_getattr(obj, name, default)
 
     with patch(
-        "custom_components.growspace_manager.sensor._setup.getattr", side_effect=mock_getattr
+        "custom_components.growspace_manager.sensor._setup.getattr",
+        side_effect=mock_getattr,
     ):
         assert _get_env_config_val(config_obj, "my_key", "default_val") == "default_val"
 
@@ -360,8 +298,8 @@ def test_drying_weight_sensor_no_plant(
     # Set up plants and growspaces in coordinator
     mock_coordinator.plants = {"plant_1": mock_plant}
     mock_coordinator.growspaces = {"gs_1": MagicMock()}
-    mock_coordinator._data_repository.get_plant.side_effect = (
-        lambda plant_id: mock_coordinator.plants.get(plant_id)
+    mock_coordinator._data_repository.get_plant.side_effect = lambda plant_id: (
+        mock_coordinator.plants.get(plant_id)
     )
 
     sensor = DryingWeightSensor(mock_coordinator, mock_plant)

--- a/tests/components/test_sensor_new_sensors.py
+++ b/tests/components/test_sensor_new_sensors.py
@@ -921,16 +921,16 @@ def test_ec_sensor_extra_state_attributes_no_curve() -> None:
 
 
 def test_check_calculated_vpd_sensor_dict_singular_fallback() -> None:
-    """Lines 451, 453: dict env_config with empty plural lists uses singular fields."""
-    env_config = {
-        "temperature_sensors": [],
-        "humidity_sensors": [],
-        "vpd_sensors": [],
-        "temperature_sensor": "sensor.temp",
-        "humidity_sensor": "sensor.hum",
-        "vpd_sensor": None,
-        "lst_offset": 0.0,
-    }
+    """Empty plural sensor lists fall back to the singular sensor fields."""
+    env_config = Mock(
+        temperature_sensors=[],
+        humidity_sensors=[],
+        vpd_sensors=[],
+        temperature_sensor="sensor.temp",
+        humidity_sensor="sensor.hum",
+        vpd_sensor=None,
+        lst_offset=0.0,
+    )
     growspace = Mock(id="gs1", name="GS1", environment_config=env_config)
     result = _check_calculated_vpd_sensor(MagicMock(), growspace)
     assert len(result) == 1

--- a/tests/test_strain_library_sensor.py
+++ b/tests/test_strain_library_sensor.py
@@ -52,6 +52,24 @@ def test_strain_library_sensor_state_counts_only_catalogued_strains() -> None:
     assert sensor.native_value == 1
 
 
+def test_strain_library_sensor_native_value_no_library() -> None:
+    """native_value returns 0 when the strain library hasn't loaded yet."""
+    coordinator = MagicMock()
+    coordinator.services.config.strain_library = None
+    sensor = StrainLibrarySensor.__new__(StrainLibrarySensor)
+    sensor.coordinator = coordinator
+    assert sensor.native_value == 0
+
+
+def test_strain_library_sensor_extra_attrs_no_library() -> None:
+    """extra_state_attributes returns {} when the strain library hasn't loaded yet."""
+    coordinator = MagicMock()
+    coordinator.services.config.strain_library = None
+    sensor = StrainLibrarySensor.__new__(StrainLibrarySensor)
+    sensor.coordinator = coordinator
+    assert sensor.extra_state_attributes == {}
+
+
 def test_strain_library_sensor_uses_dedicated_device() -> None:
     """The Strain Library sensor uses the same dedicated device identifier."""
     coordinator = MagicMock()


### PR DESCRIPTION
## Summary
- Fixes #607: all real (non-stale-ignore) mypy errors in `custom_components/growspace_manager/sensor/` are resolved — `uv run --no-sync mypy custom_components/growspace_manager/sensor` now reports zero errors for files inside `sensor/`.
- `tank.py`: parametrized `CoordinatorEntity[GrowspaceCoordinator]` (was bare `CoordinatorEntity`, which surfaced bogus `DataUpdateCoordinator[dict].services`/`.config_entry` attribute errors), typed `predictor`/`_tracker` instead of `Any`, and typed `growspace` in `__init__`.
- `strain.py`: guarded against `strain_library` being `None` (it's a real possible runtime state per `ConfigFacade.strain_library`) instead of calling into it unguarded.
- `overview.py` / `vpd.py`: typed the `async_track_state_change_event` callbacks as `Event[EventStateChangedData]`, matching the convention already used in `binary_sensor.py`.
- `_setup.py`: removed `isinstance(x, dict)` branches in two `get_val()` helpers that mypy proved structurally unreachable (`environment_config` is always a real `EnvironmentConfig` instance, never a dict); guarded `str | None` unique IDs before adding to `set[str]`; annotated `new_entities: list[Entity]` so it can hold both `PlantEntity` and drying sensor entities.

## Test plan
- [x] `../../.venv/bin/mypy custom_components/growspace_manager/sensor` — zero errors in `sensor/` (remaining errors are all in modules owned by other open mypy issues: #608, #609, #610, #611)
- [x] `../../.venv/bin/ruff check` / `ruff format --check` on all changed files
- [x] `../../.venv/bin/pytest tests/ -q` — 5092 passed
- [x] `sensor/` coverage: 99% (unchanged pre-existing gaps unrelated to this diff); `strain.py` back to 100% after adding tests for the new `strain_library is None` guards
- [x] Removed/updated coverage tests that existed solely to exercise the now-removed dead `isinstance(dict)`/`AttributeError` fallback code

Note: the local `mypy` pre-commit hook checks the whole `custom_components/` tree and still fails on pre-existing errors outside `sensor/` (owned by #608-#611, not touched here). CI's mypy job is `continue-on-error: true` during this burn-down per ADR-0020, so this is expected and this PR was committed with `SKIP=mypy` for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)