### PR TITLE
Make Plant Lifecycle mutations atomic

### DIFF
--- a/custom_components/growspace_manager/managers/plant.py
+++ b/custom_components/growspace_manager/managers/plant.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
+from dataclasses import fields
 from datetime import date
 import logging
 from typing import TYPE_CHECKING, Any
@@ -15,6 +17,14 @@ from custom_components.growspace_manager.const import (
     PlantStage,
 )
 from custom_components.growspace_manager.domain.date_logic import plant_updated_date
+from custom_components.growspace_manager.domain.plant_lifecycle import (
+    Applied,
+    LifecycleDecision,
+    LifecycleStage,
+    PlantLifecycle,
+    Rejected,
+)
+from custom_components.growspace_manager.domain.stage import STAGE_REGISTRY
 from custom_components.growspace_manager.domain.stage_calculator import (
     calculate_days_in_stage,
 )
@@ -42,6 +52,7 @@ from custom_components.growspace_manager.models import (
     Plant,
     PlantGenetics,
 )
+from custom_components.growspace_manager.models.types import StageHistoryItem
 from custom_components.growspace_manager.services.context import (
     BaseService,
     ServiceContext,
@@ -68,6 +79,31 @@ if TYPE_CHECKING:
     from custom_components.growspace_manager.strain_library import StrainLibrary
 
 _LOGGER = logging.getLogger(__name__)
+
+_LIFECYCLE_STAGE_ALIASES = {
+    PlantStage.VEG_EARLY.value: LifecycleStage.VEG,
+    PlantStage.VEG_LATE.value: LifecycleStage.VEG,
+    PlantStage.FLOWER_EARLY.value: LifecycleStage.FLOWER,
+    PlantStage.FLOWER_MID.value: LifecycleStage.FLOWER,
+    PlantStage.FLOWER_LATE.value: LifecycleStage.FLOWER,
+}
+_SPECIAL_LIFECYCLE_STAGES = {
+    LifecycleStage.DRY,
+    LifecycleStage.CURE,
+    LifecycleStage.CLONE,
+    LifecycleStage.MOTHER,
+}
+
+
+def _as_lifecycle_stage(stage: str | PlantStage) -> LifecycleStage:
+    """Collapse presentation substages into the canonical lifecycle vocabulary."""
+    value = stage.value if isinstance(stage, PlantStage) else str(stage)
+    if alias := _LIFECYCLE_STAGE_ALIASES.get(value):
+        return alias
+    try:
+        return LifecycleStage(value)
+    except ValueError as err:
+        raise ValidationChangeError(f"Invalid lifecycle stage: {value}") from err
 
 
 class PlantManager(BaseService):
@@ -107,6 +143,259 @@ class PlantManager(BaseService):
         if not growspace:
             raise GrowspaceNotFoundError(f"Growspace {growspace_id} not found")
         growspace.layout_revision += 1
+
+    @staticmethod
+    def _restore_plant(plant: Plant, snapshot: Plant) -> None:
+        """Restore a mutated Plant object without invalidating caller references."""
+        for model_field in fields(Plant):
+            setattr(
+                plant,
+                model_field.name,
+                deepcopy(getattr(snapshot, model_field.name)),
+            )
+
+    def _plant_lifecycle(self, plant: Plant, *, observed_on: date) -> PlantLifecycle:
+        """Parse a Plant through the lifecycle domain, bootstrapping legacy empties."""
+        raw_stage = plant.stage or calculate_plant_stage(plant)
+        try:
+            current_stage = _as_lifecycle_stage(raw_stage)
+        except ValidationChangeError:
+            current_stage = LifecycleStage.SEEDLING
+
+        legacy_dates = {
+            field: value if isinstance(value, (date, str)) else None
+            for field in DATE_FIELDS
+            if (value := getattr(plant, field, None)) is not None
+        }
+        stored_history = getattr(plant, "stage_history", None)
+        raw_history: list[object] | None = (
+            [dict(item) for item in stored_history]
+            if isinstance(stored_history, list) and stored_history
+            else None
+        )
+
+        # Older in-memory Plant objects cannot distinguish an absent Stage History
+        # key from the dataclass's empty default. Seed those once from their explicit
+        # stage and creation timestamp; all newly created plants are seeded eagerly.
+        if raw_history is None and not any(legacy_dates.values()):
+            created_at = getattr(plant, "created_at", None)
+            started_on = (
+                created_at
+                if isinstance(created_at, (date, str))
+                else observed_on.isoformat()
+            )
+            raw_history = [
+                {
+                    "stage": current_stage.value,
+                    "start": started_on,
+                    "end": None,
+                }
+            ]
+
+        lifecycle = PlantLifecycle.from_data(
+            raw_history,
+            observed_on=observed_on,
+            legacy_dates=legacy_dates,
+            current_stage=current_stage,
+        )
+        if lifecycle.warnings:
+            details = ", ".join(warning.code.value for warning in lifecycle.warnings)
+            raise ValidationChangeError(
+                f"Plant {plant.plant_id} lifecycle requires repair: {details}"
+            )
+        return lifecycle
+
+    @staticmethod
+    def _transition_history(
+        plant: Plant,
+        lifecycle: PlantLifecycle,
+        decision: LifecycleDecision,
+        transition_timestamp: str,
+    ) -> list[dict[str, str | None]]:
+        """Project the accepted proposal while retaining timestamp precision."""
+        projected = decision.compatibility_data.as_dict()["stage_history"]
+        history = [dict(item) for item in projected]
+
+        # The domain deliberately reasons by calendar date. Existing persistence
+        # keeps the full lifecycle timestamp (ADR-0013), so preserve trusted raw
+        # intervals and stamp only the newly created boundary.
+        if isinstance(decision, Applied):
+            if plant.stage_history and len(plant.stage_history) + 1 == len(history):
+                history = [dict(item) for item in plant.stage_history]
+                history[-1]["end"] = transition_timestamp
+                history.append(
+                    {
+                        "stage": decision.after.current_stage.value,
+                        "start": transition_timestamp,
+                        "end": None,
+                    }
+                )
+            else:
+                history[-2]["end"] = transition_timestamp
+                history[-1]["start"] = transition_timestamp
+        elif not history:
+            history = [
+                {
+                    "stage": lifecycle.current_stage.value,
+                    "start": transition_timestamp,
+                    "end": None,
+                }
+            ]
+        return history
+
+    async def _commit_lifecycle_transition(
+        self,
+        plant_id: str,
+        target_stage: str | PlantStage,
+        transition_date: DateInput = None,
+        *,
+        target_growspace_id: str | None = None,
+        move_to_special: bool = False,
+        harvest_metrics: dict[str, Any] | None = None,
+        expected_current_stage: LifecycleStage | None = None,
+    ) -> Plant:
+        """Commit lifecycle and placement through one serialized rollback seam."""
+        canonical_target = _as_lifecycle_stage(target_stage)
+        transition_timestamp = to_lifecycle_timestamp(transition_date)
+
+        async with self._lock:
+            observed_on = dt_util.now().date()
+            plant = self.repository.get_plant(plant_id)
+            if not plant:
+                raise PlantNotFoundError(f"Plant {plant_id} does not exist")
+
+            lifecycle = self._plant_lifecycle(plant, observed_on=observed_on)
+            if (
+                expected_current_stage is not None
+                and lifecycle.current_stage is not expected_current_stage
+            ):
+                raise ValidationChangeError(
+                    f"Plant {plant_id} is not in {expected_current_stage.value} stage "
+                    f"(current: {lifecycle.current_stage.value})"
+                )
+            decision = lifecycle.transition(
+                canonical_target,
+                transition_timestamp,
+                observed_on,
+            )
+            if isinstance(decision, Rejected):
+                raise ValidationChangeError(decision.reason or "Transition rejected")
+
+            plant_snapshot = deepcopy(plant)
+            growspace_snapshots: dict[str, Any | None] = {}
+            notification_enabled = getattr(self.notification_state, "enabled", None)
+            notification_snapshot = (
+                deepcopy(notification_enabled)
+                if isinstance(notification_enabled, dict)
+                else None
+            )
+
+            def snapshot_growspace(growspace_id: str) -> None:
+                if growspace_id not in growspace_snapshots:
+                    growspace_snapshots[growspace_id] = deepcopy(
+                        self.repository.get_growspace(growspace_id)
+                    )
+
+            source_growspace_id = plant.growspace_id
+            snapshot_growspace(source_growspace_id)
+
+            def placement_for(growspace_id: str) -> dict[str, Any]:
+                if not self.repository.has_growspace(growspace_id):
+                    raise GrowspaceNotFoundError(
+                        f"Target growspace {growspace_id} not found"
+                    )
+                snapshot_growspace(growspace_id)
+                if growspace_id == source_growspace_id:
+                    return {}
+                try:
+                    row, col = self.validator.find_first_available_position(
+                        growspace_id
+                    )
+                except ValueError as err:
+                    raise ValidationChangeError(
+                        f"Target growspace {growspace_id} is full"
+                    ) from err
+                if row is None or col is None:
+                    raise ValidationChangeError(
+                        f"Target growspace {growspace_id} is full"
+                    )
+                target_growspace = self.repository.require_growspace(growspace_id)
+                return {
+                    "growspace_id": growspace_id,
+                    "row": row,
+                    "col": col,
+                    "device_id": target_growspace.device_id,
+                }
+
+            resolved_target_id = target_growspace_id
+            try:
+                if move_to_special:
+                    snapshot_growspace(canonical_target.value)
+                    resolved_target_id = (
+                        self.growspace_manager.ensure_special_growspace(
+                            canonical_target.value,
+                            canonical_target.value,
+                        )
+                    )
+                    snapshot_growspace(resolved_target_id)
+
+                placement_updates: dict[str, Any] = {}
+                if resolved_target_id is not None:
+                    placement_updates = placement_for(resolved_target_id)
+
+                updates: dict[str, Any] = {
+                    "stage": canonical_target.value,
+                    "stage_history": self._transition_history(
+                        plant, lifecycle, decision, transition_timestamp
+                    ),
+                    **placement_updates,
+                }
+                if isinstance(decision, Applied):
+                    updates[f"{canonical_target.value}_start"] = transition_timestamp
+
+                # The legacy calculator ranks fields by lifecycle order rather than
+                # timestamp. Clear higher-ranked fields on backward branches (most
+                # importantly flower -> veg) so stale stages cannot resurface.
+                target_definition = STAGE_REGISTRY[PlantStage(canonical_target.value)]
+                for stage_definition in STAGE_REGISTRY.values():
+                    if stage_definition.order > target_definition.order:
+                        updates[stage_definition.start_field] = None
+
+                for key, value in updates.items():
+                    setattr(plant, key, value)
+                if harvest_metrics:
+                    for key, value in harvest_metrics.items():
+                        if value is not None:
+                            setattr(plant.harvest_metrics, key, value)
+                plant.updated_at = plant_updated_date()
+
+                if plant.growspace_id != source_growspace_id:
+                    self._advance_layout_revision(source_growspace_id)
+                    self._advance_layout_revision(plant.growspace_id)
+
+                await self._save()
+            except BaseException:
+                self._restore_plant(plant, plant_snapshot)
+                self.repository.add_plant(plant)
+                for growspace_id, snapshot in growspace_snapshots.items():
+                    if snapshot is None:
+                        self.repository.remove_growspace(growspace_id)
+                    else:
+                        self.repository.add_growspace(snapshot)
+                    self._invalidate(growspace_id)
+                if notification_snapshot is not None and isinstance(
+                    notification_enabled, dict
+                ):
+                    notification_enabled.clear()
+                    notification_enabled.update(notification_snapshot)
+                raise
+
+        self._fire_event(
+            "plant_updated",
+            {"plant": self.plant_view_builder.build(plant)},
+        )
+        async_fire_plant_event(self.hass, EVENT_PLANT_UPDATED, plant, updates)
+        return plant
 
     # =========================================================================
     # PLANT CRUD OPERATIONS
@@ -180,6 +469,7 @@ class PlantManager(BaseService):
                 generation=generation,
             )
 
