### PR TITLE
Skip stable release when manifest version is unchanged

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,8 +34,23 @@ jobs:
           echo "Publishing version $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Check for existing release
+        id: check_release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: v${{ steps.version_step.outputs.version }}
+        run: |
+          if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG_NAME" \
+            >/dev/null 2>&1; then
+            echo "Release $TAG_NAME already exists; skipping"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # 2. Creates the ZIP file
       - name: ZIP Release
+        if: steps.check_release.outputs.exists != 'true'
         run: |
           cd custom_components/growspace_manager
           zip -r ../../growspace_manager.zip . \
@@ -47,6 +62,7 @@ jobs:
 
       # 3. Creates the GitHub Release and attaches the new zip file
       - name: Create Release
+        if: steps.check_release.outputs.exists != 'true'
         uses: softprops/action-gh-release@v3.0.2
         with:
           tag_name: v${{ steps.version_step.outputs.version }}
@@ -57,6 +73,7 @@ jobs:
           fail_on_unmatched_files: true
 
       - name: Verify release tag
+        if: steps.check_release.outputs.exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: v${{ steps.version_step.outputs.version }}


### PR DESCRIPTION
## Summary

- `release.yaml` fires on every push to `main` and republishes whatever version is currently in `manifest.json`
- when a merge doesn't bump the version (e.g. #630, a docs-only change), it reuses the existing tag/release
- `softprops/action-gh-release` updates the release's `target_commitish` metadata but does not move an already-existing git tag ref, so the "Verify release tag" step correctly failed against the new commit
- adds a "Check for existing release" step that skips ZIP/Create Release/Verify when a release for the current version already exists, so the job only publishes on an actual version bump

## Root cause

Run https://github.com/Venosta-web/growspace_manager/actions/runs/32500315377/job/96828225769 failed because `manifest.json` was still `1.2.2` (last bumped for the #629 release). The workflow republished against that unchanged version, found tag `v1.2.2` already existed at the old commit, and the verify step (added in #629) correctly caught the tag/commit mismatch.

## Validation

- `yamllint .github/workflows/release.yaml` passes
- pre-commit hooks pass

Fixes failed run: https://github.com/Venosta-web/growspace_manager/actions/runs/32500315377/job/96828225769