### PR TITLE
mypy: fix errors in websocket/ and managers/

### DIFF
--- a/custom_components/growspace_manager/managers/growspace.py
+++ b/custom_components/growspace_manager/managers/growspace.py
@@ -195,9 +195,7 @@ class GrowspaceManager(BaseService):
             )
             async_fire_growspace_event(self.hass, EVENT_GROWSPACE_REMOVED, growspace)
 
-    async def update_growspace(
-        self, growspace_id: str, **kwargs: dict[str, Any]
-    ) -> Growspace:
+    async def update_growspace(self, growspace_id: str, **kwargs: Any) -> Growspace:
         """Update a growspace."""
         async with self._lock:
             if not self.repository.has_growspace(growspace_id):
@@ -546,7 +544,7 @@ class GrowspaceManager(BaseService):
             updated = False
             temps = env_config.temperature_sensors
             hums = env_config.humidity_sensors
-            vpds = env_config.vpd_sensors
+            vpds: list[str | None] = list(env_config.vpd_sensors)
 
             if not temps and env_config.temperature_sensor:
                 temps = [env_config.temperature_sensor]
@@ -566,10 +564,11 @@ class GrowspaceManager(BaseService):
                 vpds.append(None)
 
             for i in range(num_pairs):
+                vpd_entry = vpds[i]
                 if (
                     temps[i]
                     and hums[i]
-                    and (vpds[i] is None or "calculated_vpd" in vpds[i])
+                    and (vpd_entry is None or "calculated_vpd" in vpd_entry)
                 ):
                     suffix = f" {i + 1}" if num_pairs > 1 else ""
                     calc_name = f"{growspace.name} Calculated VPD{suffix}"
@@ -585,7 +584,7 @@ class GrowspaceManager(BaseService):
                         )
 
             if updated:
-                env_config.vpd_sensors = vpds
+                env_config.vpd_sensors = [v if v is not None else "" for v in vpds]
                 if len(vpds) > 0:
                     env_config.vpd_sensor = vpds[0]
                 if self.cache:

--- a/custom_components/growspace_manager/managers/plant.py
+++ b/custom_components/growspace_manager/managers/plant.py
@@ -739,7 +739,7 @@ class PlantManager(BaseService):
             updates[stage_map[new_stage]] = trans_date_str
 
         plant = self.repository.get_plant(plant_id)
-        if hasattr(plant, "stage_history"):  # Check just in case
+        if plant is not None and hasattr(plant, "stage_history"):  # Check just in case
             new_history = [dict(item) for item in plant.stage_history]
             for item in reversed(new_history):
                 if item.get("end") is None:
@@ -809,8 +809,9 @@ class PlantManager(BaseService):
         # PHI safety check - prevent harvest before pre-harvest interval clears
         if plant.phi_clearance_date:
             today = dt_util.now().date()