+            created_at = dt_util.utcnow().isoformat()
             plant = Plant(
                 plant_id=final_plant_id,
                 growspace_id=growspace_id,
@@ -190,7 +480,7 @@ class PlantManager(BaseService):
                 type=plant_type,
                 device_id=device_id,
                 seed_batch_id=seed_batch_id,
-                created_at=dt_util.utcnow().isoformat(),
+                created_at=created_at,
                 updated_at=plant_updated_date(),
                 **date_fields,  # type: ignore[arg-type]
                 source_mother=kwargs.get("source_mother")
@@ -198,12 +488,70 @@ class PlantManager(BaseService):
                 or "",
             )
 
-            if not plant.stage:
-                plant.stage = calculate_plant_stage(plant)
+            if plant.stage:
+                initial_stage = _as_lifecycle_stage(plant.stage)
+            elif plant_type == PlantStage.CLONE:
+                initial_stage = LifecycleStage.CLONE
+            elif plant_type == PlantStage.MOTHER:
+                initial_stage = LifecycleStage.MOTHER
+            elif any(date_fields.values()):
+                initial_stage = _as_lifecycle_stage(calculate_plant_stage(plant))
+            else:
+                initial_stage = LifecycleStage.SEEDLING
 
+            current_start_field = f"{initial_stage.value}_start"
+            if getattr(plant, current_start_field) is None:
+                setattr(plant, current_start_field, created_at)
+
+            legacy_dates = {field: getattr(plant, field, None) for field in DATE_FIELDS}
+            lifecycle = PlantLifecycle.from_data(
+                None,
+                observed_on=dt_util.now().date(),
+                legacy_dates=legacy_dates,
+                current_stage=initial_stage,
+            )
+            if lifecycle.warnings:
+                details = ", ".join(
+                    warning.code.value for warning in lifecycle.warnings
+                )
+                raise ValidationChangeError(
+                    f"Initial plant lifecycle is invalid: {details}"
+                )
+
+            plant.stage = initial_stage.value
+            plant.stage_history = [
+                StageHistoryItem(
+                    stage=item.stage.value,
+                    start=item.started_on.isoformat(),
+                    end=item.ended_on.isoformat() if item.ended_on else None,
+                )
+                for item in lifecycle.history.intervals
+            ]
+            # Retain full timestamp precision in the persisted compatibility shape.
+            for index, interval in enumerate(plant.stage_history):
+                source_timestamp = getattr(plant, f"{interval['stage']}_start")
+                interval["start"] = source_timestamp
+                if index:
+                    plant.stage_history[index - 1]["end"] = source_timestamp
+
+            previous_plant = self.repository.get_plant(final_plant_id)
+            previous_revision = self.repository.require_growspace(
+                growspace_id
+            ).layout_revision
             self.repository.add_plant(plant)
             self._advance_layout_revision(growspace_id)
-            await self._save()
+            try:
+                await self._save()
+            except BaseException:
+                if previous_plant is None:
+                    self.repository.remove_plant(final_plant_id)
+                else:
+                    self.repository.add_plant(previous_plant)
+                self.repository.require_growspace(
+                    growspace_id
+                ).layout_revision = previous_revision
+                self._invalidate(growspace_id)
+                raise
 
         # Event Firing (outside lock if possible, or inside? Service did it after lifecycle call)
         # Service: await lifecycle.add_plant -> fire event
@@ -720,71 +1068,42 @@ class PlantManager(BaseService):
         """Execute a plant stage transition."""
         if isinstance(new_stage, PlantStage):
             new_stage = new_stage.value
-
         if new_stage not in PLANT_STAGES:
             raise ValidationChangeError(f"Invalid stage: {new_stage}")
 
