### PR TITLE
Remove dead auto-harvest scaffolding

### DIFF
--- a/custom_components/growspace_manager/const.py
+++ b/custom_components/growspace_manager/const.py
@@ -801,7 +801,6 @@ DATE_FIELDS = [
     "cure_start",
     "mother_start",
     "clone_start",
-    "transition_date",  # Also include transition_date as it's used in some services
 ]
 
 SPECIAL_GROWSPACES = {

--- a/custom_components/growspace_manager/models/plant.py
+++ b/custom_components/growspace_manager/models/plant.py
@@ -143,7 +143,6 @@ class Plant(BaseModel):
     cure_start: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
-    transition_date: str | None = None
     source_mother: str | None = None
     seed_batch_id: str | None = None
     sex: str | None = None

--- a/custom_components/growspace_manager/services/plant_facade.py
+++ b/custom_components/growspace_manager/services/plant_facade.py
@@ -28,7 +28,6 @@ from custom_components.growspace_manager.const import (
     CANONICAL_ID_MOTHER,
     DATE_FIELDS,
     GrowspaceService,
-    NotificationTier,
     PlantStage,
 )
 from custom_components.growspace_manager.exceptions import GrowspaceError
@@ -284,34 +283,6 @@ class PlantFacade:
             cbd_percentage=cbd_percentage,
             terpene_profile=terpene_profile,
         )
-
-    async def _async_auto_harvest(self) -> None:
-        """Automatically harvest plants whose transition date has passed."""
-        today = dt_util.now().date().isoformat()
-        plants_to_harvest = [
-            plant
-            for plant in self._coordinator.plants.values()
-            if plant.transition_date
-            and plant.transition_date <= today
-            and plant.stage == PlantStage.FLOWER
-        ]
-        for plant in plants_to_harvest:
-            plant_id = plant.plant_id
-            strain_name = plant.genetics.strain_name
-            gs_id = plant.growspace_id
-            _LOGGER.info(
-                "Auto-harvesting plant %s (%s) in %s", plant_id, strain_name, gs_id
-            )
-            await self._coordinator._plant_manager.harvest(
-                plant_id=plant_id,
-                transition_date=today,
-            )
-            await self._coordinator._notification_manager.async_send_notification(
-                growspace_id=gs_id,
-                title="Auto-harvest complete",
-                message=f"Plant {strain_name} has been auto-harvested",
-                tier=NotificationTier.INFO,
-            )
 
     # -------------------------------------------------------------------------
     # Watering and IPM
@@ -590,10 +561,7 @@ class PlantFacade:
             row = call.data[ATTR_ROW]
             col = call.data[ATTR_COL]
 
-            add_date_fields = [f for f in DATE_FIELDS if f != "transition_date"]
-            parsed_dates = {
-                f: parse_date_field(call.data.get(f)) for f in add_date_fields
-            }
+            parsed_dates = {f: parse_date_field(call.data.get(f)) for f in DATE_FIELDS}
 
             if growspace_id == CANONICAL_ID_MOTHER and not parsed_dates.get(
                 "mother_start"
@@ -682,10 +650,7 @@ class PlantFacade:
             )
             batch_generation = batch.generation if batch else ""
 
