### PR TITLE
Automate stale branch cleanup

### DIFF
--- a/.github/scripts/branch-cleanup.cjs
+++ b/.github/scripts/branch-cleanup.cjs
@@ -1,0 +1,396 @@
+"use strict";
+
+const DEFAULT_KEEP_BRANCHES = [
+  "dev",
+  "prerelease",
+  "feat-stageAnalyzer",
+  "feat-stageAnalyizer",
+];
+const DEFAULT_KEEP_PREFIXES = ["release/"];
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+function csv(value) {
+  return String(value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function integerFromEnv(name, fallback) {
+  const value = Number.parseInt(process.env[name] ?? "", 10);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function booleanFromEnv(name, fallback = false) {
+  const value = process.env[name];
+  if (value === undefined || value === "") return fallback;
+  return value.toLowerCase() === "true";
+}
+
+function branchIsReserved(name, defaultBranch, keepBranches, keepPrefixes) {
+  return (
+    name === defaultBranch ||
+    keepBranches.has(name) ||
+    keepPrefixes.some((prefix) => name.startsWith(prefix))
+  );
+}
+
+function classifyBranch({
+  name,
+  defaultBranch,
+  protected: isProtected,
+  hasOpenPullRequest,
+  tipDate,
+  aheadBy,
+  now,
+  mergedGraceDays,
+  staleDays,
+  keepBranches,
+  keepPrefixes,
+}) {
+  if (branchIsReserved(name, defaultBranch, keepBranches, keepPrefixes)) {
+    return { action: "keep", reason: "reserved" };
+  }
+  if (isProtected) return { action: "keep", reason: "protected" };
+  if (hasOpenPullRequest)
+    return { action: "keep", reason: "open pull request" };
+
+  const ageDays = Math.max(
+    0,
+    Math.floor((now.getTime() - tipDate.getTime()) / DAY_IN_MS),
+  );
+  if (aheadBy === 0 && ageDays >= mergedGraceDays) {
+    return { action: "delete", reason: "merged", ageDays };
+  }
+  if (aheadBy === 0) {
+    return { action: "keep", reason: "recently merged", ageDays };
+  }
+  if (ageDays >= staleDays) {
+    return { action: "report", reason: "stale and unmerged", ageDays };
+  }
+  return { action: "keep", reason: "active and unmerged", ageDays };
+}
+
+function markdown(value) {
+  return String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+async function mapLimit(items, limit, callback) {
+  const results = new Array(items.length);
+  let cursor = 0;
+
+  async function worker() {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await callback(items[index], index);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, worker),
+  );
+  return results;
+}
+
+function configuration(defaultBranch) {
+  return {
+    defaultBranch,
+    dryRun: booleanFromEnv("DRY_RUN"),
+    mergedGraceDays: integerFromEnv("MERGED_GRACE_DAYS", 7),
+    staleDays: integerFromEnv("STALE_DAYS", 180),
+    keepBranches: new Set([
+      ...DEFAULT_KEEP_BRANCHES,
+      ...csv(process.env.KEEP_BRANCHES),
+    ]),
+    keepPrefixes: [...DEFAULT_KEEP_PREFIXES, ...csv(process.env.KEEP_PREFIXES)],
+  };
+}
+
+async function inspectBranch({
+  github,
+  owner,
+  repo,
+  branch,
+  openPullRequestBranches,
+  config,
+}) {
+  const commit = await github.rest.repos.getCommit({
+    owner,
+    repo,
+    ref: branch.name,
+  });
+  const tipDateValue =
+    commit.data.commit.committer?.date ?? commit.data.commit.author?.date;
+  if (!tipDateValue)
+    throw new Error("tip commit has no author or committer date");
+
+  const comparison = await github.rest.repos.compareCommitsWithBasehead({
+    owner,
+    repo,
+    basehead: `${config.defaultBranch}...${branch.name}`,
+  });
+  const result = classifyBranch({
+    name: branch.name,
+    defaultBranch: config.defaultBranch,
+    protected: branch.protected,
+    hasOpenPullRequest: openPullRequestBranches.has(branch.name),
+    tipDate: new Date(tipDateValue),
+    aheadBy: comparison.data.ahead_by,
+    now: new Date(),
+    mergedGraceDays: config.mergedGraceDays,
+    staleDays: config.staleDays,
+    keepBranches: config.keepBranches,
+    keepPrefixes: config.keepPrefixes,
+  });
+
+  return {
+    branch: branch.name,
+    tipSha: branch.commit.sha,
+    tipDate: tipDateValue,
+    aheadBy: comparison.data.ahead_by,
+    ...result,
+  };
+}
+
+async function sweepBranches({ github, context, core }) {
+  const { owner, repo } = context.repo;
+  const repository = await github.rest.repos.get({ owner, repo });
+  const config = configuration(repository.data.default_branch);
+  const [branches, openPullRequests] = await Promise.all([
+    github.paginate(github.rest.repos.listBranches, {
+      owner,
+      repo,
+      per_page: 100,
+    }),
+    github.paginate(github.rest.pulls.list, {
+      owner,
+      repo,
+      state: "open",
+      per_page: 100,
+    }),
+  ]);
+  const openPullRequestBranches = new Set();
+  for (const pullRequest of openPullRequests) {
+    if (pullRequest.head.repo?.full_name === `${owner}/${repo}`) {
+      openPullRequestBranches.add(pullRequest.head.ref);
+    }
+    // A merged branch can still be the base of a stacked pull request.
+    // Keep that base until the dependent pull request is closed or retargeted.
+    if (pullRequest.base.repo?.full_name === `${owner}/${repo}`) {
+      openPullRequestBranches.add(pullRequest.base.ref);
+    }
+  }
+  const candidates = branches.filter(
+    (branch) =>
+      !branchIsReserved(
+        branch.name,
+        config.defaultBranch,
+        config.keepBranches,
+        config.keepPrefixes,
+      ),
+  );
+
+  const inspections = await mapLimit(candidates, 8, async (branch) => {
+    try {
+      return await inspectBranch({
+        github,
+        owner,
+        repo,
+        branch,
+        openPullRequestBranches,
+        config,
+      });
+    } catch (error) {
+      return { branch: branch.name, action: "error", reason: error.message };
+    }
+  });
+
+  const deleted = [];
+  const changed = [];
+  const stale = [];
+  const errors = inspections.filter((result) => result.action === "error");
+  for (const result of inspections) {
+    if (result.action === "report") stale.push(result);
+    if (result.action !== "delete") continue;
+
+    if (config.dryRun) {
+      deleted.push({ ...result, dryRun: true });
+      continue;
+    }
+    try {
+      const currentBranch = await github.rest.repos.getBranch({
+        owner,
+        repo,
+        branch: result.branch,
+      });
+      if (
+        currentBranch.data.protected ||
+        currentBranch.data.commit.sha !== result.tipSha
+      ) {
+        changed.push(result);
+        continue;
+      }
+      await github.rest.git.deleteRef({
+        owner,
+        repo,
+        ref: `heads/${result.branch}`,
+      });
+      deleted.push(result);
+    } catch (error) {
+      errors.push({
+        branch: result.branch,
+        action: "error",
+        reason: error.message,
+      });
+    }
+  }
+
+  core.summary
+    .addHeading("Branch maintenance")
+    .addRaw(
+      `${config.dryRun ? "Dry run: would delete" : "Deleted"} **${deleted.length}** merged branch(es). ` +
+        `Found **${stale.length}** stale unmerged branch(es); those were not deleted.\n\n`,
+    );
+
+  if (deleted.length > 0) {
+    core.summary.addHeading(
+      config.dryRun
+        ? "Merged branches eligible for deletion"
+        : "Deleted branches",
+      2,
+    );
+    core.summary.addTable([
+      [
+        { data: "Branch", header: true },
+        { data: "Tip age", header: true },
+      ],
+      ...deleted.map((result) => [
+        markdown(result.branch),
+        `${result.ageDays} days`,
+      ]),
+    ]);
+  }
+  if (stale.length > 0) {
+    core.summary.addHeading("Review manually: stale unmerged branches", 2);
+    core.summary.addTable([
+      [
+        { data: "Branch", header: true },
+        { data: "Tip age", header: true },
+        { data: "Commits ahead", header: true },
+      ],
+      ...stale.map((result) => [
+        markdown(result.branch),
+        `${result.ageDays} days`,
+        String(result.aheadBy),
+      ]),
+    ]);
+  }
+  if (changed.length > 0) {
+    core.summary.addHeading(
+      "Kept because the branch changed during the sweep",
+      2,
+    );
+    core.summary.addList(changed.map((result) => markdown(result.branch)));
+  }
+  if (errors.length > 0) {
+    core.summary.addHeading("Errors", 2).addTable([
+      [
+        { data: "Branch", header: true },
+        { data: "Error", header: true },
+      ],
+      ...errors.map((result) => [
+        markdown(result.branch),
+        markdown(result.reason),
+      ]),
+    ]);
+  }
+  await core.summary.write();
+
+  if (errors.length > 0) {
+    core.setFailed(
+      `Branch maintenance failed for ${errors.length} branch(es).`,
+    );
+  }
+}
+
+async function deleteMergedPullRequestBranch({ github, context, core }) {
+  const pullRequest = context.payload.pull_request;
+  if (!pullRequest?.merged) return;
+
+  const { owner, repo } = context.repo;
+  if (pullRequest.head.repo?.full_name !== `${owner}/${repo}`) {
+    core.info(
+      "The merged pull request came from a fork; there is no repository branch to delete.",
+    );
+    return;
+  }
+
+  const repository = await github.rest.repos.get({ owner, repo });
+  const config = configuration(repository.data.default_branch);
+  const branchName = pullRequest.head.ref;
+  if (
+    branchIsReserved(
+      branchName,
+      config.defaultBranch,
+      config.keepBranches,
+      config.keepPrefixes,
+    )
+  ) {
+    core.info(`Keeping reserved branch ${branchName}.`);
+    return;
+  }
+
+  try {
+    const branch = await github.rest.repos.getBranch({
+      owner,
+      repo,
+      branch: branchName,
+    });
+    if (branch.data.protected) {
+      core.info(`Keeping protected branch ${branchName}.`);
+      return;
+    }
+    if (branch.data.commit.sha !== pullRequest.head.sha) {
+      core.info(
+        `Keeping ${branchName}; it changed after the pull request merged.`,
+      );
+      return;
+    }
+    const dependentPullRequests = await github.paginate(
+      github.rest.pulls.list,
+      {
+        owner,
+        repo,
+        state: "open",
+        base: branchName,
+        per_page: 100,
+      },
+    );
+    if (dependentPullRequests.length > 0) {
+      core.info(
+        `Keeping ${branchName}; it is the base of ${dependentPullRequests.length} open pull request(s).`,
+      );
+      return;
+    }
+    await github.rest.git.deleteRef({
+      owner,
+      repo,
+      ref: `heads/${branchName}`,
+    });
+    core.notice(`Deleted merged pull request branch ${branchName}.`);
+  } catch (error) {
+    if (error.status === 404 || error.status === 422) {
+      core.info(`Branch ${branchName} is already absent or cannot be deleted.`);
+      return;
+    }
+    throw error;
+  }
+}
+
+module.exports = {
+  branchIsReserved,
+  classifyBranch,
+  deleteMergedPullRequestBranch,
+  sweepBranches,
+};

--- a/.github/scripts/branch-cleanup.test.cjs
+++ b/.github/scripts/branch-cleanup.test.cjs
@@ -1,0 +1,259 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  branchIsReserved,
+  classifyBranch,
+  deleteMergedPullRequestBranch,
+} = require("./branch-cleanup.cjs");
+
+const now = new Date("2026-08-22T00:00:00Z");
+const keepBranches = new Set(["dev", "prerelease"]);
+const keepPrefixes = ["release/"];
+
+function classify(overrides = {}) {
+  return classifyBranch({
+    name: "feat/example",
+    defaultBranch: "main",
+    protected: false,
+    hasOpenPullRequest: false,
+    tipDate: new Date("2025-08-22T00:00:00Z"),
+    aheadBy: 0,
+    now,
+    mergedGraceDays: 7,
+    staleDays: 180,
+    keepBranches,
+    keepPrefixes,
+    ...overrides,
+  });
+}
+
+test("recognizes exact and prefix-based reserved branches", () => {
+  assert.equal(
+    branchIsReserved("main", "main", keepBranches, keepPrefixes),
+    true,
+  );
+  assert.equal(
+    branchIsReserved("dev", "main", keepBranches, keepPrefixes),
+    true,
+  );
+  assert.equal(
+    branchIsReserved("release/v2", "main", keepBranches, keepPrefixes),
+    true,
+  );
+  assert.equal(
+    branchIsReserved(
+      "feature/release-notes",
+      "main",
+      keepBranches,
+      keepPrefixes,
+    ),
+    false,
+  );
+});
+
+test("deletes only old branches fully contained in the default branch", () => {
+  assert.deepEqual(classify(), {
+    action: "delete",
+    reason: "merged",
+    ageDays: 365,
+  });
+  assert.deepEqual(classify({ aheadBy: 2 }), {
+    action: "report",
+    reason: "stale and unmerged",
+    ageDays: 365,
+  });
+});
+
+test("keeps protected branches and branches with open pull requests", () => {
+  assert.deepEqual(classify({ protected: true }), {
+    action: "keep",
+    reason: "protected",
+  });
+  assert.deepEqual(classify({ hasOpenPullRequest: true }), {
+    action: "keep",
+    reason: "open pull request",
+  });
+});
+
+test("honors the merged-branch grace period", () => {
+  assert.deepEqual(classify({ tipDate: new Date("2026-08-20T00:00:00Z") }), {
+    action: "keep",
+    reason: "recently merged",
+    ageDays: 2,
+  });
+});
+
+test("merged pull request cleanup preserves protected branches", async () => {
+  let deleted = false;
+  const github = {
+    paginate: async () => [],
+    rest: {
+      repos: {
+        get: async () => ({ data: { default_branch: "main" } }),
+        getBranch: async () => ({
+          data: { protected: true, commit: { sha: "abc123" } },
+        }),
+      },
+      pulls: { list() {} },
+      git: {
+        deleteRef: async () => {
+          deleted = true;
+        },
+      },
+    },
+  };
+  const context = {
+    repo: { owner: "example", repo: "project" },
+    payload: {
+      pull_request: {
+        merged: true,
+        head: {
+          ref: "feat/example",
+          sha: "abc123",
+          repo: { full_name: "example/project" },
+        },
+      },
+    },
+  };
+
+  await deleteMergedPullRequestBranch({ github, context, core: { info() {} } });
+  assert.equal(deleted, false);
+});
+
+test("merged pull request cleanup deletes an ordinary repository branch", async () => {
+  let deletedRef;
+  const github = {
+    paginate: async () => [],
+    rest: {
+      repos: {
+        get: async () => ({ data: { default_branch: "main" } }),
+        getBranch: async () => ({
+          data: { protected: false, commit: { sha: "abc123" } },
+        }),
+      },
+      pulls: { list() {} },
+      git: {
+        deleteRef: async ({ ref }) => {
+          deletedRef = ref;
+        },
+      },
+    },
+  };
+  const context = {
+    repo: { owner: "example", repo: "project" },
+    payload: {
+      pull_request: {
+        merged: true,
+        head: {
+          ref: "feat/example",
+          sha: "abc123",
+          repo: { full_name: "example/project" },
+        },
+      },
+    },
+  };
+
+  await deleteMergedPullRequestBranch({
+    github,
+    context,
+    core: { info() {}, notice() {} },
+  });
+  assert.equal(deletedRef, "heads/feat/example");
+});
+
+test("merged pull request cleanup preserves the base of a stacked pull request", async () => {
+  let deleted = false;
+  const github = {
+    paginate: async () => [{ number: 42 }],
+    rest: {
+      repos: {
+        get: async () => ({ data: { default_branch: "main" } }),
+        getBranch: async () => ({
+          data: { protected: false, commit: { sha: "abc123" } },
+        }),
+      },
+      pulls: { list() {} },
+      git: {
+        deleteRef: async () => {
+          deleted = true;
+        },
+      },
+    },
+  };
+  const context = {
+    repo: { owner: "example", repo: "project" },
+    payload: {
+      pull_request: {
+        merged: true,
+        head: {
+          ref: "feat/example",
+          sha: "abc123",
+          repo: { full_name: "example/project" },
+        },
+      },
+    },
+  };
+  const messages = [];
+
+  await deleteMergedPullRequestBranch({
+    github,
+    context,
+    core: {
+      info(message) {
+        messages.push(message);
+      },
+    },
+  });
+  assert.equal(deleted, false);
+  assert.match(messages.at(-1), /base of 1 open pull request/);
+});
+
+test("merged pull request cleanup preserves a branch updated after merge", async () => {
+  let deleted = false;
+  const github = {
+    paginate: async () => [],
+    rest: {
+      repos: {
+        get: async () => ({ data: { default_branch: "main" } }),
+        getBranch: async () => ({
+          data: { protected: false, commit: { sha: "new-tip" } },
+        }),
+      },
+      pulls: { list() {} },
+      git: {
+        deleteRef: async () => {
+          deleted = true;
+        },
+      },
+    },
+  };
+  const context = {
+    repo: { owner: "example", repo: "project" },
+    payload: {
+      pull_request: {
+        merged: true,
+        head: {
+          ref: "feat/example",
+          sha: "merged-tip",
+          repo: { full_name: "example/project" },
+        },
+      },
+    },
+  };
+  const messages = [];
+
+  await deleteMergedPullRequestBranch({
+    github,
+    context,
+    core: {
+      info(message) {
+        messages.push(message);
+      },
+    },
+  });
+  assert.equal(deleted, false);
+  assert.match(messages.at(-1), /changed after the pull request merged/);
+});

--- a/.github/workflows/branch-maintenance.yaml
+++ b/.github/workflows/branch-maintenance.yaml
@@ -1,0 +1,75 @@
+---
+name: Branch maintenance
+
+"on":
+  pull_request:
+    types: [closed]
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report merged branches without deleting them
+        type: boolean
+        default: true
+      merged_grace_days:
+        description: Minimum age of a merged branch before the sweep deletes it
+        type: string
+        default: "7"
+      stale_days:
+        description: Age at which unmerged branches appear in the review report
+        type: string
+        default: "180"
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: branch-maintenance
+  cancel-in-progress: false
+
+jobs:
+  maintain-branches:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      DRY_RUN: >-
+        ${{ github.event_name == 'workflow_dispatch' &&
+        inputs.dry_run || 'false' }}
+      MERGED_GRACE_DAYS: ${{ inputs.merged_grace_days || '7' }}
+      STALE_DAYS: ${{ inputs.stale_days || '180' }}
+      # Extend these as the integration model evolves.
+      KEEP_BRANCHES: dev,prerelease,feat-stageAnalyzer,feat-stageAnalyizer
+      KEEP_PREFIXES: release/
+    steps:
+      - name: Check out the trusted default branch
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Delete the merged pull request branch
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const maintenance = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/branch-cleanup.cjs`
+            );
+            await maintenance.deleteMergedPullRequestBranch({
+              github,
+              context,
+              core,
+            });
+
+      - name: Sweep merged branches and report stale work
+        if: github.event_name != 'pull_request'
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const maintenance = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/branch-cleanup.cjs`
+            );
+            await maintenance.sweepBranches({ github, context, core });

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,7 @@
+---
 name: Tests
 
-on:
+"on":
   push:
   pull_request:
 
@@ -9,6 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v7.0.0
+        name: Setup Node.js
+        with:
+          node-version: "24"
+      - name: Test branch maintenance safeguards
+        run: node --test .github/scripts/branch-cleanup.test.cjs
       - uses: actions/setup-python@v6.2.0
         name: Setup Python
         with:
@@ -24,19 +31,21 @@ jobs:
             ${{ runner.os }}-pip-
       - name: update pip
         run: python -m pip install --upgrade pip setuptools wheel
-      # Two-phase install so every Home-Assistant-owned dependency resolves to the
-      # version this HA release actually supports. Installing requirements.txt in one
-      # unconstrained pass let hassil float past HA 2026.5.4 and zeroed out collection
-      # on a commit that had passed a month earlier (ADR-0020, 2026-08-07 amendment).
+      # Two-phase install so every Home-Assistant-owned dependency resolves to
+      # the version this HA release actually supports. Installing
+      # requirements.txt in one unconstrained pass let hassil float past HA
+      # 2026.5.4 and zeroed out collection on a commit that had passed a month
+      # earlier (ADR-0020, 2026-08-07 amendment).
       - name: install dependencies
+        # yamllint disable rule:line-length
         run: |
-          # Phase 1: HA alone, so its package_constraints.txt is on disk to constrain phase 2.
+          # Phase 1: install HA so its constraints are available for phase 2.
           pip install "$(grep '^homeassistant==' requirements.txt)"
           pip install -r requirements.txt -c "$(
             python -c 'import homeassistant, pathlib; print(pathlib.Path(homeassistant.__file__).parent / "package_constraints.txt")'
           )"
-      # Makes the resolved set visible in the log, so a future "it passed last month"
-      # can be diffed against what actually got installed.
+        # yamllint enable rule:line-length
+      # Expose the resolved set so time-dependent failures can be compared.
       - name: record resolved dependency set
         run: pip freeze
       - name: Run Unit Tests


### PR DESCRIPTION
## Summary

- delete same-repository PR branches immediately after merge
- sweep weekly for branches already fully contained in the default branch
- report stale unmerged branches without deleting them
- preserve protected/reserved branches, open and stacked PR branches, and branches whose tip changed during cleanup
- add a manual dry-run with configurable age thresholds

## Validation

- `node --test .github/scripts/branch-cleanup.test.cjs` (8 safeguards)
- pre-commit hooks: codespell, yamllint, Prettier
- JavaScript syntax checks
- `git diff --check`

## Initial cleanup

The existing backlog was handled separately before this PR: 183 old branches fully merged into `main` were deleted, while seven old branches containing unmerged commits were preserved for manual review.