### PR TITLE
mypy: fix errors in remaining misc root-level modules

### DIFF
--- a/custom_components/growspace_manager/bayesian_evaluator.py
+++ b/custom_components/growspace_manager/bayesian_evaluator.py
@@ -188,9 +188,11 @@ async def async_evaluate_stress_trend(
                 local_trends[trend_key] = "rising"
                 gradient = trend_state.attributes.get("gradient", 0)
                 prob = (
-                    env_config.get(CONF_PROB_TREND_FAST_RISE, PROB_TREND_FAST_RISE)
+                    env_config_dict.get(CONF_PROB_TREND_FAST_RISE, PROB_TREND_FAST_RISE)
                     if gradient > TREND_GRADIENT_FAST_THRESHOLD
-                    else env_config.get(CONF_PROB_TREND_SLOW_RISE, PROB_TREND_SLOW_RISE)
+                    else env_config_dict.get(
+                        CONF_PROB_TREND_SLOW_RISE, PROB_TREND_SLOW_RISE
+                    )
                 )
                 local_obs.append(prob)
                 reason_suffix = (

--- a/custom_components/growspace_manager/cache/cache_manager.py
+++ b/custom_components/growspace_manager/cache/cache_manager.py
@@ -13,11 +13,13 @@ class CacheManager:
     """Manages serialization cache for growspace data.
 
     The CacheManager provides a simple key-value cache for storing serialized
-    growspace data. It supports per-growspace invalidation and full cache clearing.
+    growspace data alongside the timestamp it was cached at, so callers can
+    apply their own TTL. It supports per-growspace invalidation and full
+    cache clearing.
 
     Example:
         >>> cache = CacheManager()
-        >>> cache.set("growspace_1", {"name": "Main", "plants": []})
+        >>> cache.set("growspace_1", (0.0, {"name": "Main", "plants": []}))
         >>> data = cache.get("growspace_1")
         >>> cache.invalidate("growspace_1")
         >>> cache.get("growspace_1")  # Returns None
@@ -25,25 +27,25 @@ class CacheManager:
 
     def __init__(self) -> None:
         """Initialize an empty cache."""
-        self._cache: dict[str, dict[str, Any]] = {}
+        self._cache: dict[str, tuple[float, dict[str, Any]]] = {}
 
-    def get(self, growspace_id: str) -> dict[str, Any] | None:
-        """Get cached data for a growspace.
+    def get(self, growspace_id: str) -> tuple[float, dict[str, Any]] | None:
+        """Get the cached (timestamp, data) entry for a growspace.
 
         Args:
             growspace_id: The unique identifier for the growspace.
 
         Returns:
-            The cached serialized data if present, None otherwise.
+            The cached (timestamp, data) entry if present, None otherwise.
         """
         return self._cache.get(growspace_id)
 
-    def set(self, growspace_id: str, data: dict[str, Any]) -> None:
-        """Store serialized data in cache.
+    def set(self, growspace_id: str, data: tuple[float, dict[str, Any]]) -> None:
+        """Store a (timestamp, data) entry in cache.
 
         Args:
             growspace_id: The unique identifier for the growspace.
-            data: The serialized growspace data to cache.
+            data: The (timestamp, serialized data) entry to cache.
         """
         self._cache[growspace_id] = data
 
@@ -77,7 +79,7 @@ class CacheManager:
 
         Example:
             >>> cache = CacheManager()
-            >>> cache.set("gs1", {})
+            >>> cache.set("gs1", (0.0, {}))
             >>> "gs1" in cache
             True
             >>> "gs2" in cache
@@ -95,7 +97,7 @@ class CacheManager:
             >>> cache = CacheManager()
             >>> len(cache)
             0
-            >>> cache.set("gs1", {})
+            >>> cache.set("gs1", (0.0, {}))
             >>> len(cache)
             1
         """

--- a/custom_components/growspace_manager/domain/environment_patch.py
+++ b/custom_components/growspace_manager/domain/environment_patch.py
@@ -393,6 +393,7 @@ def apply_environment_patch(
     for name, ownership in ENVIRONMENT_FIELD_OWNERSHIP.items():
         if not ownership.item_runtime_fields or name not in patch.values:
             continue
+        assert ownership.item_identity is not None
         existing_by_id = {
             getattr(item, ownership.item_identity): item for item in getattr(base, name)
         }

--- a/custom_components/growspace_manager/image_manager.py
+++ b/custom_components/growspace_manager/image_manager.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def _safe_filename_part(s: str) -> str:
     """Replace URL-unsafe characters in a filename segment with underscores."""
-    return re.sub(r'[#%?&=+]', '_', s)
+    return re.sub(r"[#%?&=+]", "_", s)
 
 
 class ImageManager:
@@ -123,8 +123,7 @@ class ImageManager:
                     continue
 
                 try:
-                    # Image.open returns Image.Image (no cast needed)
-                    img = Image.open(jpg_path)
+                    img: Image.Image = Image.open(jpg_path)
 
                     # Convert to RGB if needed
                     if img.mode not in ("RGB", "RGBA"):
@@ -147,7 +146,7 @@ class ImageManager:
                         "Migrated %s to WebP format (full + thumbnail)", jpg_path.name
                     )
 
-                except Exception as e :  # noqa: BLE001
+                except Exception as e:  # noqa: BLE001
                     _LOGGER.warning(
                         "Failed to migrate %s to WebP: %s", jpg_path.name, e
                     )
@@ -157,7 +156,7 @@ class ImageManager:
                     "Auto-migration complete: converted %d image(s) to WebP", migrated
                 )
 
-        except Exception as e :  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001
             _LOGGER.error("Error during auto-migration to WebP: %s", e)
 
     async def _update_db_paths(self, db_connection: Any) -> int:
@@ -202,7 +201,7 @@ class ImageManager:
             if updated > 0:
                 _LOGGER.info("Updated %d database path(s) from .jpg to .webp", updated)
 
-        except Exception as e :  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001
             _LOGGER.error("Error updating database paths: %s", e)
             return 0
         else:
@@ -238,7 +237,7 @@ class ImageManager:
                 image_base64 = image_base64.split(",")[1]
 
             image_data = base64.b64decode(image_base64)
-            image = Image.open(BytesIO(image_data))
+            image: Image.Image = Image.open(BytesIO(image_data))
 
             # Convert to RGB (WebP supports RGBA, but RGB is safer for photos)
             if image.mode not in ("RGB", "RGBA"):
@@ -280,7 +279,15 @@ class ImageManager:
             # Return absolute path as string
             return str(file_path.absolute())
 
-        except (AttributeError, KeyError, ValueError, ServiceValidationError, GrowspaceError, OSError, UnidentifiedImageError) as e:
+        except (
+            AttributeError,
+            KeyError,
+            ValueError,
+            ServiceValidationError,
+            GrowspaceError,
+            OSError,
+            UnidentifiedImageError,
+        ) as e:
             _LOGGER.error("Error saving strain image: %s", e)
             raise
 
@@ -318,7 +325,7 @@ class ImageManager:
                 image_base64 = image_base64.split(",")[1]
 
             image_data = base64.b64decode(image_base64)
-            image = Image.open(BytesIO(image_data))
+            image: Image.Image = Image.open(BytesIO(image_data))
 
             if image.mode not in ("RGB", "RGBA"):
                 image = image.convert("RGB")
@@ -350,7 +357,15 @@ class ImageManager:
 
             return str(file_path.absolute())
 
-        except (AttributeError, KeyError, ValueError, ServiceValidationError, GrowspaceError, OSError, UnidentifiedImageError) as e:
+        except (
+            AttributeError,
+            KeyError,
+            ValueError,
+            ServiceValidationError,
+            GrowspaceError,
+            OSError,
+            UnidentifiedImageError,
+        ) as e:
             _LOGGER.error("Error saving timeline image: %s", e)
             raise
 
@@ -420,7 +435,7 @@ class ImageManager:
                 base64_data = base64_data.split(",")[1]
 
             image_data = base64.b64decode(base64_data)
-            image = Image.open(BytesIO(image_data))
+            image: Image.Image = Image.open(BytesIO(image_data))
 
             # Convert to RGB (WebP supports RGBA, but RGB is safer for photos)
             if image.mode not in ("RGB", "RGBA"):

--- a/custom_components/growspace_manager/notification_manager.py
+++ b/custom_components/growspace_manager/notification_manager.py
@@ -631,9 +631,10 @@ class NotificationManager:
 
         if days_in_stage >= day_to_trigger:
             notification_key = f"timed_{notification_id}"
-            if not self.coordinator.notification_state.sent.get(plant.plant_id, {}).get(
-                notification_key, False
-            ):
+            # This bucket is keyed by notification_key -> bool for timed notifications,
+            # unlike the stage -> day -> bool shape used elsewhere for this field.
+            sent: dict[str, Any] = self.coordinator.notification_state.sent
+            if not sent.get(plant.plant_id, {}).get(notification_key, False):
                 _LOGGER.info(
                     "Triggering timed notification for plant %s in %s",
                     plant.plant_id,
@@ -649,9 +650,5 @@ class NotificationManager:
                     message,
                 )
 
-                if plant.plant_id not in self.coordinator.notification_state.sent:
-                    self.coordinator.notification_state.sent[plant.plant_id] = {}
-                self.coordinator.notification_state.sent[plant.plant_id][
-                    notification_key
-                ] = True
+                sent.setdefault(plant.plant_id, {})[notification_key] = True
                 await self.coordinator.async_commit()

--- a/custom_components/growspace_manager/notifications/notification_settings_manager.py
+++ b/custom_components/growspace_manager/notifications/notification_settings_manager.py
@@ -12,8 +12,8 @@ import uuid
 from .timed import normalize_timed_notification_trigger, normalize_timed_notifications
 
 if TYPE_CHECKING:
-    from .custom_components.growspace_manager.coordinator import GrowspaceCoordinator
-    from .custom_components.growspace_manager.models import Growspace
+    from ..coordinator import GrowspaceCoordinator
+    from ..models import Growspace
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/growspace_manager/storage_manager.py
+++ b/custom_components/growspace_manager/storage_manager.py
@@ -164,7 +164,7 @@ class StorageManager:
         """Gather configuration data for storage."""
         # Use nutrient manager for serialization data
         nutrient_data = self.nutrient_manager.get_serialization_data()
-        genetics_data = self.genetics_manager.get_serialization_data()
+        genetics_data = self._get_genetics_data()
 
         config = {
             "growspaces": {
@@ -253,7 +253,8 @@ class StorageManager:
             eid: PollinationEvent.from_dict(e)
             for eid, e in data.get("pollination_events", {}).items()
         }
-        self.genetics_manager.load_data(seed_batches, pollination_events)
+        if self.genetics_manager is not None:
+            self.genetics_manager.load_data(seed_batches, pollination_events)
 
         # Load notification tracking
         if self.notification_state is not None:

--- a/custom_components/growspace_manager/strain_library.py
+++ b/custom_components/growspace_manager/strain_library.py
@@ -319,7 +319,7 @@ class StrainLibrary:
                 "SELECT phenotype_id, image_path, image_crop_meta FROM phenotypes"
                 " WHERE image_path IS NOT NULL AND images IS NULL"
             ) as cursor:
-                rows = await cursor.fetchall()
+                rows = list(await cursor.fetchall())
         except aiosqlite.OperationalError:
             # images column not yet present — migration will run after ALTER TABLE
             return
@@ -1105,7 +1105,7 @@ class StrainLibrary:
         normalized = phenotype_name or "default"
 
         def _thumbnail_from(pheno_data: dict[str, Any]) -> dict[str, Any] | None:
-            imgs = pheno_data.get("images")
+            imgs: list[dict[str, Any]] | None = pheno_data.get("images")
             if not imgs:
                 return None
             for img in imgs:

--- a/custom_components/growspace_manager/substrate_tracker.py
+++ b/custom_components/growspace_manager/substrate_tracker.py
@@ -363,7 +363,7 @@ class SubstrateTracker:
         events = self.get_incycle_drybacks_today(reference_ts)
         if not events:
             return None
-        return round(sum(e["dryback"] for e in events) / len(events), 4)
+        return float(round(sum(e["dryback"] for e in events) / len(events), 4))
 
     def get_shot_count_today(self, reference_ts: str | None = None) -> int:
         """Return the number of P2 in-cycle dryback shot-pairs recorded today.

--- a/custom_components/growspace_manager/tank_monitor.py
+++ b/custom_components/growspace_manager/tank_monitor.py
@@ -12,7 +12,12 @@ from .const import NotificationTier
 from .presentation import EntityQueries
 
 if TYPE_CHECKING:
-    from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
+    from homeassistant.core import (
+        CALLBACK_TYPE,
+        Event,
+        EventStateChangedData,
+        HomeAssistant,
+    )
 
     from .coordinator import GrowspaceCoordinator
 
@@ -46,11 +51,13 @@ class TankLevelMonitor:
             for tank in growspace.environment_config.irrigation_tanks:
                 self._subscribe_tank(growspace.id, growspace.name, tank)
 
-    def _subscribe_tank(self, growspace_id: str, growspace_name: str, tank: Any) -> None:
+    def _subscribe_tank(
+        self, growspace_id: str, growspace_name: str, tank: Any
+    ) -> None:
         """Register a state-change listener for a single tank sensor."""
         entity_queries = self._entity_queries
 
-        async def _on_state_change(event: Event) -> None:
+        async def _on_state_change(event: Event[EventStateChangedData]) -> None:
             new_state = event.data.get("new_state")
             if new_state is None:
                 return

--- a/custom_components/growspace_manager/trend_analyzer.py
+++ b/custom_components/growspace_manager/trend_analyzer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import timedelta
 import itertools
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State
@@ -14,12 +14,16 @@ from homeassistant.util.dt import utcnow
 
 from .exceptions import GrowspaceError
 
+if TYPE_CHECKING:
+    from homeassistant.components.recorder import Recorder
+
 _LOGGER = logging.getLogger(__name__)
 
 
-def get_recorder_instance(hass: HomeAssistant):
+def get_recorder_instance(hass: HomeAssistant) -> Recorder:
     """Get the recorder instance (deferred import)."""
     from homeassistant.helpers.recorder import get_instance  # noqa: PLC0415
+
     return get_instance(hass)
 
 
@@ -69,7 +73,7 @@ class TrendAnalyzer:
                         continue
                     try:
                         numeric_states.append(float(s.state))
-                    except (ValueError, TypeError):
+                    except ValueError, TypeError:
                         continue
 
                 # Calculate trend
@@ -82,7 +86,13 @@ class TrendAnalyzer:
 
                 results[sensor_id] = {"trend": trend, "crossed_threshold": crossed}
 
-        except (AttributeError, KeyError, ValueError, ServiceValidationError, GrowspaceError):
+        except (
+            AttributeError,
+            KeyError,
+            ValueError,
+            ServiceValidationError,
+            GrowspaceError,
+        ):
             _LOGGER.exception("Error analyzing bulk sensor history")
             return {
                 sid: {"trend": "unknown", "crossed_threshold": False}

--- a/custom_components/growspace_manager/utils.py
+++ b/custom_components/growspace_manager/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
@@ -121,7 +121,7 @@ class VPDCalculator:
         return 0.61094 * math.exp((17.625 * temperature_c) / (243.04 + temperature_c))
 
     @staticmethod
-    def calculate_vpd(temperature_c: float, humidity_rh: float) -> float | None:
+    def calculate_vpd(temperature_c: Any, humidity_rh: Any) -> float | None:
         """Calculate Vapor Pressure Deficit (VPD) in kPa.
 
         Args:
@@ -143,7 +143,7 @@ class VPDCalculator:
 
     @staticmethod
     def calculate_vpd_with_lst_offset(
-        air_temperature_c: float, humidity_rh: float, lst_offset: float = -2.0
+        air_temperature_c: Any, humidity_rh: Any, lst_offset: Any = -2.0
     ) -> float | None:
         """Calculate Vapor Pressure Deficit (VPD) with Leaf Surface Temperature offset.
 


### PR DESCRIPTION
## Summary
- Fixes the last batch of mypy errors in the misc root-level/domain modules: `strain_library.py`, `image_manager.py`, `notifications/`, `storage_manager.py`, `bayesian_evaluator.py`, `trend_analyzer.py`, `tank_monitor.py`, `substrate_tracker.py`, `notification_manager.py`, `utils.py`, `domain/environment_patch.py`, and `cache/cache_manager.py` (whose typing was hiding a real bug — `view_model_builder.py` caches `(timestamp, data)` tuples, but `CacheManager` was typed for plain dicts, making its own TTL check statically unreachable).
- `notification_settings_manager.py` had a broken relative import (`from .custom_components.growspace_manager.coordinator import ...`) that silently resolved `GrowspaceCoordinator` to `Any`, masking two `no-any-return` errors — fixed to a proper `..coordinator` import.
- `uv run --no-sync mypy custom_components/growspace_manager` now reports **zero errors** across all 205 source files — this was the last ticket in the mypy cleanup sequence.

## Test plan
- [x] `.venv/bin/mypy custom_components/growspace_manager` — 0 errors
- [x] `.venv/bin/pytest tests/ -q` — 5092 passed
- [x] `.venv/bin/ruff check` / `ruff format --check` — clean
- [x] pre-commit hooks (ruff, codespell, pytest, mypy) pass on commit

Closes #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)