-            add_date_fields = [f for f in DATE_FIELDS if f != "transition_date"]
-            parsed_dates = {
-                f: parse_date_field(call.data.get(f)) for f in add_date_fields
-            }
+            parsed_dates = {f: parse_date_field(call.data.get(f)) for f in DATE_FIELDS}
 
             if growspace_id == CANONICAL_ID_MOTHER and not parsed_dates.get(
                 "mother_start"

--- a/custom_components/growspace_manager/websocket/plant.py
+++ b/custom_components/growspace_manager/websocket/plant.py
@@ -294,8 +294,7 @@ SCHEMA_WS_PRINT_LABEL = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 
 def _parse_date_kwargs(msg: dict[str, Any]) -> dict[str, Any]:
     """Extract and parse optional date fields from a WS message."""
-    add_date_fields = [f for f in DATE_FIELDS if f != "transition_date"]
-    return {f: parse_date_field(msg[f]) for f in add_date_fields if f in msg}
+    return {f: parse_date_field(msg[f]) for f in DATE_FIELDS if f in msg}
 
 
 async def websocket_water_plant(

--- a/tests/contract/test_growspace_payload_contract.py
+++ b/tests/contract/test_growspace_payload_contract.py
@@ -445,7 +445,6 @@ def _maximal_plant() -> Plant:
         cure_start="2026-08-01T00:00:00+00:00",
         created_at="2026-01-01T00:00:00+00:00",
         updated_at="2026-08-11",
-        transition_date="2026-08-01T00:00:00+00:00",
         source_mother="mother-contract",
         seed_batch_id="batch-contract",
         sex="female",

--- a/tests/core/snapshots/test_models_snapshots.ambr
+++ b/tests/core/snapshots/test_models_snapshots.ambr
@@ -509,7 +509,6 @@
     'stage': 'veg',
     'stage_history': list([
     ]),
-    'transition_date': None,
     'type': 'normal',
     'updated_at': None,
     'veg_start': None,

--- a/tests/integration/test_facade_coverage.py
+++ b/tests/integration/test_facade_coverage.py
@@ -1,9 +1,7 @@
-from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.growspace_manager.const import PlantStage
 from custom_components.growspace_manager.models import DrainConfig, Growspace
 from custom_components.growspace_manager.services.facade import ServiceFacade
 from homeassistant.exceptions import ServiceValidationError
@@ -19,34 +17,6 @@ async def test_update_plant_name_change(mock_coordinator, mock_plant) -> None:
         await facade.plants.update_plant("plant_1", name="New Plant Name")
 
     async_get_registry.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_async_auto_harvest(mock_coordinator, mock_plant) -> None:
-    """Test auto-harvesting plants that reached their transition date."""
-    facade = ServiceFacade(mock_coordinator)
-
-    # Setup plant to be harvested
-    # Today is 2026-01-12 in frozen time (if frozen, otherwise use real date or mock it)
-    # The integration uses datetime.now().date().isoformat()
-    today = datetime.now().date().isoformat()
-
-    mock_plant.plant_id = "p1"
-    mock_plant.transition_date = today
-    mock_plant.stage = PlantStage.FLOWER
-    mock_plant.genetics.strain_name = "Blue Dream"
-    mock_plant.growspace_id = "gs1"
-
-    mock_coordinator.plants = {"p1": mock_plant}
-    mock_coordinator._plant_manager.harvest = AsyncMock()
-    mock_coordinator._notification_manager.async_send_notification = AsyncMock()
-
-    await facade.plants._async_auto_harvest()
-
-    mock_coordinator._plant_manager.harvest.assert_called_once_with(
-        plant_id="p1", transition_date=today
-    )
-    mock_coordinator._notification_manager.async_send_notification.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_plant_facade_coverage.py
+++ b/tests/integration/test_plant_facade_coverage.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.growspace_manager.const import NotificationTier, PlantStage
+from custom_components.growspace_manager.const import PlantStage
 from custom_components.growspace_manager.models import Plant, PlantGenetics
 from custom_components.growspace_manager.services.plant_facade import PlantFacade
 from homeassistant.exceptions import ServiceValidationError
@@ -292,40 +292,6 @@ async def test_async_harvest_plant(mock_coordinator: MagicMock) -> None:
         thc_percentage=None,
         cbd_percentage=None,
         terpene_profile=None,
-    )
-
-
-@pytest.mark.asyncio
-async def test_async_auto_harvest(mock_coordinator: MagicMock) -> None:
-    """Test _async_auto_harvest auto-harvests eligible flowering plants only."""
-    facade = PlantFacade(mock_coordinator)
-
-    plant1 = Plant(plant_id="plant1", growspace_id="gs1")
-    plant1.genetics = PlantGenetics(strain_name="OG Kush")
-    plant1.transition_date = "2026-01-10"  # before frozen "2026-01-12"
-    plant1.stage = PlantStage.FLOWER
-
-    plant2 = Plant(plant_id="plant2", growspace_id="gs1")
-    plant2.genetics = PlantGenetics(strain_name="LSD")
-    plant2.transition_date = "2026-01-15"  # after frozen
-    plant2.stage = PlantStage.FLOWER
-
-    mock_coordinator.plants = {"plant1": plant1, "plant2": plant2}
-    mock_coordinator._plant_manager.harvest = AsyncMock()
-    mock_coordinator._notification_manager.async_send_notification = AsyncMock()
-
-    # Call private method
-    await facade._async_auto_harvest()
-
-    mock_coordinator._plant_manager.harvest.assert_called_once_with(
-        plant_id="plant1",
-        transition_date="2026-01-12",
-    )
-    mock_coordinator._notification_manager.async_send_notification.assert_called_once_with(
-        growspace_id="gs1",
-        title="Auto-harvest complete",
-        message="Plant OG Kush has been auto-harvested",
-        tier=NotificationTier.INFO,
     )
 
 


### PR DESCRIPTION
Closes #631

## Summary

- Remove the unused `Plant.transition_date` field.
- Remove the unreferenced auto-harvest scheduler method.
- Remove the obsolete date-field exclusions and update affected tests and snapshots.

## Verification

- 5,091 tests passed.
- 99% coverage.
- Ruff passed.
- mypy passed for the affected source files.
- `git diff --check` passed.