### PR TITLE
mypy: fix errors in entity platform glue (logbook, config_flow, binary_sensor)

### DIFF
--- a/custom_components/growspace_manager/binary_sensor.py
+++ b/custom_components/growspace_manager/binary_sensor.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
-from typing import Any, override
+from typing import Any, cast, override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
@@ -687,7 +687,11 @@ class LightCycleVerificationSensor(
         stage_key = self._get_current_stage_key(stage_info)
 
         env_config_dict = self.env_config.to_dict()
-        conf_key = STAGE_PHOTOPERIOD_KEYS.get(stage_key, CONF_VEG_DAY_HOURS)
+        # stage_key is a BayesianStage value; StrEnum compares by string value
+        # so the PlantStage-keyed lookup still resolves (or safely misses) at runtime.
+        conf_key = STAGE_PHOTOPERIOD_KEYS.get(
+            cast(PlantStage, stage_key), CONF_VEG_DAY_HOURS
+        )
         default_hours = (
             DEFAULT_VEG_DAY_HOURS
             if stage_key == PlantStage.VEG
@@ -817,7 +821,11 @@ class LightCycleVerificationSensor(
 
         # Get configured day hours for the current stage
         env_config_dict = self.env_config.to_dict()
-        conf_key = STAGE_PHOTOPERIOD_KEYS.get(stage_key, CONF_VEG_DAY_HOURS)
+        # stage_key is a BayesianStage value; StrEnum compares by string value
+        # so the PlantStage-keyed lookup still resolves (or safely misses) at runtime.
+        conf_key = STAGE_PHOTOPERIOD_KEYS.get(
+            cast(PlantStage, stage_key), CONF_VEG_DAY_HOURS
+        )
         default_hours = (
             DEFAULT_VEG_DAY_HOURS
             if stage_key == PlantStage.VEG

--- a/custom_components/growspace_manager/config_flow.py
+++ b/custom_components/growspace_manager/config_flow.py
@@ -293,7 +293,6 @@ class OptionsFlowHandler(OptionsFlow):
             self._strain_handler = StrainConfigHandler(self)
         return self._strain_handler
 
-    @override
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -511,6 +510,8 @@ class OptionsFlowHandler(OptionsFlow):
             coordinator = self.env_sensors_handler.get_coordinator()
         except AbortFlow as e:
             return self.async_abort(reason=e.reason)
+        if not self.selected_growspace_id:
+            return self.async_abort(reason="growspace_not_found")
         growspace = coordinator.services.growspaces.get_growspace(
             self.selected_growspace_id
         )

--- a/custom_components/growspace_manager/logbook.py
+++ b/custom_components/growspace_manager/logbook.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.logbook import LOGBOOK_ENTRY_MESSAGE, LOGBOOK_ENTRY_NAME
@@ -69,7 +69,7 @@ def async_describe_events(
     )
 
 
-def _describe_note_event(data: dict[str, Any]) -> dict[str, Any]:
+def _describe_note_event(data: Mapping[str, Any]) -> dict[str, Any]:
     """Describe a note event."""
     notes = data.get("notes", "")
     tags = data.get("tags", [])
@@ -90,7 +90,7 @@ def _describe_note_event(data: dict[str, Any]) -> dict[str, Any]:
     return {LOGBOOK_ENTRY_NAME: "Plant Note", LOGBOOK_ENTRY_MESSAGE: message}
 
 
-def _describe_watering_event(data: dict[str, Any]) -> dict[str, Any]:
+def _describe_watering_event(data: Mapping[str, Any]) -> dict[str, Any]:
     """Describe a watering event."""
     amount = data.get("amount_ml")
     message = "Watered"
@@ -103,7 +103,7 @@ def _describe_watering_event(data: dict[str, Any]) -> dict[str, Any]:
     return {LOGBOOK_ENTRY_NAME: "Watering", LOGBOOK_ENTRY_MESSAGE: message}
 
 
-def _describe_training_event(data: dict[str, Any]) -> dict[str, Any]:
+def _describe_training_event(data: Mapping[str, Any]) -> dict[str, Any]:
     """Describe a training event."""
     technique = data.get("sensor_type", "Training")
     if technique:
@@ -115,7 +115,7 @@ def _describe_training_event(data: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _describe_ipm_event(data: dict[str, Any]) -> dict[str, Any]:
+def _describe_ipm_event(data: Mapping[str, Any]) -> dict[str, Any]:
     """Describe an IPM event."""
     treatment = data.get("sensor_type", "IPM")
     treatment = treatment.removeprefix("ipm_")
@@ -127,7 +127,7 @@ def _describe_ipm_event(data: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _describe_dehumidifier_event(data: dict[str, Any]) -> dict[str, Any]:
+def _describe_dehumidifier_event(data: Mapping[str, Any]) -> dict[str, Any]:
     """Describe a dehumidifier control event."""
     reasons = data.get("reasons", [])
     action = next(
@@ -140,7 +140,7 @@ def _describe_dehumidifier_event(data: dict[str, Any]) -> dict[str, Any]:
     return {LOGBOOK_ENTRY_NAME: "Dehumidifier Control", LOGBOOK_ENTRY_MESSAGE: message}
 
 
-def _describe_humidifier_event(data: dict[str, Any]) -> dict[str, Any]:
+def _describe_humidifier_event(data: Mapping[str, Any]) -> dict[str, Any]:
     """Describe a humidifier control event."""
     reasons = data.get("reasons", [])
     action = next(
@@ -153,14 +153,14 @@ def _describe_humidifier_event(data: dict[str, Any]) -> dict[str, Any]:
     return {LOGBOOK_ENTRY_NAME: "Humidifier Control", LOGBOOK_ENTRY_MESSAGE: message}
 
 
-def _describe_milestone_event(data: dict[str, Any]) -> dict[str, Any]:
+def _describe_milestone_event(data: Mapping[str, Any]) -> dict[str, Any]:
     """Describe a growth milestone event (e.g. stage transition)."""
     reasons = data.get("reasons", [])
     message = reasons[0] if reasons else data.get("sensor_type", "Milestone reached")
     return {LOGBOOK_ENTRY_NAME: "Growth Milestone", LOGBOOK_ENTRY_MESSAGE: message}
 
 
-def _describe_alert_event(data: dict[str, Any]) -> dict[str, Any]:
+def _describe_alert_event(data: Mapping[str, Any]) -> dict[str, Any]:
     """Describe a stress or mold alert event."""
     sensor_type = data.get("sensor_type", "alert")
     label = sensor_type.replace("_", " ").title()
@@ -169,13 +169,17 @@ def _describe_alert_event(data: dict[str, Any]) -> dict[str, Any]:
     message = f"{label} detected"
     if duration:
         minutes = duration // 60
-        message += f" — lasted {minutes} minutes" if minutes else f" — lasted {duration} seconds"
+        message += (
+            f" — lasted {minutes} minutes"
+            if minutes
+            else f" — lasted {duration} seconds"
+        )
     if reasons:
         message += f" • {reasons[0]}"
     return {LOGBOOK_ENTRY_NAME: f"{label} Alert", LOGBOOK_ENTRY_MESSAGE: message}
 
 
-def _describe_irrigation_error_event(data: dict[str, Any]) -> dict[str, Any]:
+def _describe_irrigation_error_event(data: Mapping[str, Any]) -> dict[str, Any]:
     """Describe an irrigation skip or failure event."""
     return {
         LOGBOOK_ENTRY_NAME: "Irrigation",
@@ -183,7 +187,7 @@ def _describe_irrigation_error_event(data: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _describe_environment_event(data: dict[str, Any]) -> dict[str, Any]:
+def _describe_environment_event(data: Mapping[str, Any]) -> dict[str, Any]:
     """Describe an optimal-conditions drop event."""
     reasons = data.get("reasons", [])
     duration = data.get("duration_sec", 0)
@@ -197,7 +201,7 @@ def _describe_environment_event(data: dict[str, Any]) -> dict[str, Any]:
 
 
 def _describe_default_event(
-    category: str | None, data: dict[str, Any]
+    category: str | None, data: Mapping[str, Any]
 ) -> dict[str, Any]:
     """Describe a default event."""
     return {


### PR DESCRIPTION
## Summary
- `switch.py` and `calendar.py` were already fully clean after #603's stale-ignore removal — no work needed there.
- `logbook.py`: the `_describe_*_event` helpers declared `data: dict[str, Any]` but `LazyEventPartialState.data` is a `Mapping[str, Any]`; widened the params (none of them mutate `data`).
- `binary_sensor.py`: `stage_key` is a `BayesianStage` value widened to `str`, which the `PlantStage`-keyed `STAGE_PHOTOPERIOD_KEYS.get()` overload rejects even though the `StrEnum` value comparison is safe at runtime (both enums share string values for veg/flower stages). Cast to `PlantStage` at the two call sites with a comment explaining why.
- `config_flow.py`:
  - `async_step_init` carried an incorrect `@override` — `OptionsFlow`/`FlowHandler` declare no such method; it's invoked by name via the flow manager's `init_step` convention. Removed the decorator rather than suppressing.
  - `async_step_save_and_finish` passed `self.selected_growspace_id` (`str | None`) straight into `get_growspace()`, which expects `str`. Added a guard that aborts with `growspace_not_found` when unset, matching the existing abort path just below it.

## Test plan
- [x] `mypy custom_components/growspace_manager` reports zero errors for `logbook.py`, `config_flow.py`, `switch.py`, `binary_sensor.py`, `calendar.py` (total project errors dropped 40 → 25, no new errors elsewhere)
- [x] `ruff check`/`ruff format` clean on changed files
- [x] `pytest tests/ -k "logbook or config_flow or switch or binary_sensor or calendar"` — 381 passed
- [x] Full suite: `pytest tests/` — 5092 passed

Closes #610.