### PR TITLE
Fix orphaned growspace devices after deletion

### DIFF
--- a/custom_components/growspace_manager/managers/growspace.py
+++ b/custom_components/growspace_manager/managers/growspace.py
@@ -43,7 +43,7 @@ from custom_components.growspace_manager.services.context import (
 from custom_components.growspace_manager.view_model_builder import ViewModelBuilder
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import dt as dt_util, slugify
 
 if TYPE_CHECKING:
@@ -173,13 +173,22 @@ class GrowspaceManager(BaseService):
             # Remove notification state
             self.notification_state.enabled.pop(growspace_id, None)
 
-            # Remove device from registry
+            # Remove registry entities before their parent device. Home Assistant
+            # keeps a device visible while entity-registry entries still refer to
+            # it, even after the growspace has disappeared from domain storage.
             try:
                 dev_reg = dr.async_get(self.hass)
                 device = dev_reg.async_get_device(identifiers={(DOMAIN, growspace_id)})
                 if device:
+                    entity_reg = er.async_get(self.hass)
+                    for entry in er.async_entries_for_device(
+                        entity_reg, device.id, include_disabled_entities=True
+                    ):
+                        entity_reg.async_remove(entry.entity_id)
                     dev_reg.async_remove_device(device.id)
-                    _LOGGER.debug("Removed device for growspace %s", growspace_id)
+                    _LOGGER.debug(
+                        "Removed device and entities for growspace %s", growspace_id
+                    )
             except Exception:
                 _LOGGER.exception(
                     "Error removing device for growspace %s", growspace_id

--- a/tests/core/test_coordinator.py
+++ b/tests/core/test_coordinator.py
@@ -685,11 +685,30 @@ async def test_async_remove_growspace(coordinator: GrowspaceCoordinator) -> None
     # Setup: add a growspace with plants
     gs = await coordinator._growspace_manager.add_growspace("Test GS", 2, 2)
 
-    # Create a device entry
-    config_entry = MockConfigEntry(domain=DOMAIN, data={}, entry_id="test_entry")
-    config_entry.add_to_hass(coordinator.hass)
-
     dev_reg = dr.async_get(coordinator.hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=coordinator.config_entry.entry_id,
+        identifiers={(DOMAIN, gs.id)},
+        name=gs.name,
+    )
+    entity_reg = er.async_get(coordinator.hass)
+    active_entity = entity_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{gs.id}_overview",
+        config_entry=coordinator.config_entry,
+        device_id=device.id,
+        suggested_object_id=f"{gs.id}_overview",
+    )
+    disabled_entity = entity_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{gs.id}_disabled",
+        config_entry=coordinator.config_entry,
+        device_id=device.id,
+        suggested_object_id=f"{gs.id}_disabled",
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
 
     plant1 = await coordinator._plant_manager.add_plant(gs.id, "StrainA", row=1, col=1)
     plant2 = await coordinator._plant_manager.add_plant(gs.id, "StrainB", row=2, col=2)
@@ -724,6 +743,8 @@ async def test_async_remove_growspace(coordinator: GrowspaceCoordinator) -> None
 
     # Verify device removed
     assert dev_reg.async_get_device(identifiers={(DOMAIN, gs.id)}) is None
+    assert entity_reg.async_get(active_entity.entity_id) is None
+    assert entity_reg.async_get(disabled_entity.entity_id) is None
 
 
 @pytest.mark.asyncio
@@ -1620,7 +1641,9 @@ async def test_async_move_plant(hass: HomeAssistant) -> None:
     gs = await coordinator._growspace_manager.add_growspace(
         "Test GS", rows=2, plants_per_row=2
     )
-    plant = await coordinator._plant_manager.add_plant(gs.id, "Test Plant", row=1, col=1)
+    plant = await coordinator._plant_manager.add_plant(
+        gs.id, "Test Plant", row=1, col=1
+    )
 
     await coordinator._plant_manager.move_plant(plant.plant_id, 2, 2)
 


### PR DESCRIPTION
## Summary

- remove entity-registry entries associated with a growspace device before deleting the device
- include disabled entities so they cannot keep an orphan device visible
- replace the incomplete device-removal test setup with a real device and active/disabled entity entries

## Testing

- `../../.venv/bin/pytest -q tests/core/test_coordinator.py::test_async_remove_growspace`
- `../../.venv/bin/pytest -q tests/integration/test_services_growspace_coverage.py tests/core/test_coordinator.py -k "remove_growspace"`
- pre-commit hooks: ruff check, ruff format, codespell, check json, branch guard, yamllint, prettier