-            phi_date = dt_util.parse_datetime(plant.phi_clearance_date).date()
-            if today < phi_date:
+            phi_datetime = dt_util.parse_datetime(plant.phi_clearance_date)
+            phi_date = phi_datetime.date() if phi_datetime else None
+            if phi_date and today < phi_date:
                 days_remaining = (phi_date - today).days
                 from custom_components.growspace_manager.const import (  # noqa: PLC0415
                     DOMAIN,
@@ -1150,29 +1151,29 @@ class PlantManager(BaseService):
         """Alias for remove_plant."""
         return await self.remove_plant(*args, **kwargs)
 
-    async def async_move_plant(self, *args: Any, **kwargs: Any) -> Plant:
+    async def async_move_plant(self, *args: Any, **kwargs: Any) -> None:
         """Alias for move_plant."""
-        return await self.move_plant(*args, **kwargs)
+        await self.move_plant(*args, **kwargs)
 
-    async def async_switch_plants(self, *args: Any, **kwargs: Any) -> list[Plant]:
+    async def async_switch_plants(self, *args: Any, **kwargs: Any) -> None:
         """Alias for switch_plants."""
-        return await self.switch_plants(*args, **kwargs)
+        await self.switch_plants(*args, **kwargs)
 
     async def async_take_clones(self, *args: Any, **kwargs: Any) -> list[Plant]:
         """Alias for take_clones."""
         return await self.take_clones(*args, **kwargs)
 
-    async def async_transition_plant_stage(self, *args: Any, **kwargs: Any) -> Plant:
+    async def async_transition_plant_stage(self, *args: Any, **kwargs: Any) -> None:
         """Alias for transition_plant_stage."""
-        return await self.transition_plant_stage(*args, **kwargs)
+        await self.transition_plant_stage(*args, **kwargs)
 
     async def async_transition_plant(self, *args: Any, **kwargs: Any) -> None:
         """Alias for transition_plant."""
         await self.transition_plant(*args, **kwargs)
 
-    async def async_promote_clone(self, *args: Any, **kwargs: Any) -> Plant:
+    async def async_promote_clone(self, *args: Any, **kwargs: Any) -> None:
         """Alias for promote_clone."""
-        return await self.promote_clone(*args, **kwargs)
+        await self.promote_clone(*args, **kwargs)
 
     async def handle_clone_creation(self, **kwargs: Any) -> str:
         """Compatibility wrapper for add_plant as a clone."""
@@ -1203,17 +1204,17 @@ class PlantManager(BaseService):
         else:
             await self.transition_plant(*args, **kwargs)
 
-    async def handle_move_plant(self, *args: Any, **kwargs: Any) -> Plant:
+    async def handle_move_plant(self, *args: Any, **kwargs: Any) -> None:
         """Alias for move_plant."""
-        return await self.move_plant(*args, **kwargs)
+        await self.move_plant(*args, **kwargs)
 
     async def handle_take_clone(self, *args: Any, **kwargs: Any) -> list[Plant]:
         """Alias for take_clones."""
         return await self.take_clones(*args, **kwargs)
 
-    async def handle_transition_plant_stage(self, *args: Any, **kwargs: Any) -> Plant:
+    async def handle_transition_plant_stage(self, *args: Any, **kwargs: Any) -> None:
         """Alias for transition_plant_stage."""
-        return await self.transition_plant_stage(*args, **kwargs)
+        await self.transition_plant_stage(*args, **kwargs)
 
     async def handle_update_plant(self, *args: Any, **kwargs: Any) -> Plant:
         """Alias for update_plant."""
@@ -1223,6 +1224,6 @@ class PlantManager(BaseService):
         """Alias for remove_plant."""
         await self.remove_plant(*args, **kwargs)
 
-    async def handle_switch_plants(self, *args: Any, **kwargs: Any) -> list[Plant]:
+    async def handle_switch_plants(self, *args: Any, **kwargs: Any) -> None:
         """Alias for switch_plants."""
-        return await self.switch_plants(*args, **kwargs)
+        await self.switch_plants(*args, **kwargs)

--- a/custom_components/growspace_manager/websocket/ai_assistant.py
+++ b/custom_components/growspace_manager/websocket/ai_assistant.py
@@ -109,7 +109,6 @@ def _extract_action(text: str) -> tuple[str, dict[str, Any] | None]:
     except json.JSONDecodeError, ValueError:
         # Malformed block — return the full text without modification
         return text, None
-        return text, None
 
     # Strip the block (and any surrounding whitespace) from the display text
     display = _ACTION_RE.sub("", text).strip()
@@ -164,7 +163,7 @@ def _build_context_message(
     env = growspace.environment_config
 
     # Collect sensor readings — first valid entity per type wins
-    sensor_specs: list[tuple[str, list[str | None]]] = [
+    sensor_specs: list[tuple[str, list[str]]] = [
         (
             "Temperature",
             env.temperature_sensors

--- a/custom_components/growspace_manager/websocket/genetics.py
+++ b/custom_components/growspace_manager/websocket/genetics.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
-from custom_components.growspace_manager.strain_library import StrainLibrary
+from custom_components.growspace_manager.exceptions import CoordinatorNotReadyError
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
 
@@ -51,7 +51,9 @@ async def websocket_update_breeder(
     hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
 ) -> dict[str, Any]:
     """Handle updating breeder info across all strains."""
-    strain_library: StrainLibrary = coordinator.services.config.strain_library
+    strain_library = coordinator.services.config.strain_library
+    if strain_library is None:
+        raise CoordinatorNotReadyError("Strain library not initialized")
     count = await strain_library.update_breeder(
         original_name=msg["original_name"],
         new_name=msg["new_name"],
@@ -64,7 +66,9 @@ async def websocket_delete_breeder(
     hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
 ) -> dict[str, Any]:
     """Handle removing breeder association from all strains."""
-    strain_library: StrainLibrary = coordinator.services.config.strain_library
+    strain_library = coordinator.services.config.strain_library
+    if strain_library is None:
+        raise CoordinatorNotReadyError("Strain library not initialized")
     count = await strain_library.delete_breeder(
         breeder_name=msg["breeder_name"],
     )

--- a/custom_components/growspace_manager/websocket/lineage.py
+++ b/custom_components/growspace_manager/websocket/lineage.py
@@ -9,7 +9,10 @@ import voluptuous as vol
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
-from custom_components.growspace_manager.exceptions import PlantNotFoundError
+from custom_components.growspace_manager.exceptions import (
+    CoordinatorNotReadyError,
+    PlantNotFoundError,
+)
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
 
@@ -86,6 +89,8 @@ async def websocket_get_strain_lineage_tree(
 ) -> dict[str, Any]:
     """Handle get_strain_lineage_tree command."""
     strain_library = coordinator.services.config.strain_library
+    if strain_library is None:
+        raise CoordinatorNotReadyError("Strain library not initialized")
     return strain_library.get_strain_lineage_tree(msg["strain_name"])
 
 
@@ -94,6 +99,8 @@ async def websocket_update_strain_lineage_tree(
 ) -> dict[str, Any]:
     """Handle update_strain_lineage_tree command."""
     strain_library = coordinator.services.config.strain_library
+    if strain_library is None:
+        raise CoordinatorNotReadyError("Strain library not initialized")
     flat_lineage = await strain_library.update_strain_lineage_tree(
         msg["strain_name"], msg["parents"]
     )
@@ -105,6 +112,8 @@ async def websocket_import_strain_lineage_tree(
 ) -> dict[str, Any]:
     """Import a full seedfinder lineage tree, creating ancestor stubs as needed."""
     strain_library = coordinator.services.config.strain_library
+    if strain_library is None:
+        raise CoordinatorNotReadyError("Strain library not initialized")
     await strain_library.async_import_seedfinder_lineage_tree(
         msg["strain_name"], msg["tree"], scraper=coordinator.seedfinder_scraper
     )

--- a/custom_components/growspace_manager/websocket/strain.py
+++ b/custom_components/growspace_manager/websocket/strain.py
@@ -6,12 +6,15 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from aiohttp import ClientTimeout
 import voluptuous as vol
 
 from custom_components.growspace_manager.const import CONF_BLACKLIST_BREEDERS, DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
-from custom_components.growspace_manager.exceptions import GrowspaceError
-from custom_components.growspace_manager.strain_library import StrainLibrary
+from custom_components.growspace_manager.exceptions import (
+    CoordinatorNotReadyError,
+    GrowspaceError,
+)
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -73,7 +76,9 @@ def websocket_get_strain_library(
     hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
 ) -> dict[str, Any]:
     """Handle get strain library command via WebSocket."""
-    strain_library: StrainLibrary = coordinator.services.config.strain_library
+    strain_library = coordinator.services.config.strain_library
+    if strain_library is None:
+        raise CoordinatorNotReadyError("Strain library not initialized")
     all_strains = strain_library.get_all()
     return {
         "strains": all_strains,
@@ -85,7 +90,10 @@ async def websocket_upload_strain_image(
     hass: HomeAssistant, coordinator: GrowspaceCoordinator, msg: dict[str, Any]
 ) -> dict[str, Any]:
     """Upload a strain image to disk and return its local path."""
-    image_manager = coordinator.services.config.strain_library.image_manager
+    strain_library = coordinator.services.config.strain_library
+    if strain_library is None:
+        raise CoordinatorNotReadyError("Strain library not initialized")
+    image_manager = strain_library.image_manager
     abs_path = await image_manager.save_strain_image(
         slugify(msg["strain"]), slugify(msg["phenotype"]), msg["image_base64"]
     )
@@ -100,7 +108,10 @@ async def websocket_download_strain_image(
     import base64 as _base64  # noqa: PLC0415
 
     url = msg["url"]
-    image_manager = coordinator.services.config.strain_library.image_manager
+    strain_library = coordinator.services.config.strain_library
+    if strain_library is None:
+        raise CoordinatorNotReadyError("Strain library not initialized")
+    image_manager = strain_library.image_manager
 
     session = async_get_clientsession(hass)
     headers = {
@@ -109,7 +120,11 @@ async def websocket_download_strain_image(
         "Referer": "https://en.seedfinder.eu/",
     }
     async with session.get(
-        url, timeout=15, headers=headers, allow_redirects=True, max_redirects=20
+        url,
+        timeout=ClientTimeout(total=15),
+        headers=headers,
+        allow_redirects=True,
+        max_redirects=20,
     ) as response:
         if response.status != 200:
             raise GrowspaceError(f"Image download failed: HTTP {response.status}")
@@ -129,6 +144,8 @@ async def websocket_query_external_strain(
 ) -> Any:
     """Query external strain database."""
     scraper = coordinator.seedfinder_scraper
+    if scraper is None:
+        raise CoordinatorNotReadyError("Seedfinder scraper not initialized")
 
     blacklist = []
     try:
@@ -146,6 +163,8 @@ async def websocket_get_external_strain_details(
     import re  # noqa: PLC0415
 
     scraper = coordinator.seedfinder_scraper
+    if scraper is None:
+        raise CoordinatorNotReadyError("Seedfinder scraper not initialized")
 
     raw = await scraper.async_get_strain_details(msg["url"])
     if raw is None:


### PR DESCRIPTION
## Summary
- Fixes #608
- Guards `None` `strain_library`/`seedfinder_scraper` accesses in `websocket/{strain,lineage,genetics}.py` with `CoordinatorNotReadyError`, fixes an untyped `aiohttp` timeout, and removes an unreachable duplicate `return` and a mis-typed sensor list in `websocket/ai_assistant.py`.
- Fixes `managers/growspace.py`: `update_growspace`'s `**kwargs: dict[str, Any]` annotation was wrong (should be `**kwargs: Any`), and the `vpd_sensors` placeholder-padding logic now uses a properly typed local copy instead of mutating the model's `list[str]` with `None`.
- Fixes `managers/plant.py`: narrows `Plant | None` before `hasattr`, guards `parse_datetime` returning `None` in the PHI clearance check, and corrects several alias methods whose declared return types (`Plant`/`list[Plant]`) didn't match what the underlying (`None`-returning) methods actually return.

## Test plan
- [x] `.venv/bin/mypy custom_components/growspace_manager/websocket custom_components/growspace_manager/managers` reports zero errors in those two directories (remaining errors are pre-existing, in files outside this change's scope)
- [x] `.venv/bin/pytest tests/ -q` — 5092 passed
- [x] `ruff check` / `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)