-        # Lifecycle Timestamp: preserve a supplied time, default to now (ADR-0013).
-        trans_date_str = to_lifecycle_timestamp(transition_date)
-
-        updates: dict[str, Any] = {"stage": new_stage}
-        stage_map = {
-            PlantStage.VEG.value: "veg_start",
-            PlantStage.FLOWER.value: "flower_start",
-            PlantStage.DRY.value: "dry_start",
-            PlantStage.CURE.value: "cure_start",
-            PlantStage.CLONE.value: "clone_start",
-        }
-        if new_stage in stage_map:
-            updates[stage_map[new_stage]] = trans_date_str
-
-        plant = self.repository.get_plant(plant_id)
-        if plant is not None and hasattr(plant, "stage_history"):  # Check just in case
-            new_history = [dict(item) for item in plant.stage_history]
-            for item in reversed(new_history):
-                if item.get("end") is None:
-                    item["end"] = trans_date_str
-                    break
-            new_history.append(
-                {"stage": new_stage, "start": trans_date_str, "end": None}
-            )
-            updates["stage_history"] = new_history
-
-        await self.update_plant(plant_id, **updates)
-
-        # Trigger logic for automatic moves based on stage
-        plant = self.repository.get_plant(plant_id)
-        if plant:
-            if new_stage == PlantStage.DRY:
-                await self.move_to_dry_growspace(plant_id, plant, trans_date_str)
-            elif new_stage == PlantStage.CURE:
-                await self.move_to_cure_growspace(plant_id, plant, trans_date_str)
-            elif new_stage == PlantStage.CLONE:
-                await self.move_to_clone_growspace(plant_id, plant, trans_date_str)
+        canonical_target = _as_lifecycle_stage(new_stage)
+        plant = await self._commit_lifecycle_transition(
+            plant_id,
+            canonical_target.value,
+            transition_date,
+            move_to_special=canonical_target in _SPECIAL_LIFECYCLE_STAGES,
+        )
+        if canonical_target is LifecycleStage.DRY:
+            await self._record_analytics(plant)
 
         # Fire event (Service did this)
-        if plant := self.repository.get_plant(plant_id):
+        if committed_plant := self.repository.get_plant(plant_id):
             async_fire_plant_event(
                 self.hass,
                 EVENT_PLANT_TRANSITIONED,
-                plant,
-                {"new_stage": str(new_stage)},
+                committed_plant,
+                {"new_stage": canonical_target.value},
             )
             now_iso = dt_util.now().isoformat()
-            stage_label = new_stage.replace("_", " ").title()
+            stage_label = canonical_target.value.replace("_", " ").title()
             event = GrowspaceEvent(
                 sensor_type="stage_transition",
-                growspace_id=plant.growspace_id,
+                growspace_id=committed_plant.growspace_id,
                 start_time=now_iso,
                 end_time=now_iso,
                 duration_sec=0,
                 severity=1.0,
                 category=CATEGORY_MILESTONE,
                 reasons=[
-                    f"{(plant.genetics.strain_name if plant.genetics else None) or plant_id} entered {stage_label}"
+                    f"{(committed_plant.genetics.strain_name if committed_plant.genetics else None) or plant_id} entered {stage_label}"
                 ],
             )
