### PR TITLE
Fix stable release on protected main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,36 +26,13 @@ jobs:
         id: version_step
         run: |
           MANIFEST="custom_components/growspace_manager/manifest.json"
-          BASE_VERSION="$(jq -r .version "$MANIFEST")"
-          VERSION="$(
-            python3 .github/scripts/prerelease_version.py \
-              --stable "$BASE_VERSION"
-          )"
-          echo "Updating version to $VERSION"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          cd custom_components/growspace_manager
-          # Use jq to reliably update the version
-          if ! jq --arg v "$VERSION" '.version = $v' manifest.json \
-            > manifest.json.tmp; then
-            echo "jq command failed"
+          VERSION="$(jq -r .version "$MANIFEST")"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Expected stable X.Y.Z manifest version, got $VERSION" >&2
             exit 1
           fi
-          mv manifest.json.tmp manifest.json
-          cd ../..
-
-      - name: Commit stable version
-        id: stable_commit
-        env:
-          VERSION: ${{ steps.version_step.outputs.version }}
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add custom_components/growspace_manager/manifest.json
-          if ! git diff --staged --quiet; then
-            git commit -m "chore: bump version to v$VERSION"
-            git push origin HEAD:main
-          fi
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "Publishing version $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       # 2. Creates the ZIP file
       - name: ZIP Release
@@ -73,7 +50,7 @@ jobs:
         uses: softprops/action-gh-release@v3.0.2
         with:
           tag_name: v${{ steps.version_step.outputs.version }}
-          target_commitish: ${{ steps.stable_commit.outputs.sha }}
+          target_commitish: ${{ github.sha }}
           generate_release_notes: true
           files: |
             growspace_manager.zip
@@ -83,7 +60,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: v${{ steps.version_step.outputs.version }}
-          TARGET_SHA: ${{ steps.stable_commit.outputs.sha }}
+          TARGET_SHA: ${{ github.sha }}
         run: |
           tag_sha="$(
             gh api \

--- a/custom_components/growspace_manager/manifest.json
+++ b/custom_components/growspace_manager/manifest.json
@@ -18,5 +18,5 @@
     "beautifulsoup4>=4.12.0"
   ],
   "single_config_entry": true,
-  "version": "1.2.1"
+  "version": "1.2.2"
 }

--- a/tests/test_prerelease_publishing.py
+++ b/tests/test_prerelease_publishing.py
@@ -1,5 +1,6 @@
 """Regression tests for the active prerelease publishing channel."""
 
+import json
 from pathlib import Path
 import runpy
 
@@ -9,6 +10,7 @@ import yaml
 REPO_ROOT = Path(__file__).parents[1]
 WORKFLOW_PATH = REPO_ROOT / ".github/workflows/prerelease.yaml"
 STABLE_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/release.yaml"
+MANIFEST_PATH = REPO_ROOT / "custom_components/growspace_manager/manifest.json"
 VERSION_SCRIPT = REPO_ROOT / ".github/scripts/prerelease_version.py"
 
 
@@ -57,6 +59,7 @@ def test_stable_publishing_contract() -> None:
     """A main push must publish and verify the next stable patch release."""
     version_module = runpy.run_path(VERSION_SCRIPT)
     assert version_module["next_stable_version"]("1.2.1") == "1.2.2"
+    assert json.loads(MANIFEST_PATH.read_text())["version"] == "1.2.2"
 
     workflow = yaml.safe_load(STABLE_WORKFLOW_PATH.read_text())
     assert workflow["on"] == {
@@ -71,10 +74,9 @@ def test_stable_publishing_contract() -> None:
     steps = workflow["jobs"]["build"]["steps"]
     release = next(step for step in steps if step.get("name") == "Create Release")
     assert release["with"]["tag_name"] == "v${{ steps.version_step.outputs.version }}"
-    assert (
-        release["with"]["target_commitish"] == "${{ steps.stable_commit.outputs.sha }}"
-    )
+    assert release["with"]["target_commitish"] == "${{ github.sha }}"
     assert release["with"]["fail_on_unmatched_files"] is True
+    assert not any(step.get("name") == "Commit stable version" for step in steps)
 
     verification = next(
         step for step in steps if step.get("name") == "Verify release tag"


### PR DESCRIPTION
## Summary

- remove the workflow push that protected `main` rejects
- bump the committed manifest version to `1.2.2`
- publish and verify `v1.2.2` against the merged commit SHA
- keep the release artifact and repository tag on the same version

## Root cause

The release workflow created a local version-bump commit and attempted `git push origin HEAD:main`. Repository rules rejected that direct push with `GH013`, so packaging and release creation were skipped.

## Validation

- full pre-commit hook suite passed
- focused release publishing tests: 2 passed
- Ruff, yamllint, Prettier, and JSON validation passed

Fixes failed run: https://github.com/Venosta-web/growspace_manager/actions/runs/32387946850/job/96486918700