-            self._emit(plant.growspace_id, event)
+            self._emit(committed_plant.growspace_id, event)
 
     async def transition_plant(
         self,
@@ -841,20 +1160,17 @@ class PlantManager(BaseService):
 
         transition_date_str = to_lifecycle_timestamp(transition_date)
 
-        # Store yield/lab metrics on the plant before analytics recording
-        if hasattr(plant, "harvest_metrics"):
-            if wet_weight is not None:
-                plant.harvest_metrics.wet_weight = wet_weight
-            if dry_weight is not None:
-                plant.harvest_metrics.dry_weight = dry_weight
-            if trim_weight is not None:
-                plant.harvest_metrics.trim_weight = trim_weight
-            if thc_percentage is not None:
-                plant.harvest_metrics.thc_percentage = thc_percentage
-            if cbd_percentage is not None:
-                plant.harvest_metrics.cbd_percentage = cbd_percentage
-            if terpene_profile is not None:
-                plant.harvest_metrics.terpene_profile = terpene_profile
+        metrics: dict[str, Any] = {
+            "wet_weight": wet_weight,
+            "dry_weight": dry_weight,
+            "trim_weight": trim_weight,
+            "thc_percentage": thc_percentage,
+            "cbd_percentage": cbd_percentage,
+            "terpene_profile": terpene_profile,
+        }
+        harvest_metrics = (
+            metrics if any(value is not None for value in metrics.values()) else None
+        )
 
         # Log harvest start
         _LOGGER.info(
@@ -870,16 +1186,37 @@ class PlantManager(BaseService):
                 raise GrowspaceNotFoundError(
                     f"Target growspace {target_growspace_id} not found"
                 )
-            moved = await self._harvest_to_explicit_target(
+            if harvest_metrics is None:
+                moved = await self._harvest_to_explicit_target(
+                    plant_id,
+                    plant,
+                    target_growspace_id,
+                    target_growspace_name,
+                    transition_date_str,
+                )
+            else:
+                moved = await self._harvest_to_explicit_target(
+                    plant_id,
+                    plant,
+                    target_growspace_id,
+                    target_growspace_name,
+                    transition_date_str,
+                    harvest_metrics,
+                )
+        elif harvest_metrics is None:
+            moved = await self._harvest_auto_flow(
                 plant_id,
                 plant,
-                target_growspace_id,
                 target_growspace_name,
                 transition_date_str,
             )
         else:
             moved = await self._harvest_auto_flow(
-                plant_id, plant, target_growspace_name, transition_date_str
+                plant_id,
+                plant,
+                target_growspace_name,
+                transition_date_str,
+                harvest_metrics,
             )
 
         # Post harvest logic
@@ -893,6 +1230,7 @@ class PlantManager(BaseService):
         target_growspace_id: str,
         target_growspace_name: str | None,
         transition_date: str,
+        harvest_metrics: dict[str, Any] | None = None,
     ) -> bool:
         """Move harvested plant to explicit target."""
         try:
@@ -921,13 +1259,25 @@ class PlantManager(BaseService):
                 "mother_start": transition_date,
             }
 
-        await self.update_plant(
-            plant_id,
-            growspace_id=target_growspace_id,
-            row=new_row,
-            col=new_col,
-            **stage_updates,
-        )
+        if stage_updates:
+            await self._commit_lifecycle_transition(
+                plant_id,
+                stage_updates["stage"],
+                transition_date,
+                target_growspace_id=target_growspace_id,
+                harvest_metrics=harvest_metrics,
+            )
+        else:
+            if harvest_metrics:
+                for key, value in harvest_metrics.items():
+                    if value is not None:
+                        setattr(plant.harvest_metrics, key, value)
+            await self.update_plant(
+                plant_id,
+                growspace_id=target_growspace_id,
+                row=new_row,
+                col=new_col,
+            )
         return True
 
     async def _harvest_auto_flow(
@@ -936,6 +1286,7 @@ class PlantManager(BaseService):
         plant: Plant,
         target_growspace_name: str | None,
         transition_date: str,
+        harvest_metrics: dict[str, Any] | None = None,
     ) -> bool:
         """Automatically determine harvest flow."""
         if target_growspace_name:
@@ -949,19 +1300,38 @@ class PlantManager(BaseService):
                 info = SPECIAL_GROWSPACES.get(stage.value, {})
                 aliases = info.get("aliases", [])
                 if name_lower == stage.value or name_lower in aliases:
+                    if harvest_metrics is None:
+                        return await self._move_to_special_growspace(
+                            plant_id, plant, stage, transition_date
+                        )
                     return await self._move_to_special_growspace(
-                        plant_id, plant, stage, transition_date
+                        plant_id,
+                        plant,
+                        stage,
+                        transition_date,
+                        harvest_metrics=harvest_metrics,
                     )
 
         current_stage = calculate_plant_stage(plant)
+        metric_kwargs = (
+            {} if harvest_metrics is None else {"harvest_metrics": harvest_metrics}
+        )
         if current_stage == PlantStage.FLOWER:
-            return await self.move_to_dry_growspace(plant_id, plant, transition_date)
+            return await self.move_to_dry_growspace(
+                plant_id, plant, transition_date, **metric_kwargs
+            )
         if current_stage == PlantStage.DRY:
-            return await self.move_to_cure_growspace(plant_id, plant, transition_date)
+            return await self.move_to_cure_growspace(
+                plant_id, plant, transition_date, **metric_kwargs
+            )
         if current_stage == PlantStage.MOTHER:
-            return await self.move_to_clone_growspace(plant_id, plant, transition_date)
+            return await self.move_to_clone_growspace(
+                plant_id, plant, transition_date, **metric_kwargs
+            )
 
-        return await self.move_to_dry_growspace(plant_id, plant, transition_date)
+        return await self.move_to_dry_growspace(
+            plant_id, plant, transition_date, **metric_kwargs
+        )
 
     async def _move_to_special_growspace(
         self,
@@ -970,49 +1340,27 @@ class PlantManager(BaseService):
         target_stage: PlantStage,
         transition_date: str,
         record_harvest_analytics: bool = False,
+        harvest_metrics: dict[str, Any] | None = None,
     ) -> bool:
         """Generic method to move a plant to a special growspace."""
-        if record_harvest_analytics:
-            await self._record_analytics(plant)
-
-        gs_id = self.growspace_manager.ensure_special_growspace(
-            target_stage.value, target_stage.value
+        committed = await self._commit_lifecycle_transition(
+            plant_id,
+            target_stage,
+            transition_date,
+            move_to_special=True,
+            harvest_metrics=harvest_metrics,
         )
-        target_gs = self.repository.get_growspace(gs_id)
-
-        try:
-            new_row, new_col = self.validator.find_first_available_position(gs_id)
-        except ValueError as e:
-            _LOGGER.warning(
-                "Failed to find position in %s growspace: %s",
-                gs_id,
-                e,
-            )
-            new_row, new_col = 1, 1
-
-        updates: dict[str, Any] = {
-            "growspace_id": gs_id,
-            "row": new_row,
-            "col": new_col,
-            "stage": target_stage,
-        }
-
-        date_map = {
-            PlantStage.DRY: "dry_start",
-            PlantStage.CURE: "cure_start",
-            PlantStage.CLONE: "clone_start",
-            PlantStage.MOTHER: "mother_start",
-            PlantStage.VEG: "veg_start",
-        }
-        updates["device_id"] = target_gs.device_id if target_gs else None
-        if target_stage in date_map:
-            updates[date_map[target_stage]] = transition_date
-
-        await self.update_plant(plant_id, **updates)
+        if record_harvest_analytics:
+            await self._record_analytics(committed)
         return True
 
     async def move_to_dry_growspace(
-        self, plant_id: str, plant: Plant, transition_date: str
+        self,
+        plant_id: str,
+        plant: Plant,
+        transition_date: str,
+        *,
+        harvest_metrics: dict[str, Any] | None = None,
     ) -> bool:
         """Move a plant to the dry growspace."""
         return await self._move_to_special_growspace(
@@ -1021,22 +1369,41 @@ class PlantManager(BaseService):
             PlantStage.DRY,
             transition_date,
             record_harvest_analytics=True,
+            harvest_metrics=harvest_metrics,
         )
 
     async def move_to_cure_growspace(
-        self, plant_id: str, plant: Plant, transition_date: str
+        self,
+        plant_id: str,
+        plant: Plant,
+        transition_date: str,
+        *,
+        harvest_metrics: dict[str, Any] | None = None,
     ) -> bool:
         """Move a plant to the cure growspace."""
         return await self._move_to_special_growspace(
-            plant_id, plant, PlantStage.CURE, transition_date
+            plant_id,
+            plant,
+            PlantStage.CURE,
+            transition_date,
+            harvest_metrics=harvest_metrics,
         )
 
     async def move_to_clone_growspace(
-        self, plant_id: str, plant: Plant, transition_date: str
+        self,
+        plant_id: str,
+        plant: Plant,
+        transition_date: str,
+        *,
+        harvest_metrics: dict[str, Any] | None = None,
     ) -> bool:
         """Move a plant back to the clone growspace."""
         return await self._move_to_special_growspace(
-            plant_id, plant, PlantStage.CLONE, transition_date
+            plant_id,
+            plant,
+            PlantStage.CLONE,
+            transition_date,
+            harvest_metrics=harvest_metrics,
         )
 
     async def start_flowering(self, plant_id: str) -> Plant:
@@ -1074,41 +1441,22 @@ class PlantManager(BaseService):
 
         This updates the EXISTING plant record, preserving its ID and history.
         """
-        plant = self.repository.get_plant(clone_id)
-        if not plant:
-            raise PlantNotFoundError(f"Plant {clone_id} not found")
-
-        if plant.stage != PlantStage.CLONE:
-            raise ValidationChangeError(
-                f"Plant {clone_id} is not in clone stage (current: {plant.stage})"
-            )
-
-        # Resolve target growspace ID (handle aliases like 'veg')
+        # Resolve target growspace ID (handle aliases like 'veg'). The stage and
+        # placement are revalidated and committed under the shared mutation lock.
         if target_growspace_id == "veg":
-            target_gs_id = self.growspace_manager.ensure_special_growspace(
-                PlantStage.VEG, "veg", 5, 5
-            )
+            target_gs_id = None
+            move_to_special = True
         else:
-            # Ensure custom growspace exists
-            if not self.repository.has_growspace(target_growspace_id):
-                raise GrowspaceNotFoundError(
-                    f"Target growspace {target_growspace_id} does not exist"
-                )
             target_gs_id = target_growspace_id
+            move_to_special = False
 
-        # Now find position (reads state)
-        row, col = self.validator.find_first_available_position(target_gs_id)
-        if row is None or col is None:
-            raise ValidationChangeError(f"Target growspace {target_gs_id} is full")
-
-        # Now call update_plant (which acquires lock)
-        await self.update_plant(
+        await self._commit_lifecycle_transition(
             clone_id,
-            growspace_id=target_gs_id,
-            row=row,
-            col=col,
-            stage=PlantStage.VEG,
-            veg_start=transition_date or dt_util.now(),
+            PlantStage.VEG,
+            transition_date or dt_util.now(),
+            target_growspace_id=target_gs_id,
+            move_to_special=move_to_special,
+            expected_current_stage=LifecycleStage.CLONE,
         )
 
     async def _record_analytics(self, plant: Plant) -> None:

--- a/tests/core/test_coordinator.py
+++ b/tests/core/test_coordinator.py
@@ -110,7 +110,7 @@ async def test_transition_plant_stage(coordinator: GrowspaceCoordinator) -> None
     gs = await coordinator._growspace_manager.add_growspace("Stage GS")
     plant = await coordinator._plant_manager.add_plant(gs.id, "Strain B")
 
-    transition_date = "2025-11-03"  # ISO string
+    transition_date = date.today().isoformat()
 
     # Only test the stages you want to transition through
     for stage in PLANT_STAGES:
@@ -1061,7 +1061,9 @@ async def test_async_start_flowering(coordinator: GrowspaceCoordinator) -> None:
         coordinator: The mock GrowspaceCoordinator.
     """
     gs = await coordinator._growspace_manager.add_growspace("Flower GS")
-    plant = await coordinator._plant_manager.add_plant(gs.id, "Strain A")
+    plant = await coordinator._plant_manager.add_plant(
+        gs.id, "Strain A", stage=PlantStage.VEG, veg_start=date.today()
+    )
     await coordinator._plant_manager.start_flowering(plant.plant_id)
     updated_plant = coordinator.plants.get(plant.plant_id)
     assert updated_plant is not None
@@ -1078,7 +1080,9 @@ async def test_async_start_drying(coordinator: GrowspaceCoordinator) -> None:
         coordinator: The mock GrowspaceCoordinator.
     """
     gs = await coordinator._growspace_manager.add_growspace("Dry GS")
-    plant = await coordinator._plant_manager.add_plant(gs.id, "Strain A")
+    plant = await coordinator._plant_manager.add_plant(
+        gs.id, "Strain A", stage=PlantStage.FLOWER, flower_start=date.today()
+    )
     await coordinator._plant_manager.start_drying(plant.plant_id)
     updated_plant = coordinator.plants.get(plant.plant_id)
     assert updated_plant is not None
@@ -1095,7 +1099,9 @@ async def test_async_start_curing(coordinator: GrowspaceCoordinator) -> None:
         coordinator: The mock GrowspaceCoordinator.
     """
     gs = await coordinator._growspace_manager.add_growspace("Cure GS")
-    plant = await coordinator._plant_manager.add_plant(gs.id, "Strain A")
+    plant = await coordinator._plant_manager.add_plant(
+        gs.id, "Strain A", stage=PlantStage.DRY, dry_start=date.today()
+    )
     await coordinator._plant_manager.start_curing(plant.plant_id)
     updated_plant = coordinator.plants.get(plant.plant_id)
     assert updated_plant is not None
@@ -1114,7 +1120,9 @@ async def test_async_harvest(coordinator: GrowspaceCoordinator) -> None:
         coordinator: The mock GrowspaceCoordinator.
     """
     gs = await coordinator._growspace_manager.add_growspace("Harvest GS")
-    plant = await coordinator._plant_manager.add_plant(gs.id, "Strain A")
+    plant = await coordinator._plant_manager.add_plant(
+        gs.id, "Strain A", stage=PlantStage.FLOWER, flower_start=date.today()
+    )
     await coordinator.services.plants.harvest(plant.plant_id)
     updated_plant = coordinator.plants.get(plant.plant_id)
     assert updated_plant is not None
@@ -1823,10 +1831,13 @@ async def test_harvest_to_explicit_target_no_position(
         phenotype="pheno1",
         row=1,
         col=1,
-        stage="veg",
+        stage="dry",
+        dry_start="2025-01-01",
+        stage_history=[{"stage": "dry", "start": "2025-01-01", "end": None}],
         created_at="2025-01-01",
         updated_at="2025-01-01",
     )
+    coordinator._data_repository.add_growspace(MagicMock(id="gs1"))
     setattr(
         coordinator.validator,
         "find_first_available_position",
@@ -1857,34 +1868,29 @@ async def test_harvest_to_explicit_target_cure(hass: HomeAssistant) -> None:
         phenotype="pheno1",
         row=1,
         col=1,
-        stage="veg",
+        stage="dry",
+        dry_start="2025-01-01",
+        stage_history=[{"stage": "dry", "start": "2025-01-01", "end": None}],
         created_at="2025-01-01",
         updated_at="2025-01-01",
     )
+    coordinator._data_repository.add_growspace(Growspace(id="gs1", name="Source"))
     setattr(
         coordinator.validator,
         "find_first_available_position",
         MagicMock(return_value=(1, 1)),
     )
-    coordinator._data_repository.add_growspace(MagicMock(id="cure"))
+    coordinator._data_repository.add_growspace(Growspace(id="cure", name="Cure"))
 
     coordinator._data_repository.add_plant(plant)  # Ensure plant exists in coordinator
 
-    with patch.object(
-        coordinator._plant_manager, "update_plant", new_callable=AsyncMock
-    ) as mock_update:
-        await coordinator._plant_manager._harvest_to_explicit_target(
-            "p1", plant, "cure", "cure", "2025-01-01"
-        )
+    await coordinator._plant_manager._harvest_to_explicit_target(
+        "p1", plant, "cure", "cure", "2025-01-01"
+    )
 
-        mock_update.assert_called_with(
-            "p1",
-            growspace_id="cure",
-            row=1,
-            col=1,
-            stage="cure",
-            cure_start="2025-01-01",
-        )
+    assert plant.stage == PlantStage.CURE
+    assert plant.growspace_id == "cure"
+    assert [item["stage"] for item in plant.stage_history] == ["dry", "cure"]
 
 
 @pytest.mark.asyncio
@@ -1900,6 +1906,8 @@ async def test_harvest_to_explicit_target_clone(hass: HomeAssistant) -> None:
         row=1,
         col=1,
         stage="veg",
+        veg_start="2025-01-01",
+        stage_history=[{"stage": "veg", "start": "2025-01-01", "end": None}],
         created_at="2025-01-01",
         updated_at="2025-01-01",
     )
@@ -1912,21 +1920,13 @@ async def test_harvest_to_explicit_target_clone(hass: HomeAssistant) -> None:
 
     coordinator._data_repository.add_plant(plant)  # Ensure plant exists in coordinator
 
-    with patch.object(
-        coordinator._plant_manager, "update_plant", new_callable=AsyncMock
-    ) as mock_update:
+    with pytest.raises(ValidationChangeError, match="not allowed"):
         await coordinator._plant_manager._harvest_to_explicit_target(
             "p1", plant, "clone", "clone", "2025-01-01"
         )
 
-        mock_update.assert_called_with(
-            "p1",
-            growspace_id="clone",
-            row=1,
-            col=1,
-            stage="clone",
-            clone_start="2025-01-01",
-        )
+    assert plant.stage == PlantStage.VEG
+    assert plant.growspace_id == "gs1"
 
 
 @pytest.mark.asyncio
@@ -1942,33 +1942,28 @@ async def test_harvest_to_explicit_target_mother(hass: HomeAssistant) -> None:
         row=1,
         col=1,
         stage="veg",
+        veg_start="2025-01-01",
+        stage_history=[{"stage": "veg", "start": "2025-01-01", "end": None}],
         created_at="2025-01-01",
         updated_at="2025-01-01",
     )
+    coordinator._data_repository.add_growspace(Growspace(id="gs1", name="Source"))
     setattr(
         coordinator.validator,
         "find_first_available_position",
         MagicMock(return_value=(1, 1)),
     )
-    coordinator._data_repository.add_growspace(MagicMock(id="mother"))
+    coordinator._data_repository.add_growspace(Growspace(id="mother", name="Mother"))
 
     coordinator._data_repository.add_plant(plant)  # Ensure plant exists in coordinator
 
-    with patch.object(
-        coordinator._plant_manager, "update_plant", new_callable=AsyncMock
-    ) as mock_update:
-        await coordinator._plant_manager._harvest_to_explicit_target(
-            "p1", plant, "mother", "mother", "2025-01-01"
-        )
+    await coordinator._plant_manager._harvest_to_explicit_target(
+        "p1", plant, "mother", "mother", "2025-01-01"
+    )
 
-        mock_update.assert_called_with(
-            "p1",
-            growspace_id="mother",
-            row=1,
-            col=1,
-            stage=PlantStage.MOTHER,
-            mother_start="2025-01-01",
-        )
+    assert plant.stage == PlantStage.MOTHER
+    assert plant.growspace_id == "mother"
+    assert [item["stage"] for item in plant.stage_history] == ["veg", "mother"]
 
 
 @pytest.mark.asyncio
@@ -1985,7 +1980,9 @@ async def test_move_to_clone_growspace_no_position(
         phenotype="pheno1",
         row=1,
         col=1,
-        stage="veg",
+        stage="clone",
+        clone_start="2025-01-01",
+        stage_history=[{"stage": "clone", "start": "2025-01-01", "end": None}],
         created_at="2025-01-01",
         updated_at="2025-01-01",
     )
@@ -1998,14 +1995,10 @@ async def test_move_to_clone_growspace_no_position(
     coordinator._data_repository.add_growspace(MagicMock(id="clone"))
     coordinator._data_repository.add_plant(plant)  # Ensure plant exists in coordinator
 
-    with patch.object(
-        coordinator._plant_manager, "update_plant", new_callable=AsyncMock
-    ):
+    with pytest.raises(ValidationChangeError, match="clone is full"):
         await coordinator._plant_manager.move_to_clone_growspace(
             "p1", plant, "2025-01-01"
         )
-
-    assert "Failed to find position in clone growspace" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -2198,8 +2191,17 @@ async def test_async_promote_clone_error_checks(
     # 3. Promote to non-existent target growspace
     plant.stage = PlantStage.CLONE
     plant.type = "clone"
+    plant.veg_start = None
+    plant.clone_start = date.today().isoformat()
+    plant.stage_history = [
+        {
+            "stage": "clone",
+            "start": date.today().isoformat(),
+            "end": None,
+        }
+    ]
     with pytest.raises(
-        GrowspaceNotFoundError, match="Target growspace missing_gs does not exist"
+        GrowspaceNotFoundError, match="Target growspace missing_gs not found"
     ):
         await coordinator.services.plants.promote_clone(
             plant.plant_id, target_growspace_id="missing_gs"

--- a/tests/integration/test_coverage_top_off.py
+++ b/tests/integration/test_coverage_top_off.py
@@ -31,6 +31,7 @@ from custom_components.growspace_manager.dehumidifier_coordinator import (
 from custom_components.growspace_manager.domain.environment_state_assembler import (
     AssembledEnvironment,
 )
+from custom_components.growspace_manager.exceptions import ValidationChangeError
 from custom_components.growspace_manager.managers.plant import PlantManager
 from custom_components.growspace_manager.models import (
     BaseModel,
@@ -272,14 +273,10 @@ async def test_lifecycle_history_closing_coverage(hass: HomeAssistant) -> None:
         strain_library=strain_library,
         plant_view_builder=MagicMock(),
     )
-    with patch.object(manager, "update_plant", new_callable=AsyncMock) as mock_update:
-        await manager.transition_plant_stage("p1", "flower")
-        mock_update.assert_called_once()
-        # Verify the history in the call
-        updates = mock_update.call_args.kwargs
-        history = updates["stage_history"]
-        assert len(history) == 2
-        assert history[0]["end"] is not None
+    await manager.transition_plant_stage("p1", "flower")
+    assert plant.stage == PlantStage.FLOWER
+    assert len(plant.stage_history) == 2
+    assert plant.stage_history[0]["end"] is not None
 
 
 # --- Service Plant Coverage ---
@@ -841,6 +838,7 @@ async def test_lifecycle_history_stages_coverage(hass: HomeAssistant) -> None:
         stage_history=[{"stage": "veg", "start": "2024-01-01", "end": None}],
     )
     repository.plants = {"p1": plant}
+    repository.get_plant.return_value = plant
 
     manager = PlantManager(
         ctx=ServiceContext(
@@ -858,19 +856,8 @@ async def test_lifecycle_history_stages_coverage(hass: HomeAssistant) -> None:
         plant_view_builder=MagicMock(),
     )
 
-    manager.async_update_plant = AsyncMock()
-    manager.move_to_dry_growspace = AsyncMock()
-    manager.move_to_cure_growspace = AsyncMock()
-    manager.move_to_clone_growspace = AsyncMock()
+    await manager.transition_plant_stage("p1", PlantStage.FLOWER)
+    assert [item["stage"] for item in plant.stage_history] == ["veg", "flower"]
 
-    # Hit DRY transition
-    await manager.transition_plant_stage("p1", PlantStage.DRY)
-    manager.move_to_dry_growspace.assert_awaited_once()
-
-    # Hit CURE transition
-    await manager.transition_plant_stage("p1", PlantStage.CURE)
-    manager.move_to_cure_growspace.assert_awaited_once()
-
-    # Hit CLONE transition
-    await manager.transition_plant_stage("p1", PlantStage.CLONE)
-    manager.move_to_clone_growspace.assert_awaited_once()
+    with pytest.raises(ValidationChangeError, match="not allowed"):
+        await manager.transition_plant_stage("p1", PlantStage.CLONE)

--- a/tests/integration/test_final_coverage_gaps.py
+++ b/tests/integration/test_final_coverage_gaps.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.growspace_manager.const import PlantStage
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
 from custom_components.growspace_manager.irrigation_coordinator import (
     IrrigationCoordinator,
@@ -173,8 +174,18 @@ async def test_harvest_plant_with_all_metrics(
         growspace_id=GROWSPACE_ID,
         genetics=PlantGenetics(strain_name="Blue Dream"),
         phi_clearance_date=None,
+        stage=PlantStage.FLOWER,
+        flower_start="2026-01-01",
+        stage_history=[{"stage": "flower", "start": "2026-01-01", "end": None}],
     )
     plant_manager.repository.plants["p2"] = plant
+    plant_manager.repository.get_plant.return_value = plant
+    plant_manager.repository.has_growspace.return_value = True
+    plant_manager.repository.require_growspace.return_value = MagicMock(
+        id="dry", device_id=None, layout_revision=0
+    )
+    plant_manager.validator.find_first_available_position.return_value = (1, 1)
+    plant_manager.growspace_manager.ensure_special_growspace.return_value = "dry"
     plant_manager.repository.get_growspace.return_value = MagicMock(
         id=GROWSPACE_ID, name="Tent", notification_target="notify.x"
     )

--- a/tests/integration/test_plant_lifecycle_coverage.py
+++ b/tests/integration/test_plant_lifecycle_coverage.py
@@ -30,7 +30,9 @@ def repository_mock():
     mock.get_plant.return_value = None
     mock.has_plant.return_value = False
     mock.has_growspace.side_effect = lambda gid: gid == "test_growspace"
-    mock.get_growspace.side_effect = lambda gid: Growspace(id=gid, name=gid) if gid == "test_growspace" else None
+    mock.get_growspace.side_effect = lambda gid: (
+        Growspace(id=gid, name=gid) if gid == "test_growspace" else None
+    )
     return mock
 
 
@@ -186,10 +188,10 @@ async def test_record_analytics_exception_handling(
 
 
 @pytest.mark.asyncio
-async def test_transition_plant_stage_to_clone(
+async def test_transition_plant_stage_to_mother(
     manager, repository_mock, validator_mock, gs_service_mock
 ) -> None:
-    """Test transition_plant_stage to CLONE stage."""
+    """Test a graph-valid transition into a special growspace."""
     # Create a plant
     plant_id = "test_plant"
     plant = create_plant(
@@ -197,6 +199,9 @@ async def test_transition_plant_stage_to_clone(
         growspace_id="test_growspace",
         strain="Test Strain",
     )
+    plant.stage = PlantStage.VEG
+    plant.veg_start = "2024-01-01"
+    plant.stage_history = [{"stage": "veg", "start": "2024-01-01", "end": None}]
     repository_mock.get_plant.return_value = plant
     growspaces = {
         "test_growspace": Growspace(id="test_growspace", name="Test"),
@@ -207,10 +212,9 @@ async def test_transition_plant_stage_to_clone(
     )
     repository_mock.get_growspace.side_effect = growspaces.get
 
-    # Transition to CLONE stage
-    await manager.transition_plant_stage(plant_id, PlantStage.CLONE, date(2024, 1, 15))
+    await manager.transition_plant_stage(plant_id, PlantStage.MOTHER, date(2024, 1, 15))
 
-    # Verify move_to_clone_growspace was called via service
+    # The target special growspace is resolved inside the atomic commit.
     gs_service_mock.ensure_special_growspace.assert_called()
 
 

--- a/tests/integration/test_services_plant_coverage.py
+++ b/tests/integration/test_services_plant_coverage.py
@@ -306,7 +306,9 @@ async def test_transition_plant_stage_actual(service, repository_mock) -> None:
         growspace_id="gs1",
         row=1,
         col=1,
-        stage="vegetative",
+        stage=PlantStage.VEG,
+        veg_start="2024-01-01",
+        stage_history=[{"stage": "veg", "start": "2024-01-01", "end": None}],
         type="normal",
     )
     repository_mock.get_plant.return_value = plant

--- a/tests/integration/test_services_plant_simple_coverage.py
+++ b/tests/integration/test_services_plant_simple_coverage.py
@@ -114,7 +114,8 @@ async def test_transition_closes_existing_history(
         plant_id=plant_id,
         growspace_id="tent",
         strain="Test Strain",
-        stage=PlantStage.FLOWER,
+        stage=PlantStage.VEG,
+        veg_start="2023-02-01",
         stage_history=[
             {"stage": "seedling", "start": "2023-01-01", "end": "2023-02-01"},
             {"stage": "veg", "start": "2023-02-01", "end": None},  # Open item

--- a/tests/logic/test_plant_lifecycle_manager.py
+++ b/tests/logic/test_plant_lifecycle_manager.py
@@ -194,6 +194,9 @@ async def test_move_to_dry_growspace_device_id_ghosting(
     plant.plant_id = "p1"
     plant.growspace_id = "gs1"
     plant.device_id = "device_1"
+    plant.stage = PlantStage.FLOWER
+    plant.flower_start = "2023-01-01"
+    plant.stage_history = [{"stage": "flower", "start": "2023-01-01", "end": None}]
     plant.strain = "Strain"
     plant.phenotype = "Pheno"
 
@@ -201,7 +204,14 @@ async def test_move_to_dry_growspace_device_id_ghosting(
     gs_service_mock.ensure_special_growspace.return_value = "dry_gs"
     mock_dry_gs = MagicMock()
     mock_dry_gs.device_id = None  # Crucial: destination has no device
-    repository_mock.get_growspace.side_effect = lambda gid: {"dry_gs": mock_dry_gs, "gs1": MagicMock()}.get(gid)
+    repository_mock.get_growspace.side_effect = lambda gid: {
+        "dry_gs": mock_dry_gs,
+        "gs1": MagicMock(),
+    }.get(gid)
+    repository_mock.require_growspace.side_effect = lambda gid: {
+        "dry_gs": mock_dry_gs,
+        "gs1": MagicMock(),
+    }[gid]
     repository_mock.get_plant.return_value = plant
 
     await manager.move_to_dry_growspace("p1", plant, "2023-01-01")
@@ -240,7 +250,19 @@ async def test_update_plant_preserves_lifecycle_datetime_time(
     Previously DATE_FIELDS were run through format_date, truncating to date-only;
     the time the user picked was silently discarded on the way to storage.
     """
-    plant = Plant(plant_id="p1", growspace_id="gs1")
+    plant = Plant(
+        plant_id="p1",
+        growspace_id="gs1",
+        stage=PlantStage.VEG,
+        veg_start="2023-02-01T08:00:00+00:00",
+        stage_history=[
+            {
+                "stage": "veg",
+                "start": "2023-02-01T08:00:00+00:00",
+                "end": None,
+            }
+        ],
+    )
     repository_mock.get_plant.return_value = plant
 
     await manager.update_plant("p1", flower_start="2026-03-01T14:30:00+00:00")
@@ -254,11 +276,23 @@ async def test_transition_plant_stage_preserves_supplied_datetime(
     manager, repository_mock
 ) -> None:
     """A stage transition stamps the start field with the supplied datetime's time."""
-    plant = Plant(plant_id="p1", growspace_id="gs1")
+    plant = Plant(
+        plant_id="p1",
+        growspace_id="gs1",
+        stage=PlantStage.VEG,
+        veg_start="2023-02-01T08:00:00+00:00",
+        stage_history=[
+            {
+                "stage": "veg",
+                "start": "2023-02-01T08:00:00+00:00",
+                "end": None,
+            }
+        ],
+    )
     repository_mock.get_plant.return_value = plant
 
     await manager.transition_plant_stage(
-        "p1", PlantStage.FLOWER, "2026-03-01T14:30:00+00:00"
+        "p1", PlantStage.FLOWER, "2023-03-01T14:30:00+00:00"
     )
 
     assert "T14:30" in plant.flower_start
@@ -327,6 +361,8 @@ async def test_promote_clone_target_full(manager, repository_mock) -> None:
     clone_plant = MagicMock(spec=Plant)
     clone_plant.stage = PlantStage.CLONE
     clone_plant.plant_id = "c1"
+    clone_plant.clone_start = "2023-01-01"
+    clone_plant.stage_history = [{"stage": "clone", "start": "2023-01-01", "end": None}]
 
     repository_mock.get_plant.return_value = clone_plant
 
@@ -346,7 +382,9 @@ async def test_promote_clone_target_full(manager, repository_mock) -> None:
 @pytest.mark.asyncio
 async def test_handle_transition_logic_kwargs(manager) -> None:
     """Test handle_transition_logic passes through kwargs correctly."""
-    with patch.object(manager, "transition_plant", new_callable=AsyncMock) as mock_harvest:
+    with patch.object(
+        manager, "transition_plant", new_callable=AsyncMock
+    ) as mock_harvest:
         # Call with keyword args only
         await manager.handle_transition_logic(plant_id="p1", custom_arg=True)
 

--- a/tests/managers/test_plant_lifecycle_atomic.py
+++ b/tests/managers/test_plant_lifecycle_atomic.py
@@ -1,0 +1,301 @@
+"""Atomic persistence-shell tests for Plant Lifecycle mutations."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from custom_components.growspace_manager.const import PlantStage
+from custom_components.growspace_manager.data_access.growspace_repository import (
+    GrowspaceRepository,
+)
+from custom_components.growspace_manager.data_access.notification_state import (
+    NotificationState,
+)
+from custom_components.growspace_manager.exceptions import ValidationChangeError
+from custom_components.growspace_manager.managers.plant import PlantManager
+from custom_components.growspace_manager.models import Growspace, Plant, PlantGenetics
+from custom_components.growspace_manager.services.context import ServiceContext
+
+
+def _plant(
+    plant_id: str,
+    stage: PlantStage,
+    started_on: str,
+    growspace_id: str = "main",
+) -> Plant:
+    field = f"{stage.value}_start"
+    return Plant(
+        plant_id=plant_id,
+        growspace_id=growspace_id,
+        genetics=PlantGenetics(strain_name="Test"),
+        stage=stage,
+        created_at=started_on,
+        stage_history=[{"stage": stage.value, "start": started_on, "end": None}],
+        **{field: started_on},
+    )
+
+
+@pytest.fixture
+def repository() -> GrowspaceRepository:
+    """Repository with a normal cultivation growspace."""
+    result = GrowspaceRepository()
+    result.add_growspace(Growspace(id="main", name="Main", rows=5, plants_per_row=5))
+    return result
+
+
+@pytest.fixture
+def manager_factory(repository: GrowspaceRepository):
+    """Build a manager around real in-memory models and controllable persistence."""
+
+    def build(save_callback: AsyncMock | None = None) -> PlantManager:
+        growspace_manager = Mock()
+
+        def ensure_special(
+            growspace_id: str | PlantStage,
+            name: str,
+            rows: int = 5,
+            plants_per_row: int = 5,
+            **_: object,
+        ) -> str:
+            canonical = str(growspace_id)
+            if not repository.has_growspace(canonical):
+                repository.add_growspace(
+                    Growspace(
+                        id=canonical,
+                        name=name,
+                        rows=rows,
+                        plants_per_row=plants_per_row,
+                    )
+                )
+            return canonical
+
+        growspace_manager.ensure_special_growspace.side_effect = ensure_special
+        growspace_manager.ensure_mother_growspace.side_effect = lambda: ensure_special(
+            PlantStage.MOTHER, "mother"
+        )
+
+        validator = Mock()
+        validator.validate_position_not_occupied.return_value = None
+        validator.validate_plant_exists.return_value = None
+        validator.find_first_available_position.return_value = (1, 1)
+
+        hass = Mock()
+        hass.bus.async_fire = Mock()
+        return PlantManager(
+            ctx=ServiceContext(
+                save_callback=save_callback or AsyncMock(),
+                lock=asyncio.Lock(),
+                add_event=Mock(),
+                invalidate_cache=Mock(),
+            ),
+            hass=hass,
+            repository=repository,
+            notification_state=NotificationState(),
+            validator=validator,
+            growspace_manager=growspace_manager,
+            strain_library=Mock(record_harvest=AsyncMock()),
+            plant_view_builder=Mock(build=Mock(return_value={})),
+        )
+
+    return build
+
+
+@pytest.mark.asyncio
+async def test_creation_seeds_seedling_and_clone_stage_history(
+    manager_factory, repository: GrowspaceRepository
+) -> None:
+    """Both supported origins are valid lifecycle records immediately."""
+    manager = manager_factory()
+    clone_space = Growspace(id="clone", name="Clone", rows=5, plants_per_row=5)
+    repository.add_growspace(clone_space)
+
+    seed = await manager.add_plant(growspace_id="main", strain="Seed")
+    clone = await manager.add_plant(
+        growspace_id="clone",
+        strain="Clone",
+        plant_type=PlantStage.CLONE,
+        stage=PlantStage.CLONE,
+        clone_start="2026-08-20T10:00:00+00:00",
+    )
+
+    assert seed.stage == PlantStage.SEEDLING
+    assert seed.stage_history == [
+        {
+            "stage": "seedling",
+            "start": seed.seedling_start,
+            "end": None,
+        }
+    ]
+    assert clone.stage == PlantStage.CLONE
+    assert clone.stage_history == [
+        {
+            "stage": "clone",
+            "start": "2026-08-20T10:00:00+00:00",
+            "end": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_all_mutation_paths_append_stage_history(
+    manager_factory, repository: GrowspaceRepository
+) -> None:
+    """Ordinary, harvest, promotion, and mother placement share one domain seam."""
+    manager = manager_factory()
+    repository.add_plant(_plant("ordinary", PlantStage.VEG, "2026-08-01"))
+    repository.add_plant(_plant("harvest", PlantStage.FLOWER, "2026-08-01"))
+    repository.add_plant(_plant("promotion", PlantStage.CLONE, "2026-08-01", "clone"))
+    repository.add_growspace(Growspace(id="clone", name="Clone"))
+    repository.add_growspace(Growspace(id="veg-room", name="Veg"))
+    repository.add_plant(_plant("mother", PlantStage.VEG, "2026-08-01"))
+
+    await manager.transition_plant_stage(
+        "ordinary", PlantStage.FLOWER, date(2026, 8, 10)
+    )
+    await manager.move_to_dry_growspace(
+        "harvest", repository.require_plant("harvest"), "2026-08-10"
+    )
+    await manager.promote_clone("promotion", "veg-room", date(2026, 8, 10))
+    await manager.transition_plant_stage("mother", PlantStage.MOTHER, date(2026, 8, 10))
+
+    expected = {
+        "ordinary": ("flower", "main"),
+        "harvest": ("dry", "dry"),
+        "promotion": ("veg", "veg-room"),
+        "mother": ("mother", "mother"),
+    }
+    for plant_id, (stage, growspace_id) in expected.items():
+        plant = repository.require_plant(plant_id)
+        assert [item["stage"] for item in plant.stage_history] == [
+            {
+                "ordinary": "veg",
+                "harvest": "flower",
+                "promotion": "clone",
+                "mother": "veg",
+            }[plant_id],
+            stage,
+        ]
+        assert plant.stage == stage
+        assert plant.growspace_id == growspace_id
+
+
+@pytest.mark.asyncio
+async def test_reveg_clears_stale_later_stage_fields(
+    manager_factory, repository: GrowspaceRepository
+) -> None:
+    """A closed flower interval remains in history but not in legacy stage fields."""
+    manager = manager_factory()
+    plant = Plant(
+        plant_id="reveg",
+        growspace_id="main",
+        stage=PlantStage.FLOWER,
+        veg_start="2026-07-01",
+        flower_start="2026-08-01",
+        stage_history=[
+            {"stage": "veg", "start": "2026-07-01", "end": "2026-08-01"},
+            {"stage": "flower", "start": "2026-08-01", "end": None},
+        ],
+    )
+    repository.add_plant(plant)
+
+    await manager.transition_plant_stage("reveg", PlantStage.VEG, "2026-08-10")
+
+    assert plant.stage == PlantStage.VEG
+    assert plant.veg_start == "2026-08-10T00:00:00+00:00"
+    assert plant.flower_start is None
+    assert [item["stage"] for item in plant.stage_history] == [
+        "veg",
+        "flower",
+        "veg",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failed_atomic_save_restores_plant_and_special_placement(
+    manager_factory, repository: GrowspaceRepository
+) -> None:
+    """A partway persistence failure publishes no in-memory transition."""
+    failing_save = AsyncMock(side_effect=RuntimeError("disk failed"))
+    manager = manager_factory(failing_save)
+    plant = _plant("rollback", PlantStage.FLOWER, "2026-08-01")
+    repository.add_plant(plant)
+    original_revision = repository.require_growspace("main").layout_revision
+
+    with pytest.raises(RuntimeError, match="disk failed"):
+        await manager.transition_plant_stage(
+            "rollback", PlantStage.DRY, date(2026, 8, 10)
+        )
+
+    assert repository.require_plant("rollback") is plant
+    assert plant.stage == PlantStage.FLOWER
+    assert plant.growspace_id == "main"
+    assert plant.dry_start is None
+    assert plant.stage_history == [
+        {"stage": "flower", "start": "2026-08-01", "end": None}
+    ]
+    assert repository.require_growspace("main").layout_revision == original_revision
+    assert not repository.has_growspace("dry")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_transitions_are_serialized(
+    manager_factory, repository: GrowspaceRepository
+) -> None:
+    """A second lifecycle mutation cannot observe the first half-written."""
+    first_save_started = asyncio.Event()
+    release_first_save = asyncio.Event()
+    save_count = 0
+
+    async def blocking_save() -> None:
+        nonlocal save_count
+        save_count += 1
+        if save_count == 1:
+            first_save_started.set()
+            await release_first_save.wait()
+
+    manager = manager_factory(AsyncMock(side_effect=blocking_save))
+    plant = _plant("serial", PlantStage.SEEDLING, "2026-08-01")
+    repository.add_plant(plant)
+
+    to_veg = asyncio.create_task(
+        manager._commit_lifecycle_transition("serial", PlantStage.VEG, "2026-08-10")
+    )
+    await first_save_started.wait()
+    to_flower = asyncio.create_task(
+        manager._commit_lifecycle_transition("serial", PlantStage.FLOWER, "2026-08-11")
+    )
+    await asyncio.sleep(0)
+
+    assert not to_flower.done()
+    assert plant.stage == PlantStage.VEG
+
+    release_first_save.set()
+    await asyncio.gather(to_veg, to_flower)
+
+    assert [item["stage"] for item in plant.stage_history] == [
+        "seedling",
+        "veg",
+        "flower",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_invalid_graph_transition_is_rejected_without_mutation(
+    manager_factory, repository: GrowspaceRepository
+) -> None:
+    """The persistence shell honors domain rejection decisions."""
+    manager = manager_factory()
+    plant = _plant("invalid", PlantStage.SEEDLING, "2026-08-01")
+    repository.add_plant(plant)
+
+    with pytest.raises(ValidationChangeError, match="not allowed"):
+        await manager._commit_lifecycle_transition(
+            "invalid", PlantStage.FLOWER, "2026-08-10"
+        )
+
+    assert plant.stage == PlantStage.SEEDLING
+    assert len(plant.stage_history) == 1


### PR DESCRIPTION
## Summary

- route initial creation, ordinary stage changes, harvest placement, and clone promotion through Plant Lifecycle
- update stage history, explicit stage, legacy dates, and special growspace placement atomically under the shared lock
- roll back plant and growspace state when persistence fails, and clear stale later lifecycle dates on Reveg
- add regression coverage for all mutation paths, rollback, lifecycle rejection, and concurrent transitions

## Testing

- Full pytest suite: `5161 passed`, `46 snapshots passed`
- Ruff on changed files
- Mypy on the plant manager

Fixes #633