### PR TITLE
style: apply ruff format across custom_components and tests

### DIFF
--- a/custom_components/growspace_manager/conversation_store.py
+++ b/custom_components/growspace_manager/conversation_store.py
@@ -34,7 +34,9 @@ class ConversationStore:
         """Load persisted threads into memory."""
         raw = await self._store.async_load() or {}
         self._data = raw.get("threads_by_growspace", {})
-        _LOGGER.debug("Loaded conversation threads for %d growspace(s)", len(self._data))
+        _LOGGER.debug(
+            "Loaded conversation threads for %d growspace(s)", len(self._data)
+        )
 
     def get_threads(self, growspace_id: str) -> list[dict[str, Any]]:
         """Return the thread list for *growspace_id* (empty list if none)."""

--- a/custom_components/growspace_manager/data_access/growspace_repository.py
+++ b/custom_components/growspace_manager/data_access/growspace_repository.py
@@ -106,9 +106,7 @@ class GrowspaceRepository:
 
     def get_growspace_options(self) -> dict[str, str]:
         """Return growspaces as {id: name} for dropdown selection."""
-        return {
-            gs.id: getattr(gs, "name", gs.id) for gs in self._growspaces.values()
-        }
+        return {gs.id: getattr(gs, "name", gs.id) for gs in self._growspaces.values()}
 
     def get_sorted_growspace_options(self) -> list[tuple[str, str]]:
         """Return a sorted list of (id, name) tuples for dropdown selection."""

--- a/custom_components/growspace_manager/diagnostics.py
+++ b/custom_components/growspace_manager/diagnostics.py
@@ -33,7 +33,8 @@ async def async_get_config_entry_diagnostics(
             "mode": getattr(coord, "mode", None),
         }
         for gs_id in coordinator.growspaces
-        if (coord := coordinator.services.growspaces.get_irrigation_coordinator(gs_id)) is not None
+        if (coord := coordinator.services.growspaces.get_irrigation_coordinator(gs_id))
+        is not None
     }
 
     dehumidifier_states = {
@@ -42,7 +43,10 @@ async def async_get_config_entry_diagnostics(
             "target_vpd": getattr(coord, "_target_vpd", None),
         }
         for gs_id in coordinator.growspaces
-        if (coord := coordinator.services.growspaces.get_dehumidifier_coordinator(gs_id)) is not None
+        if (
+            coord := coordinator.services.growspaces.get_dehumidifier_coordinator(gs_id)
+        )
+        is not None
     }
 
     return {
@@ -51,7 +55,9 @@ async def async_get_config_entry_diagnostics(
         "system_stats": {
             "growspace_count": len(coordinator.growspaces),
             "plant_count": len(coordinator.plants),
-            "strain_library_count": len(coordinator.services.config.strain_library.get_all())
+            "strain_library_count": len(
+                coordinator.services.config.strain_library.get_all()
+            )
             if coordinator.services.config.strain_library
             else 0,
         },

--- a/custom_components/growspace_manager/domain/environmental_targets.py
+++ b/custom_components/growspace_manager/domain/environmental_targets.py
@@ -144,7 +144,9 @@ class StageEnvironmentalTargets:
 
     # ── Evaluator interface ──────────────────────────────────────────────────
 
-    def vpd_stress_band(self, time_of_day: str, env_config: dict[str, Any]) -> VpdStressBand:
+    def vpd_stress_band(
+        self, time_of_day: str, env_config: dict[str, Any]
+    ) -> VpdStressBand:
         """Return interpolated VPD stress/mild bands with per-env overridable probabilities.
 
         Uses direct subscript access — callers must ensure stage_a/stage_b are valid keys
@@ -153,8 +155,12 @@ class StageEnvironmentalTargets:
         thr_a = VPD_STRESS_THRESHOLDS[self._stage_a][time_of_day]
         thr_b = VPD_STRESS_THRESHOLDS[self._stage_b][time_of_day]
 
-        stress_low = interpolate_value(thr_a["stress"][0], thr_b["stress"][0], self._factor)
-        stress_high = interpolate_value(thr_a["stress"][1], thr_b["stress"][1], self._factor)
+        stress_low = interpolate_value(
+            thr_a["stress"][0], thr_b["stress"][0], self._factor
+        )
+        stress_high = interpolate_value(
+            thr_a["stress"][1], thr_b["stress"][1], self._factor
+        )
         mild_low = interpolate_value(thr_a["mild"][0], thr_b["mild"][0], self._factor)
         mild_high = interpolate_value(thr_a["mild"][1], thr_b["mild"][1], self._factor)
 
@@ -165,7 +171,9 @@ class StageEnvironmentalTargets:
         prob_stress = env_config.get(prob_stress_key, prob_stress_default)
         prob_mild = env_config.get(prob_mild_key, prob_mild_default)
 
-        return VpdStressBand(stress_low, stress_high, mild_low, mild_high, prob_stress, prob_mild)
+        return VpdStressBand(
+            stress_low, stress_high, mild_low, mild_high, prob_stress, prob_mild
+        )
 
     def vpd_optimal_band(
         self, time_of_day: str, overrides: dict[str, Any]
@@ -192,11 +200,15 @@ class StageEnvironmentalTargets:
         high = interpolate_value(high_a, high_b, self._factor)
 
         if (
-            self._stage_a in (BayesianStage.SEEDLING, BayesianStage.CLONE, BayesianStage.VEG)
+            self._stage_a
+            in (BayesianStage.SEEDLING, BayesianStage.CLONE, BayesianStage.VEG)
             and self._factor < 0.5
         ):
             prob = env_config.get("prob_humidity_high_veg", PROB_HUMIDITY_HIGH_VEG)
-        elif BayesianStage.FLOWER_LATE in (self._stage_a, self._stage_b) and self._factor > 0.5:
+        elif (
+            BayesianStage.FLOWER_LATE in (self._stage_a, self._stage_b)
+            and self._factor > 0.5
+        ):
             prob = PROB_HUMIDITY_FLOWER_LATE_OUT_OF_RANGE
         else:
             prob = PROB_HUMIDITY_FLOWER_MID_OUT_OF_RANGE
@@ -226,8 +238,12 @@ class StageEnvironmentalTargets:
         Uses veg-stage fallback on missing keys — distinct from vpd_stress_band
         which uses direct subscript access and raises on a missing stage.
         """
-        thr_a = VPD_STRESS_THRESHOLDS.get(self._stage_a, VPD_STRESS_THRESHOLDS[BayesianStage.VEG])
-        thr_b = VPD_STRESS_THRESHOLDS.get(self._stage_b, VPD_STRESS_THRESHOLDS[BayesianStage.VEG])
+        thr_a = VPD_STRESS_THRESHOLDS.get(
+            self._stage_a, VPD_STRESS_THRESHOLDS[BayesianStage.VEG]
+        )
+        thr_b = VPD_STRESS_THRESHOLDS.get(
+            self._stage_b, VPD_STRESS_THRESHOLDS[BayesianStage.VEG]
+        )
 
         def _interp(
             data_a: dict[str, Any], data_b: dict[str, Any]

--- a/custom_components/growspace_manager/domain/stage.py
+++ b/custom_components/growspace_manager/domain/stage.py
@@ -112,22 +112,40 @@ def classify_stages(days: StageDays) -> StageClassification:
 
         if days.flower <= b1:
             if days.flower < b1 - TRANSITION_WINDOW:
-                return StageClassification(BayesianStage.FLOWER_EARLY, BayesianStage.FLOWER_EARLY, 0.0)
+                return StageClassification(
+                    BayesianStage.FLOWER_EARLY, BayesianStage.FLOWER_EARLY, 0.0
+                )
             factor = (days.flower - (b1 - TRANSITION_WINDOW)) / TRANSITION_WINDOW
-            return StageClassification(BayesianStage.FLOWER_EARLY, BayesianStage.FLOWER_MID, round(float(factor), 2))
+            return StageClassification(
+                BayesianStage.FLOWER_EARLY,
+                BayesianStage.FLOWER_MID,
+                round(float(factor), 2),
+            )
 
         if days.flower <= b2:
             if days.flower < b2 - TRANSITION_WINDOW:
-                return StageClassification(BayesianStage.FLOWER_MID, BayesianStage.FLOWER_MID, 0.0)
+                return StageClassification(
+                    BayesianStage.FLOWER_MID, BayesianStage.FLOWER_MID, 0.0
+                )
             factor = (days.flower - (b2 - TRANSITION_WINDOW)) / TRANSITION_WINDOW
-            return StageClassification(BayesianStage.FLOWER_MID, BayesianStage.FLOWER_LATE, round(float(factor), 2))
+            return StageClassification(
+                BayesianStage.FLOWER_MID,
+                BayesianStage.FLOWER_LATE,
+                round(float(factor), 2),
+            )
 
-        return StageClassification(BayesianStage.FLOWER_LATE, BayesianStage.FLOWER_LATE, 0.0)
+        return StageClassification(
+            BayesianStage.FLOWER_LATE, BayesianStage.FLOWER_LATE, 0.0
+        )
 
     if days.veg >= 0:
         if days.veg < TRANSITION_WINDOW:
             factor = days.veg / TRANSITION_WINDOW
-            return StageClassification(BayesianStage.SEEDLING_STANDARD, BayesianStage.VEG, round(float(factor), 2))
+            return StageClassification(
+                BayesianStage.SEEDLING_STANDARD,
+                BayesianStage.VEG,
+                round(float(factor), 2),
+            )
         return StageClassification(BayesianStage.VEG, BayesianStage.VEG, 0.0)
 
     if days.seedling >= 0:
@@ -135,22 +153,38 @@ def classify_stages(days: StageDays) -> StageClassification:
         ac_end = ACCLIMATION_END_DAYS
         if days.seedling <= ac_end:
             if days.seedling <= ac_start:
-                return StageClassification(BayesianStage.SEEDLING, BayesianStage.SEEDLING, 0.0)
+                return StageClassification(
+                    BayesianStage.SEEDLING, BayesianStage.SEEDLING, 0.0
+                )
             window = ac_end - ac_start
             factor = (days.seedling - ac_start) / window
-            return StageClassification(BayesianStage.SEEDLING, BayesianStage.SEEDLING_STANDARD, round(float(factor), 2))
-        return StageClassification(BayesianStage.SEEDLING_STANDARD, BayesianStage.SEEDLING_STANDARD, 0.0)
+            return StageClassification(
+                BayesianStage.SEEDLING,
+                BayesianStage.SEEDLING_STANDARD,
+                round(float(factor), 2),
+            )
+        return StageClassification(
+            BayesianStage.SEEDLING_STANDARD, BayesianStage.SEEDLING_STANDARD, 0.0
+        )
 
     if days.clone >= 0:
         ac_start = ACCLIMATION_START_DAYS
         ac_end = ACCLIMATION_END_DAYS
         if days.clone <= ac_end:
             if days.clone <= ac_start:
-                return StageClassification(BayesianStage.CLONE, BayesianStage.CLONE, 0.0)
+                return StageClassification(
+                    BayesianStage.CLONE, BayesianStage.CLONE, 0.0
+                )
             window = ac_end - ac_start
             factor = (days.clone - ac_start) / window
-            return StageClassification(BayesianStage.CLONE, BayesianStage.CLONE_STANDARD, round(float(factor), 2))
-        return StageClassification(BayesianStage.CLONE_STANDARD, BayesianStage.CLONE_STANDARD, 0.0)
+            return StageClassification(
+                BayesianStage.CLONE,
+                BayesianStage.CLONE_STANDARD,
+                round(float(factor), 2),
+            )
+        return StageClassification(
+            BayesianStage.CLONE_STANDARD, BayesianStage.CLONE_STANDARD, 0.0
+        )
 
     return StageClassification(BayesianStage.EMPTY, BayesianStage.EMPTY, 0.0)
 

--- a/custom_components/growspace_manager/domain/stage_calculator.py
+++ b/custom_components/growspace_manager/domain/stage_calculator.py
@@ -60,15 +60,11 @@ def determine_coordinator_stage(plants: list[Plant]) -> PlantStage:
         max_clone_days = max(
             max_clone_days, calculate_days_in_stage(plant, PlantStage.CLONE)
         )
-        max_veg_days = max(
-            max_veg_days, calculate_days_in_stage(plant, PlantStage.VEG)
-        )
+        max_veg_days = max(max_veg_days, calculate_days_in_stage(plant, PlantStage.VEG))
         max_flower_days = max(
             max_flower_days, calculate_days_in_stage(plant, PlantStage.FLOWER)
         )
-        max_dry_days = max(
-            max_dry_days, calculate_days_in_stage(plant, PlantStage.DRY)
-        )
+        max_dry_days = max(max_dry_days, calculate_days_in_stage(plant, PlantStage.DRY))
         max_cure_days = max(
             max_cure_days, calculate_days_in_stage(plant, PlantStage.CURE)
         )

--- a/custom_components/growspace_manager/domain/water_aggregation.py
+++ b/custom_components/growspace_manager/domain/water_aggregation.py
@@ -35,9 +35,7 @@ class _TankTracker(Protocol):
 
     def get_total_liters_today(self, reference_ts: str | None = None) -> float: ...
 
-    def get_total_liters_since(
-        self, cycle_start_date: str | None = None
-    ) -> float: ...
+    def get_total_liters_since(self, cycle_start_date: str | None = None) -> float: ...
 
 
 @dataclass(slots=True)
@@ -138,9 +136,7 @@ def compute_growspace_water(
     if is_tank_derived_mode(growspace) and tracker_list:
         cycle_start = usage.cycle_start_date or None
         tank_today = sum(t.get_total_liters_today() for t in tracker_list)
-        tank_cycle = sum(
-            t.get_total_liters_since(cycle_start) for t in tracker_list
-        )
+        tank_cycle = sum(t.get_total_liters_since(cycle_start) for t in tracker_list)
         # Manual lives in WaterUsageData; pump estimates are write-gated out of
         # tank mode, so adding usage_* here adds manual only (per ADR-0017).
         return WaterUseFigures(

--- a/custom_components/growspace_manager/environment_analyzer.py
+++ b/custom_components/growspace_manager/environment_analyzer.py
@@ -75,7 +75,9 @@ class EnvironmentAnalyzer:
         stage_b = classification.stage_b
         factor = classification.factor
 
-        display = StageEnvironmentalTargets(stage_a, stage_b, factor).vpd_display_targets()
+        display = StageEnvironmentalTargets(
+            stage_a, stage_b, factor
+        ).vpd_display_targets()
         d_danger_min = display.day_danger_min
         d_danger_max = display.day_danger_max
         d_target_min = display.day_target_min
@@ -165,7 +167,7 @@ class EnvironmentAnalyzer:
                         break
                     # If it parses but is 0, it's valid code (night)
                     has_valid_state = True
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
 
         if not has_valid_state:
@@ -188,7 +190,7 @@ class EnvironmentAnalyzer:
         if state and state.state not in ["unknown", "unavailable"]:
             try:
                 return float(state.state)
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 return None
         return None
 

--- a/custom_components/growspace_manager/image_processor.py
+++ b/custom_components/growspace_manager/image_processor.py
@@ -100,7 +100,9 @@ class GrowspaceImageProcessor:
         try:
             img: Image.Image = Image.open(io.BytesIO(image_bytes))
         except Exception as exc:
-            raise ValueError(f"Could not decode the supplied image bytes: {exc}") from exc
+            raise ValueError(
+                f"Could not decode the supplied image bytes: {exc}"
+            ) from exc
 
         if img.mode != "RGB":
             img = img.convert("RGB")

--- a/custom_components/growspace_manager/light_cycle_tracker.py
+++ b/custom_components/growspace_manager/light_cycle_tracker.py
@@ -41,11 +41,7 @@ class LightCycleTracker:
             return False
         env = getattr(growspace, "environment_config", None)
         light_sensors = getattr(env, "light_sensors", []) if env else []
-        return (
-            strategy.enabled
-            and strategy.auto_light_tracking
-            and bool(light_sensors)
-        )
+        return strategy.enabled and strategy.auto_light_tracking and bool(light_sensors)
 
     def _light_sensors(self) -> list[str]:
         growspace = self.main_coordinator.growspaces.get(self.growspace_id)

--- a/custom_components/growspace_manager/managers/lineage_classifier.py
+++ b/custom_components/growspace_manager/managers/lineage_classifier.py
@@ -1,4 +1,5 @@
 """Pure functions for classifying cannabis cross types from lineage trees."""
+
 from __future__ import annotations
 
 import re

--- a/custom_components/growspace_manager/managers/nutrient.py
+++ b/custom_components/growspace_manager/managers/nutrient.py
@@ -80,7 +80,9 @@ class NutrientManager:
             preset = self.nutrient_presets[preset_id]
             preset.name = name
             preset.items = [
-                NutrientPresetItem(nutrient_id=n["nutrient_id"], dose_ml_l=n["dose_ml_l"])
+                NutrientPresetItem(
+                    nutrient_id=n["nutrient_id"], dose_ml_l=n["dose_ml_l"]
+                )
                 for n in nutrients
             ]
             preset.stage = stage
@@ -95,7 +97,9 @@ class NutrientManager:
                 id=pid,
                 name=name,
                 items=[
-                    NutrientPresetItem(nutrient_id=n["nutrient_id"], dose_ml_l=n["dose_ml_l"])
+                    NutrientPresetItem(
+                        nutrient_id=n["nutrient_id"], dose_ml_l=n["dose_ml_l"]
+                    )
                     for n in nutrients
                 ],
                 stage=stage,

--- a/custom_components/growspace_manager/managers/strain_analytics.py
+++ b/custom_components/growspace_manager/managers/strain_analytics.py
@@ -69,17 +69,20 @@ class StrainAnalyticsManager:
                 pheno_meta = {
                     k: v
                     for k, v in pheno_data.items()
-                    if k not in ["harvests", "description", "image_path", "image_crop_meta"]
+                    if k
+                    not in ["harvests", "description", "image_path", "image_crop_meta"]
                 }
                 pheno_analytics[pheno_name] = {**stats, **pheno_meta}
 
             num_strain_harvests = len(strain_harvests)
             if num_strain_harvests:
                 strain_avg_veg = round(
-                    sum(h.get("veg_days", 0) for h in strain_harvests) / num_strain_harvests
+                    sum(h.get("veg_days", 0) for h in strain_harvests)
+                    / num_strain_harvests
                 )
                 strain_avg_flower = round(
-                    sum(h.get("flower_days", 0) for h in strain_harvests) / num_strain_harvests
+                    sum(h.get("flower_days", 0) for h in strain_harvests)
+                    / num_strain_harvests
                 )
             else:
                 strain_avg_veg = 0

--- a/custom_components/growspace_manager/managers/subsystem.py
+++ b/custom_components/growspace_manager/managers/subsystem.py
@@ -123,15 +123,25 @@ class SubsystemManager:
         await irrigation_coordinator.async_setup()
         self.irrigation_coordinators[growspace_id] = irrigation_coordinator
 
-        light_cycle_tracker = LightCycleTracker(self.hass, growspace_id, self.coordinator)
+        light_cycle_tracker = LightCycleTracker(
+            self.hass, growspace_id, self.coordinator
+        )
         await light_cycle_tracker.async_setup()
         self.light_cycle_trackers[growspace_id] = light_cycle_tracker
 
         controllers: list[EnvironmentController] = [
-            DehumidifierCoordinator(self.hass, self.entry, growspace_id, self.coordinator),
-            HumidifierCoordinator(self.hass, self.entry, growspace_id, self.coordinator),
-            CirculationFanCoordinator(self.hass, self.entry, growspace_id, self.coordinator),
-            ExhaustFanCoordinator(self.hass, self.entry, growspace_id, self.coordinator),
+            DehumidifierCoordinator(
+                self.hass, self.entry, growspace_id, self.coordinator
+            ),
+            HumidifierCoordinator(
+                self.hass, self.entry, growspace_id, self.coordinator
+            ),
+            CirculationFanCoordinator(
+                self.hass, self.entry, growspace_id, self.coordinator
+            ),
+            ExhaustFanCoordinator(
+                self.hass, self.entry, growspace_id, self.coordinator
+            ),
             GrowLightCoordinator(self.hass, self.entry, growspace_id, self.coordinator),
         ]
         for controller in controllers:
@@ -163,14 +173,18 @@ class SubsystemManager:
             except Exception as err:  # noqa: BLE001
                 _LOGGER.error("Error unloading environment controller: %s", err)
 
-    def get_dehumidifier_controller(self, growspace_id: str) -> DehumidifierCoordinator | None:
+    def get_dehumidifier_controller(
+        self, growspace_id: str
+    ) -> DehumidifierCoordinator | None:
         """Return the dehumidifier coordinator for a growspace, or None."""
         for c in self.environment_controllers.get(growspace_id, []):
             if isinstance(c, DehumidifierCoordinator):
                 return c
         return None
 
-    def get_humidifier_controller(self, growspace_id: str) -> HumidifierCoordinator | None:
+    def get_humidifier_controller(
+        self, growspace_id: str
+    ) -> HumidifierCoordinator | None:
         """Return the humidifier coordinator for a growspace, or None."""
         for c in self.environment_controllers.get(growspace_id, []):
             if isinstance(c, HumidifierCoordinator):

--- a/custom_components/growspace_manager/models/base.py
+++ b/custom_components/growspace_manager/models/base.py
@@ -33,7 +33,7 @@ def _sanitize_numeric_fields(cls: type, data: dict[str, Any]) -> dict[str, Any]:
             elif f.type == "int" and isinstance(val, (float, str)):
                 try:
                     data[f.name] = int(float(val))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     # On conversion error, fall back to the field's default or 0.
                     if f.default is not MISSING:
                         data[f.name] = f.default

--- a/custom_components/growspace_manager/models/plant.py
+++ b/custom_components/growspace_manager/models/plant.py
@@ -167,7 +167,7 @@ class Plant(BaseModel):
             if field_name in data:
                 try:
                     data[field_name] = int(float(data[field_name]))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     data[field_name] = 1  # Safe default
 
         # Migration: old 'scores' dict → new 'phenotype_score' with renamed fields.

--- a/custom_components/growspace_manager/presentation/entity_queries.py
+++ b/custom_components/growspace_manager/presentation/entity_queries.py
@@ -85,7 +85,7 @@ class EntityQueries:
 
         try:
             return float(state.state)
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             return None
 
     def get_sensor_state(self, sensor_id: str | None) -> str | None:
@@ -129,9 +129,9 @@ class EntityQueries:
             # Replace European comma with period
             cleaned = cleaned.replace(",", ".")
             return float(cleaned)
-        except (ValueError, TypeError, AttributeError):
+        except ValueError, TypeError, AttributeError:
             # If it's already a number or conversion failed
             try:
                 return float(state_value)
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 return None

--- a/custom_components/growspace_manager/services/batch.py
+++ b/custom_components/growspace_manager/services/batch.py
@@ -64,7 +64,7 @@ async def handle_batch_action(
                 # Better to just log. But since it repeats for all, break.
                 break
 
-        except Exception as err :  # noqa: BLE001
+        except Exception as err:  # noqa: BLE001
             _LOGGER.error("Error processing batch action for %s: %s", entity_id, err)
             errors.append(str(err))
 

--- a/custom_components/growspace_manager/services/config_facade.py
+++ b/custom_components/growspace_manager/services/config_facade.py
@@ -142,7 +142,9 @@ class ConfigFacade:
 
     async def remove_nutrient_preset(self, preset_id: str) -> None:
         """Remove a nutrient preset."""
-        await self._coordinator._nutrient_manager.async_remove_nutrient_preset(preset_id)
+        await self._coordinator._nutrient_manager.async_remove_nutrient_preset(
+            preset_id
+        )
 
     def get_applicable_presets(self, plant_id: str) -> list[NutrientPreset]:
         """Return all nutrient presets applicable to a plant."""

--- a/custom_components/growspace_manager/services/environment_reporter.py
+++ b/custom_components/growspace_manager/services/environment_reporter.py
@@ -92,7 +92,7 @@ class EnvironmentReporter:
         try:
             # Handle numeric sensor (brightness or power) treated as light sensor
             return float(state_obj.state) > 0
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             return False
 
     async def _handle_light_change(
@@ -159,7 +159,7 @@ class EnvironmentReporter:
             try:
                 if s.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
                     values.append(float(s.state))
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 continue
 
         if not values:

--- a/custom_components/growspace_manager/services/genetics_facade.py
+++ b/custom_components/growspace_manager/services/genetics_facade.py
@@ -51,7 +51,9 @@ class GeneticsFacade:
 
     async def async_update_seed_batch(self, **kwargs: Any) -> Any:
         """Update an existing seed batch."""
-        return await self._coordinator._genetics_manager.async_update_seed_batch(**kwargs)
+        return await self._coordinator._genetics_manager.async_update_seed_batch(
+            **kwargs
+        )
 
     async def async_log_pollination(self, **kwargs: Any) -> Any:
         """Log a pollination event."""
@@ -67,7 +69,9 @@ class GeneticsFacade:
 
     async def async_update_pollination(self, **kwargs: Any) -> Any:
         """Update an existing pollination event."""
-        return await self._coordinator._genetics_manager.async_update_pollination(**kwargs)
+        return await self._coordinator._genetics_manager.async_update_pollination(
+            **kwargs
+        )
 
     async def async_delete_pollination(self, event_id: str) -> None:
         """Delete a pollination event."""

--- a/custom_components/growspace_manager/services/ipm_service.py
+++ b/custom_components/growspace_manager/services/ipm_service.py
@@ -150,10 +150,7 @@ class IPMService(BaseService):
                     dt_util.now().date() + timedelta(days=max_phi_days)
                 ).isoformat()
                 # Only update if new clearance is later than existing
-                if (
-                    not plant.phi_clearance_date
-                    or clearance > plant.phi_clearance_date
-                ):
+                if not plant.phi_clearance_date or clearance > plant.phi_clearance_date:
                     plant.phi_clearance_date = clearance
 
         # Group by growspace for event logging

--- a/custom_components/growspace_manager/services/irrigation_watering.py
+++ b/custom_components/growspace_manager/services/irrigation_watering.py
@@ -41,7 +41,9 @@ async def handle_water_plant(
         nutrients: dict[str, float] | None = call.data.get("nutrients")
         preset_id: str | None = call.data.get("preset_id")
 
-        await coordinator.services.plants.water_plant(plant_id, amount, nutrients, preset_id)
+        await coordinator.services.plants.water_plant(
+            plant_id, amount, nutrients, preset_id
+        )
 
         _LOGGER.info(
             "Service water_plant completed for plant %s with %sL",

--- a/custom_components/growspace_manager/services/vision_checkup.py
+++ b/custom_components/growspace_manager/services/vision_checkup.py
@@ -32,9 +32,7 @@ async def handle_trigger_vision_checkup(
     growspace_id = call.data["growspace_id"]
 
     if growspace_id not in coordinator.growspaces:
-        raise ServiceValidationError(
-            f"Growspace '{growspace_id}' not found"
-        )
+        raise ServiceValidationError(f"Growspace '{growspace_id}' not found")
 
     result = await coordinator.vision_scheduler.run_vision_analysis(
         growspace_id, "manual"

--- a/custom_components/growspace_manager/services/water_analytics.py
+++ b/custom_components/growspace_manager/services/water_analytics.py
@@ -36,7 +36,9 @@ async def handle_reset_water_tracking(
     """
     growspace_id: str = call.data[ATTR_GROWSPACE_ID]
 
-    await coordinator.services.growspaces.reset_water_tracking(growspace_id=growspace_id)
+    await coordinator.services.growspaces.reset_water_tracking(
+        growspace_id=growspace_id
+    )
 
     _LOGGER.info("Reset water tracking for growspace %s", growspace_id)
 

--- a/custom_components/growspace_manager/strategies/mold.py
+++ b/custom_components/growspace_manager/strategies/mold.py
@@ -31,15 +31,17 @@ if TYPE_CHECKING:
 
 
 def _classify_mold(state: EnvironmentState) -> StageClassification:
-    return classify_stages(StageDays(
-        veg=state.veg_days,
-        flower=state.flower_days,
-        dry=state.dry_days,
-        cure=state.cure_days,
-        seedling=state.seedling_days,
-        clone=state.clone_days,
-        mother=state.mother_days,
-    ))
+    return classify_stages(
+        StageDays(
+            veg=state.veg_days,
+            flower=state.flower_days,
+            dry=state.dry_days,
+            cure=state.cure_days,
+            seedling=state.seedling_days,
+            clone=state.clone_days,
+            mother=state.mother_days,
+        )
+    )
 
 
 class MoldRiskEvaluatorStrategy(BayesianEvaluatorStrategy):

--- a/custom_components/growspace_manager/tank_depletion_predictor.py
+++ b/custom_components/growspace_manager/tank_depletion_predictor.py
@@ -97,7 +97,7 @@ class TankDepletionPredictor:
 
         try:
             level = float(state.state)
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             _LOGGER.warning(
                 "Invalid tank level from %s: %s",
                 self.tank.sensor_entity,
@@ -278,7 +278,7 @@ class TankDepletionPredictor:
 
         try:
             vpd = float(vpd_state.state)
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             return None
 
         # Apply multiplier for high VPD (increased transpiration)

--- a/custom_components/growspace_manager/views.py
+++ b/custom_components/growspace_manager/views.py
@@ -84,7 +84,7 @@ class StrainLibraryUploadView(HomeAssistantView):
         # 2. Save to temp file
         try:
             temp_path = await self._save_upload_to_temp(file_field)
-        except (OSError, RuntimeError):
+        except OSError, RuntimeError:
             return web.Response(status=500, text="Failed to save upload")
 
         try:
@@ -147,6 +147,6 @@ class StrainLibraryImageView(HomeAssistantView):
                 return web.Response(status=404, text="Image not found")
 
             return web.FileResponse(file_path)
-        except (OSError, ValueError, RuntimeError, Exception):
+        except OSError, ValueError, RuntimeError, Exception:
             _LOGGER.exception("Error serving image %s", filename)
             return web.Response(status=500, text="Internal server error")

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -67,8 +67,12 @@ def mock_coordinator():
     coordinator._growspace_manager.async_update_growspace = AsyncMock()
     coordinator._growspace_manager.async_remove_growspace = AsyncMock()
     coordinator._growspace_manager.async_update_environment_config = AsyncMock()
-    coordinator._growspace_manager.ensure_special_growspace = MagicMock(return_value="special_gs")
-    coordinator._growspace_manager.get_sorted_growspace_options = MagicMock(return_value=[])
+    coordinator._growspace_manager.ensure_special_growspace = MagicMock(
+        return_value="special_gs"
+    )
+    coordinator._growspace_manager.get_sorted_growspace_options = MagicMock(
+        return_value=[]
+    )
 
     # Clone manager methods
     coordinator.clone_manager.async_take_clones = AsyncMock(return_value=["clone_1"])

--- a/tests/components/test_binary_sensor.py
+++ b/tests/components/test_binary_sensor.py
@@ -144,10 +144,14 @@ def mock_coordinator(mock_growspace):
         return (date.today() - dt).days
 
     # UPDATE: Use a lambda so plant updates in individual tests evaluate dynamically
-    coordinator.services.growspaces.get_all_growspaces.return_value = coordinator.growspaces
-    coordinator.services.growspaces.get_growspace.side_effect = coordinator.growspaces.get
-    coordinator.services.growspaces.get_growspace_plants.side_effect = lambda gid=None: list(
-        coordinator.plants.values()
+    coordinator.services.growspaces.get_all_growspaces.return_value = (
+        coordinator.growspaces
+    )
+    coordinator.services.growspaces.get_growspace.side_effect = (
+        coordinator.growspaces.get
+    )
+    coordinator.services.growspaces.get_growspace_plants.side_effect = lambda gid=None: (
+        list(coordinator.plants.values())
     )
     coordinator.services.plants.get_plant.side_effect = coordinator.plants.get
     coordinator.services.notifications.is_notifications_enabled.return_value = True
@@ -201,7 +205,9 @@ def create_test_sensor(
         sensor.trend_analyzer = TrendAnalyzer(hass)
         sensor.strategy = strategy_class(
             env_config=sensor.env_config,
-            analyze_trend=lambda *args, **kwargs: sensor.async_analyze_sensor_trend(*args, **kwargs),
+            analyze_trend=lambda *args, **kwargs: sensor.async_analyze_sensor_trend(
+                *args, **kwargs
+            ),
             get_state=hass.states.get,
             get_growspace=lambda: coordinator.growspaces.get(growspace_id),
             get_notification_message=generate_notification_message,
@@ -478,7 +484,9 @@ def testgenerate_notification_message_truncation(
         mock_coordinator.growspaces["gs1"].environment_config,
     )
     # Use real NotificationManager to test truncation logic
-    sensor.notification_manager = NotificationManager(hass, mock_coordinator, AINotificationRewriter(hass))
+    sensor.notification_manager = NotificationManager(
+        hass, mock_coordinator, AINotificationRewriter(hass)
+    )
 
     sensor._reasons = [
         (0.9, "VPD out of range"),
@@ -625,9 +633,7 @@ async def test_bayesian_stress_sensor_granular(
             hass, mock_coordinator, AINotificationRewriter(hass)
         )
         manager._latest_snapshots[("gs1", snapshot.sensor_type)] = snapshot
-        with patch.object(
-            manager, "async_send_notification"
-        ) as mock_send_final:
+        with patch.object(manager, "async_send_notification") as mock_send_final:
             await manager._async_send_batched_notification("gs1")
             mock_send_final.assert_awaited_once()
             args, kwargs = mock_send_final.call_args
@@ -1715,7 +1721,9 @@ def test_light_cycle_get_growth_stage_info_scenarios(
         get_plants=mock_coordinator.services.growspaces.get_growspace_plants,
         calculate_days=mock_coordinator.services.calculate_days,
     )
-    mock_coordinator.services.growspaces.get_growspace_plants.side_effect = lambda gid=None: plants
+    mock_coordinator.services.growspaces.get_growspace_plants.side_effect = (
+        lambda gid=None: plants
+    )
 
     mock_coordinator.services.calculate_days.side_effect = lambda date_str: (
         (date(2026, 1, 12) - date.fromisoformat(date_str)).days if date_str else 0
@@ -1892,7 +1900,9 @@ class TestBayesianEnvironmentSensor:
                 get_plants=sensor._get_plants,
             )
 
-            sensor._strategy_class = MagicMock()  # Strategy class for async_added_to_hass
+            sensor._strategy_class = (
+                MagicMock()
+            )  # Strategy class for async_added_to_hass
             sensor.strategy = MagicMock()  # Mock strategy (pre-wired)
             sensor.strategy.async_evaluate = AsyncMock(return_value=([], []))
             # Notification state is handled by notification_manager, not sensor attributes

--- a/tests/components/test_sensor.py
+++ b/tests/components/test_sensor.py
@@ -85,7 +85,10 @@ def mock_coordinator() -> MagicMock:
     coordinator.services.notifications.should_send_notification.return_value = True
     coordinator.services.notifications.mark_notification_sent = AsyncMock()
     coordinator.async_add_listener = Mock()
-    coordinator.services.config.get_strain_options.return_value = ["Strain A", "Strain B"]
+    coordinator.services.config.get_strain_options.return_value = [
+        "Strain A",
+        "Strain B",
+    ]
     coordinator.services.get_growspace_options.return_value = ["gs1"]
     coordinator.strains = MagicMock()
     coordinator.created_entity_ids = []
@@ -1060,9 +1063,7 @@ def test_growspace_list_sensor_state_and_attributes(
     sensor.platform_data = sensor.platform
     attrs = sensor.extra_state_attributes
     assert "growspaces" in attrs
-    assert attrs["growspaces"] == {
-        "gs1": {"name": "Growspace 1", "total_plants": 1}
-    }
+    assert attrs["growspaces"] == {"gs1": {"name": "Growspace 1", "total_plants": 1}}
 
 
 def test_growspace_list_sensor_plant_counts_per_growspace() -> None:

--- a/tests/components/test_sensor_tank_water.py
+++ b/tests/components/test_sensor_tank_water.py
@@ -108,7 +108,9 @@ async def test_async_added_to_hass_tracker_none():
         await sensor.async_added_to_hass()
 
     # get_tank_tracker was called and returned None, so early return happened
-    coordinator.services.growspaces.get_tank_tracker.assert_called_once_with("gs_1", "sensor.tank_1")
+    coordinator.services.growspaces.get_tank_tracker.assert_called_once_with(
+        "gs_1", "sensor.tank_1"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/components/test_sensors_extra_coverage.py
+++ b/tests/components/test_sensors_extra_coverage.py
@@ -421,7 +421,9 @@ async def test_update_growspace_entities_new_vpd(hass: HomeAssistant):
             "custom_components.growspace_manager.sensor._setup._async_create_derivative_sensors",
             new_callable=AsyncMock,
         ),
-        patch("custom_components.growspace_manager.sensor._setup.GrowspaceOverviewSensor"),
+        patch(
+            "custom_components.growspace_manager.sensor._setup.GrowspaceOverviewSensor"
+        ),
     ):
         await _update_growspace_entities(
             hass,

--- a/tests/components/test_switch.py
+++ b/tests/components/test_switch.py
@@ -71,7 +71,9 @@ async def test_async_setup_entry_creates_entities(mock_hass, mock_coordinator) -
     mock_coordinator.async_set_updated_data = Mock()
 
     mock_coordinator.services = Mock()
-    mock_coordinator.services.notifications.is_notifications_enabled = Mock(return_value=True)
+    mock_coordinator.services.notifications.is_notifications_enabled = Mock(
+        return_value=True
+    )
 
     await async_setup_entry(
         mock_hass,
@@ -97,7 +99,9 @@ async def test_growspace_notification_switch_on_off(mock_coordinator) -> None:
     # Mock coordinator methods
     mock_coordinator.services = Mock()
     mock_coordinator.services.notifications.set_notifications_enabled = AsyncMock()
-    mock_coordinator.services.notifications.is_notifications_enabled = Mock(return_value=True)
+    mock_coordinator.services.notifications.is_notifications_enabled = Mock(
+        return_value=True
+    )
 
     switch = GrowspaceNotificationSwitch(
         mock_coordinator, "gs1", growspace, NOTIFICATION_SWITCH

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -64,7 +64,9 @@ def mock_coordinator():
     coordinator._plant_manager.services.plants.add_plant = AsyncMock(
         side_effect=_mock_add_plant
     )
-    coordinator._plant_manager.add_plant = coordinator._plant_manager.services.plants.add_plant
+    coordinator._plant_manager.add_plant = (
+        coordinator._plant_manager.services.plants.add_plant
+    )
 
     for method in plant_methods:
         mock_method = AsyncMock()
@@ -128,6 +130,7 @@ def mock_coordinator():
     coordinator.ipm_service.services = MagicMock()
 
     from custom_components.growspace_manager.services.facade import ServiceFacade
+
     services = ServiceFacade(coordinator)
     services.save = AsyncMock(side_effect=services.save)
     coordinator.services = services

--- a/tests/config/test_plant_config_handler.py
+++ b/tests/config/test_plant_config_handler.py
@@ -357,7 +357,11 @@ async def test_async_step_add_plant_success(
     """Test add plant step success."""
     mock_flow = MagicMock()
     mock_flow.async_create_entry = MagicMock(
-        side_effect=lambda title, data: {"type": FlowResultType.CREATE_ENTRY, "title": title, "data": data}
+        side_effect=lambda title, data: {
+            "type": FlowResultType.CREATE_ENTRY,
+            "title": title,
+            "data": data,
+        }
     )
     handler.flow = mock_flow
     handler.flow.selected_growspace_id = "gs1"
@@ -383,7 +387,11 @@ async def test_async_step_update_plant_success(
     """Test update plant step success."""
     mock_flow = MagicMock()
     mock_flow.async_create_entry = MagicMock(
-        side_effect=lambda title, data: {"type": FlowResultType.CREATE_ENTRY, "title": title, "data": data}
+        side_effect=lambda title, data: {
+            "type": FlowResultType.CREATE_ENTRY,
+            "title": title,
+            "data": data,
+        }
     )
     handler.flow = mock_flow
     handler.flow.selected_plant_id = "p1"

--- a/tests/config_handlers/test_bayesian_advanced_handler.py
+++ b/tests/config_handlers/test_bayesian_advanced_handler.py
@@ -43,9 +43,7 @@ def _make_flow(growspace: Growspace | None = None) -> MagicMock:
     flow.async_step_configure_sensor_placement = AsyncMock(
         return_value={"type": "form", "step_id": "configure_sensor_placement"}
     )
-    flow.async_step_save_and_finish = AsyncMock(
-        return_value={"type": "create_entry"}
-    )
+    flow.async_step_save_and_finish = AsyncMock(return_value={"type": "create_entry"})
     return flow
 
 
@@ -252,7 +250,9 @@ def test_parse_passthrough_non_string_value() -> None:
     flow = _make_flow()
     handler = BayesianAdvancedHandler(flow)
 
-    result = handler.parse_advanced_bayesian_input({CONF_PROB_TEMP_EXTREME_HEAT: (0.9, 0.1)})
+    result = handler.parse_advanced_bayesian_input(
+        {CONF_PROB_TEMP_EXTREME_HEAT: (0.9, 0.1)}
+    )
 
     assert result[CONF_PROB_TEMP_EXTREME_HEAT] == (0.9, 0.1)
 

--- a/tests/config_handlers/test_dehumidifier_handler.py
+++ b/tests/config_handlers/test_dehumidifier_handler.py
@@ -149,7 +149,9 @@ async def test_configure_dehumidifier_aborts_when_growspace_not_found() -> None:
 
 
 @pytest.mark.asyncio
-async def test_configure_dehumidifier_routes_to_advanced_bayesian_when_flag_set() -> None:
+async def test_configure_dehumidifier_routes_to_advanced_bayesian_when_flag_set() -> (
+    None
+):
     """When configure_advanced is truthy the flow continues to advanced Bayesian step."""
     flow = _make_flow()
     flow.env_config_step1 = {"configure_advanced": True}
@@ -257,7 +259,9 @@ def test_add_dehumidifier_control_toggles_defaults_all_false_when_empty() -> Non
     assert defaults[CONF_CONFIGURE_FAN_CONTROLLER] is False
 
 
-def test_add_dehumidifier_control_toggles_configure_dehumidifier_true_when_thresholds_present() -> None:
+def test_add_dehumidifier_control_toggles_configure_dehumidifier_true_when_thresholds_present() -> (
+    None
+):
     """CONF_CONFIGURE_DEHUMIDIFIER defaults to True when CONF_DEHUMIDIFIER_THRESHOLDS is set."""
     flow = _make_flow()
     handler = DehumidifierHandler(flow)
@@ -271,7 +275,9 @@ def test_add_dehumidifier_control_toggles_configure_dehumidifier_true_when_thres
     assert defaults[CONF_CONFIGURE_DEHUMIDIFIER] is True
 
 
-def test_add_dehumidifier_control_toggles_fan_controller_uses_circulation_fan_config() -> None:
+def test_add_dehumidifier_control_toggles_fan_controller_uses_circulation_fan_config() -> (
+    None
+):
     """CONF_CONFIGURE_FAN_CONTROLLER mirrors circulation_fan_config enabled flag."""
     flow = _make_flow()
     handler = DehumidifierHandler(flow)
@@ -285,7 +291,9 @@ def test_add_dehumidifier_control_toggles_fan_controller_uses_circulation_fan_co
     assert defaults[CONF_CONFIGURE_FAN_CONTROLLER] is True
 
 
-def test_add_dehumidifier_control_toggles_fan_controller_false_for_non_dict_fan_config() -> None:
+def test_add_dehumidifier_control_toggles_fan_controller_false_for_non_dict_fan_config() -> (
+    None
+):
     """A non-dict circulation_fan_config treats fan as not configured."""
     flow = _make_flow()
     handler = DehumidifierHandler(flow)

--- a/tests/config_handlers/test_fan_controller_handler.py
+++ b/tests/config_handlers/test_fan_controller_handler.py
@@ -240,7 +240,11 @@ async def test_base_step_routes_based_on_regulation_mode(
     """Base step routes to correct sub-step based on selected regulation mode."""
     flow = _make_flow()
 
-    setattr(flow, expected_step_call, AsyncMock(return_value={"type": "form", "step_id": expected_step_call}))
+    setattr(
+        flow,
+        expected_step_call,
+        AsyncMock(return_value={"type": "form", "step_id": expected_step_call}),
+    )
 
     handler = FanControllerHandler(flow)
     result = await handler.async_step_configure_fan_controller(
@@ -260,8 +264,14 @@ async def test_base_step_routes_based_on_regulation_mode(
     ("step_method_name", "step_user_input"),
     [
         ("async_step_configure_fan_vpd", {"vpd_target": 1.1, "vpd_tolerance": 0.1}),
-        ("async_step_configure_fan_humidity", {"humidity_target": 55.0, "humidity_tolerance": 4.0}),
-        ("async_step_configure_fan_temperature", {"temperature_target": 24.0, "temperature_tolerance": 1.5}),
+        (
+            "async_step_configure_fan_humidity",
+            {"humidity_target": 55.0, "humidity_tolerance": 4.0},
+        ),
+        (
+            "async_step_configure_fan_temperature",
+            {"temperature_target": 24.0, "temperature_tolerance": 1.5},
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -282,8 +292,12 @@ async def test_sub_steps_route_based_on_wind(
     flow = _make_flow()
     flow.fan_config_step1 = {"wind_enabled": wind_enabled}
 
-    flow.async_step_configure_fan_wind = AsyncMock(return_value={"type": "form", "step_id": "configure_fan_wind"})
-    flow.async_step_configure_sensor_placement = AsyncMock(return_value={"type": "form", "step_id": "configure_sensor_placement"})
+    flow.async_step_configure_fan_wind = AsyncMock(
+        return_value={"type": "form", "step_id": "configure_fan_wind"}
+    )
+    flow.async_step_configure_sensor_placement = AsyncMock(
+        return_value={"type": "form", "step_id": "configure_sensor_placement"}
+    )
 
     handler = FanControllerHandler(flow)
     method = getattr(handler, step_method_name)
@@ -353,7 +367,9 @@ async def test_save_fan_config_uses_defaults() -> None:
 async def test_fan_step_handles_missing_environment_config() -> None:
     """Step methods handle growspace environment_config being None."""
     flow = _make_flow()
-    growspace = flow.config_entry.runtime_data.services.growspaces.get_growspace.return_value
+    growspace = (
+        flow.config_entry.runtime_data.services.growspaces.get_growspace.return_value
+    )
     growspace.environment_config = None
 
     handler = FanControllerHandler(flow)
@@ -361,4 +377,3 @@ async def test_fan_step_handles_missing_environment_config() -> None:
 
     assert result["type"] == "form"
     assert result["step_id"] == "configure_fan_controller"
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,10 +9,13 @@ from unittest.mock import MagicMock
 
 try:
     from sqlalchemy.orm import Session
+
     builtins.Session = Session
 except ImportError:
+
     class DummySession:
         pass
+
     builtins.Session = DummySession
 
 # Must precede any imports that pull in these dependencies
@@ -204,6 +207,7 @@ def _stop_scheduler(obj: Any, attr: str) -> None:
     """Helper to safely call async_stop on an attribute."""
     import contextlib
     from unittest.mock import Mock
+
     if hasattr(obj, attr) and (scheduler := getattr(obj, attr)):
         if isinstance(scheduler, Mock):
             return
@@ -217,6 +221,7 @@ def _cancel_debouncer(obj: Any) -> None:
     """Helper to safely cancel a debouncer."""
     import contextlib
     from unittest.mock import Mock
+
     if hasattr(obj, "_debounced_refresh") and (debouncer := obj._debounced_refresh):
         if isinstance(debouncer, Mock):
             return
@@ -230,6 +235,7 @@ def _close_unawaited_coro(mock_func: Any) -> None:
     """Helper to safely close unawaited mocked coroutines."""
     import contextlib
     from unittest.mock import Mock
+
     if isinstance(mock_func, Mock):
         for call in mock_func.call_args_list:
             for arg in call[0]:
@@ -267,14 +273,22 @@ def cleanup_coordinators(request):
     async def shutdown_all():
         for coord in coordinators:
             # 1. Stop all internal schedulers/monitors to release timers immediately
-            for attr in ("briefing_scheduler", "vision_scheduler", "photoperiod_checker", "alert_monitor"):
+            for attr in (
+                "briefing_scheduler",
+                "vision_scheduler",
+                "photoperiod_checker",
+                "alert_monitor",
+            ):
                 _stop_scheduler(coord, attr)
 
             # Cancel debouncer on the main coordinator
             _cancel_debouncer(coord)
 
             # Cancel debouncers and shut down irrigation coordinators
-            if hasattr(coord, "irrigation_coordinators") and coord.irrigation_coordinators:
+            if (
+                hasattr(coord, "irrigation_coordinators")
+                and coord.irrigation_coordinators
+            ):
                 for irr_coord in coord.irrigation_coordinators.values():
                     _cancel_debouncer(irr_coord)
                     with contextlib.suppress(Exception):
@@ -283,7 +297,10 @@ def cleanup_coordinators(request):
             # Cancel debouncers and shut down dehumidifier coordinators
             if hasattr(coord, "subsystem_manager") and coord._subsystem_manager:
                 sub_mgr = coord._subsystem_manager
-                if hasattr(sub_mgr, "dehumidifier_coordinators") and sub_mgr.dehumidifier_coordinators:
+                if (
+                    hasattr(sub_mgr, "dehumidifier_coordinators")
+                    and sub_mgr.dehumidifier_coordinators
+                ):
                     for deh_coord in sub_mgr.dehumidifier_coordinators.values():
                         _cancel_debouncer(deh_coord)
                         with contextlib.suppress(Exception):
@@ -292,7 +309,9 @@ def cleanup_coordinators(request):
             # 2. Close any unawaited coroutines passed to mocked async_create_background_task on the coordinator's entry
             if hasattr(coord, "config_entry") and coord.config_entry:
                 if hasattr(coord.config_entry, "async_create_background_task"):
-                    _close_unawaited_coro(coord.config_entry.async_create_background_task)
+                    _close_unawaited_coro(
+                        coord.config_entry.async_create_background_task
+                    )
 
             # 3. Call full async_shutdown
             with contextlib.suppress(Exception):
@@ -302,15 +321,24 @@ def cleanup_coordinators(request):
         if "hass" in request.fixturenames:
             with contextlib.suppress(Exception):
                 hass_obj = request.getfixturevalue("hass")
-                for attr_name in ("async_create_background_task", "async_create_task", "async_add_job", "async_add_executor_job"):
+                for attr_name in (
+                    "async_create_background_task",
+                    "async_create_task",
+                    "async_add_job",
+                    "async_add_executor_job",
+                ):
                     if hasattr(hass_obj, attr_name):
                         _close_unawaited_coro(getattr(hass_obj, attr_name))
 
         # 5. Clean up any unawaited coroutines created by AsyncMock or any other Mock in gc
         import gc
+
         for obj in list(gc.get_objects()):
             if type(obj).__name__ == "coroutine":
-                if "AsyncMockMixin._execute_mock_call" in str(obj) or "mock" in str(obj).lower():
+                if (
+                    "AsyncMockMixin._execute_mock_call" in str(obj)
+                    or "mock" in str(obj).lower()
+                ):
                     with contextlib.suppress(Exception):
                         obj.close()
 

--- a/tests/core/test_batch_actions.py
+++ b/tests/core/test_batch_actions.py
@@ -43,9 +43,7 @@ async def test_batch_transition(
 
     await handle_batch_action(mock_hass, mock_coordinator, call)
 
-    assert (
-        mock_coordinator.services.plants.transition_plant_stage.call_count == 2
-    )
+    assert mock_coordinator.services.plants.transition_plant_stage.call_count == 2
     mock_coordinator.services.plants.transition_plant_stage.assert_any_call(
         plant_id="plant1", new_stage="flower", transition_date="2023-01-01"
     )

--- a/tests/core/test_batch_add_plants.py
+++ b/tests/core/test_batch_add_plants.py
@@ -51,7 +51,10 @@ def plant_facade(mock_coordinator: Mock) -> PlantFacade:
 
 @pytest.mark.asyncio
 async def test_batch_add_plants_success(
-    hass: HomeAssistant, mock_coordinator: Mock, mock_strain_library: Mock, plant_facade: PlantFacade
+    hass: HomeAssistant,
+    mock_coordinator: Mock,
+    mock_strain_library: Mock,
+    plant_facade: PlantFacade,
 ) -> None:
     """Test successful batch add of plants."""
     call = ServiceCall(
@@ -106,7 +109,10 @@ async def test_batch_add_plants_success(
 
 @pytest.mark.asyncio
 async def test_batch_add_plants_growspace_full(
-    hass: HomeAssistant, mock_coordinator: Mock, mock_strain_library: Mock, plant_facade: PlantFacade
+    hass: HomeAssistant,
+    mock_coordinator: Mock,
+    mock_strain_library: Mock,
+    plant_facade: PlantFacade,
 ) -> None:
     """Test handling when growspace becomes full mid-batch."""
     call = ServiceCall(
@@ -140,7 +146,10 @@ async def test_batch_add_plants_growspace_full(
 
 @pytest.mark.asyncio
 async def test_batch_add_plants_initially_full(
-    hass: HomeAssistant, mock_coordinator: Mock, mock_strain_library: Mock, plant_facade: PlantFacade
+    hass: HomeAssistant,
+    mock_coordinator: Mock,
+    mock_strain_library: Mock,
+    plant_facade: PlantFacade,
 ) -> None:
     """Test error when growspace is full from the start."""
     call = ServiceCall(
@@ -164,7 +173,10 @@ async def test_batch_add_plants_initially_full(
 
 @pytest.mark.asyncio
 async def test_batch_add_plants_growspace_not_found(
-    hass: HomeAssistant, mock_coordinator: Mock, mock_strain_library: Mock, plant_facade: PlantFacade
+    hass: HomeAssistant,
+    mock_coordinator: Mock,
+    mock_strain_library: Mock,
+    plant_facade: PlantFacade,
 ) -> None:
     """Test error when growspace ID is invalid."""
     mock_coordinator.growspaces = {}  # Empty
@@ -186,7 +198,10 @@ async def test_batch_add_plants_growspace_not_found(
 
 @pytest.mark.asyncio
 async def test_batch_add_plants_individual_error(
-    hass: HomeAssistant, mock_coordinator: Mock, mock_strain_library: Mock, plant_facade: PlantFacade
+    hass: HomeAssistant,
+    mock_coordinator: Mock,
+    mock_strain_library: Mock,
+    plant_facade: PlantFacade,
 ) -> None:
     """Test aborting when an individual plant addition fails."""
     call = ServiceCall(
@@ -209,7 +224,9 @@ async def test_batch_add_plants_individual_error(
     ]
 
     # 1st add raises error
-    mock_coordinator.services.plants.add_plant.side_effect = GrowspaceError("Test Error")
+    mock_coordinator.services.plants.add_plant.side_effect = GrowspaceError(
+        "Test Error"
+    )
 
     await plant_facade.add_plants_from_call(hass, mock_strain_library, call)
 

--- a/tests/core/test_circulation_fan_speed.py
+++ b/tests/core/test_circulation_fan_speed.py
@@ -1,6 +1,5 @@
 """Unit tests for the compute_fan_speed and compute_wind_offset pure functions."""
 
-
 import pytest
 
 from custom_components.growspace_manager.circulation_fan_coordinator import (

--- a/tests/core/test_coordinator_coverage2.py
+++ b/tests/core/test_coordinator_coverage2.py
@@ -83,7 +83,6 @@ async def test_plants_property(hass: HomeAssistant) -> None:
 # =============================================================================
 
 
-
 @pytest.mark.asyncio
 async def test_get_for_service_call(hass: HomeAssistant) -> None:
     """Test the get_for_service_call static method (line 132)."""
@@ -441,9 +440,7 @@ async def test_async_water_plant(hass: HomeAssistant) -> None:
     """Test async_water_plant delegates to WateringService (line 1102)."""
     coordinator = create_test_coordinator(hass)
     mock_result = MagicMock()
-    coordinator.watering_service.async_water_plant = AsyncMock(
-        return_value=mock_result
-    )
+    coordinator.watering_service.async_water_plant = AsyncMock(return_value=mock_result)
 
     result = await coordinator.services.plants.water_plant("plant_1", 500.0)
 

--- a/tests/core/test_coordinator_tank_water.py
+++ b/tests/core/test_coordinator_tank_water.py
@@ -65,7 +65,9 @@ async def test_async_configure_tank_updates_volume(hass: HomeAssistant) -> None:
     coordinator.services.growspaces.configure_tank = AsyncMock()
 
     # 2. Call the services facade method directly
-    await coordinator.services.growspaces.configure_tank("gs_1", "sensor.tank_1", volume_liters=100.0)
+    await coordinator.services.growspaces.configure_tank(
+        "gs_1", "sensor.tank_1", volume_liters=100.0
+    )
 
     # 3. Verify the call was made
     coordinator.services.growspaces.configure_tank.assert_called_once_with(
@@ -116,7 +118,9 @@ async def test_async_configure_tank_volume_none_does_not_overwrite(
 
     coordinator.storage_manager.async_save = AsyncMock()
 
-    await coordinator.services.growspaces.configure_tank("gs_1", "sensor.tank_1", volume_liters=None)
+    await coordinator.services.growspaces.configure_tank(
+        "gs_1", "sensor.tank_1", volume_liters=None
+    )
 
     tank = growspace.environment_config.irrigation_tanks[0]
     assert tank.volume_liters == 60.0
@@ -162,7 +166,9 @@ def test_get_tank_tracker_returns_none_for_unknown_entity(hass: HomeAssistant) -
     coordinator = _make_coordinator(hass)
     _add_growspace_with_tank(coordinator, volume_liters=200.0)
 
-    tracker = coordinator.services.growspaces.get_tank_tracker("gs_1", "sensor.does_not_exist")
+    tracker = coordinator.services.growspaces.get_tank_tracker(
+        "gs_1", "sensor.does_not_exist"
+    )
 
     assert tracker is None
 
@@ -173,7 +179,9 @@ def test_get_tank_tracker_returns_none_for_unknown_growspace(
     """Test get_tank_tracker returns None when growspace_id is not found."""
     coordinator = _make_coordinator(hass)
 
-    tracker = coordinator.services.growspaces.get_tank_tracker("nonexistent_gs", "sensor.tank_1")
+    tracker = coordinator.services.growspaces.get_tank_tracker(
+        "nonexistent_gs", "sensor.tank_1"
+    )
 
     assert tracker is None
 
@@ -185,13 +193,19 @@ def test_get_tank_tracker_returns_same_instance_on_repeated_calls(
     coordinator = _make_coordinator(hass)
     _add_growspace_with_tank(coordinator, volume_liters=150.0)
 
-    tracker_first = coordinator.services.growspaces.get_tank_tracker("gs_1", "sensor.tank_1")
-    tracker_second = coordinator.services.growspaces.get_tank_tracker("gs_1", "sensor.tank_1")
+    tracker_first = coordinator.services.growspaces.get_tank_tracker(
+        "gs_1", "sensor.tank_1"
+    )
+    tracker_second = coordinator.services.growspaces.get_tank_tracker(
+        "gs_1", "sensor.tank_1"
+    )
 
     assert tracker_first is tracker_second
 
 
-def test_get_tank_tracker_stage_resolver_reflects_plant_stage(hass: HomeAssistant) -> None:
+def test_get_tank_tracker_stage_resolver_reflects_plant_stage(
+    hass: HomeAssistant,
+) -> None:
     """Tracker stage_resolver resolves dominant plant stage from growspace plants."""
     from custom_components.growspace_manager.models import Plant
 
@@ -209,7 +223,9 @@ def test_get_tank_tracker_stage_resolver_reflects_plant_stage(hass: HomeAssistan
     assert stage == "veg"
 
 
-def test_get_tank_tracker_stage_resolver_reflects_cure_stage(hass: HomeAssistant) -> None:
+def test_get_tank_tracker_stage_resolver_reflects_cure_stage(
+    hass: HomeAssistant,
+) -> None:
     """Stage resolver correctly identifies cure stage when a plant is in cure."""
     from freezegun import freeze_time
 
@@ -237,7 +253,9 @@ def test_get_tank_tracker_stage_resolver_reflects_cure_stage(hass: HomeAssistant
     assert stage == "cure"
 
 
-def test_get_tank_tracker_stage_resolver_no_plants_returns_veg(hass: HomeAssistant) -> None:
+def test_get_tank_tracker_stage_resolver_no_plants_returns_veg(
+    hass: HomeAssistant,
+) -> None:
     """Stage resolver with no plants defaults to 'veg'."""
     coordinator = _make_coordinator(hass)
     _add_growspace_with_tank(coordinator, volume_liters=200.0)

--- a/tests/core/test_environment_config_migration.py
+++ b/tests/core/test_environment_config_migration.py
@@ -1,6 +1,5 @@
 """Tests for EnvironmentConfig field rename: substrate_ec_sensors → bulk_ec_sensors."""
 
-
 from custom_components.growspace_manager.models import EnvironmentConfig
 
 

--- a/tests/core/test_facade_seam.py
+++ b/tests/core/test_facade_seam.py
@@ -56,6 +56,5 @@ def test_no_external_access_to_coordinator_internals() -> None:
 
     assert not offenders, (
         "Coordinator internals must be reached through coordinator.services.* "
-        "(see CONTEXT.md 'Seam Enforcement'). Offending lines:\n"
-        + "\n".join(offenders)
+        "(see CONTEXT.md 'Seam Enforcement'). Offending lines:\n" + "\n".join(offenders)
     )

--- a/tests/core/test_growspace_manager_drain_water.py
+++ b/tests/core/test_growspace_manager_drain_water.py
@@ -1,4 +1,5 @@
 """Tests for GrowspaceManager drain/water/tank methods."""
+
 from __future__ import annotations
 
 import asyncio
@@ -91,7 +92,9 @@ async def test_async_log_drain_reading_enforces_rolling_window(
     gs.drain_config.max_readings = 3
 
     for i in range(5):
-        await manager.async_log_drain_reading("gs1", feed_ec=float(i), drain_ec=float(i) + 0.3)
+        await manager.async_log_drain_reading(
+            "gs1", feed_ec=float(i), drain_ec=float(i) + 0.3
+        )
 
     assert len(gs.drain_config.readings) == 3
     assert gs.drain_config.readings[0].feed_ec == 2.0
@@ -235,9 +238,13 @@ def manager_with_tank() -> GrowspaceManager:
 async def test_async_configure_tank_updates_volume(
     manager_with_tank: GrowspaceManager,
 ) -> None:
-    await manager_with_tank.async_configure_tank("gs1", "sensor.tank1", volume_liters=80.0)
+    await manager_with_tank.async_configure_tank(
+        "gs1", "sensor.tank1", volume_liters=80.0
+    )
 
-    tank = manager_with_tank.repository.require_growspace("gs1").environment_config.irrigation_tanks[0]
+    tank = manager_with_tank.repository.require_growspace(
+        "gs1"
+    ).environment_config.irrigation_tanks[0]
     assert tank.volume_liters == pytest.approx(80.0)
     manager_with_tank._ctx.save_callback.assert_awaited_once()
 
@@ -246,11 +253,17 @@ async def test_async_configure_tank_updates_volume(
 async def test_async_configure_tank_volume_none_is_noop(
     manager_with_tank: GrowspaceManager,
 ) -> None:
-    manager_with_tank.repository.require_growspace("gs1").environment_config.irrigation_tanks[0].volume_liters = 50.0
+    manager_with_tank.repository.require_growspace(
+        "gs1"
+    ).environment_config.irrigation_tanks[0].volume_liters = 50.0
 
-    await manager_with_tank.async_configure_tank("gs1", "sensor.tank1", volume_liters=None)
+    await manager_with_tank.async_configure_tank(
+        "gs1", "sensor.tank1", volume_liters=None
+    )
 
-    tank = manager_with_tank.repository.require_growspace("gs1").environment_config.irrigation_tanks[0]
+    tank = manager_with_tank.repository.require_growspace(
+        "gs1"
+    ).environment_config.irrigation_tanks[0]
     assert tank.volume_liters == pytest.approx(50.0)
     manager_with_tank._ctx.save_callback.assert_not_awaited()
 
@@ -259,7 +272,9 @@ async def test_async_configure_tank_volume_none_is_noop(
 async def test_async_configure_tank_unknown_entity_is_noop(
     manager_with_tank: GrowspaceManager,
 ) -> None:
-    await manager_with_tank.async_configure_tank("gs1", "sensor.missing", volume_liters=100.0)
+    await manager_with_tank.async_configure_tank(
+        "gs1", "sensor.missing", volume_liters=100.0
+    )
 
     manager_with_tank._ctx.save_callback.assert_not_awaited()
 
@@ -269,4 +284,6 @@ async def test_async_configure_tank_unknown_growspace(
     manager_with_tank: GrowspaceManager,
 ) -> None:
     with pytest.raises(GrowspaceNotFoundError):
-        await manager_with_tank.async_configure_tank("no_gs", "sensor.tank1", volume_liters=10.0)
+        await manager_with_tank.async_configure_tank(
+            "no_gs", "sensor.tank1", volume_liters=10.0
+        )

--- a/tests/core/test_models_coverage.py
+++ b/tests/core/test_models_coverage.py
@@ -99,7 +99,7 @@ def test_growspace_pre_deserialize_sanitization_failures():
         "name": "GS1",
         "irrigation_config": {
             "irrigation_times": [{"time": "08:00", "duration": "invalid"}]
-        }
+        },
     }
     sanitized = Growspace.__pre_deserialize__(data)
     assert sanitized["irrigation_config"]["irrigation_times"][0]["duration"] == 60
@@ -110,8 +110,8 @@ def test_growspace_pre_deserialize_sanitization_failures():
         "name": "GS1",
         "irrigation_strategy": {
             "p0_duration_minutes": "not_an_int",
-            "shot_duration_seconds": "invalid"  # Added another one for coverage
-        }
+            "shot_duration_seconds": "invalid",  # Added another one for coverage
+        },
     }
     sanitized = Growspace.__pre_deserialize__(data)
     # The invalid field should be deleted from the dict
@@ -119,10 +119,6 @@ def test_growspace_pre_deserialize_sanitization_failures():
     assert "shot_duration_seconds" not in sanitized["irrigation_strategy"]
 
     # Test invalid rows/plants_per_row (Line 598)
-    data = {
-        "id": "gs1",
-        "name": "GS1",
-        "rows": "invalid"
-    }
+    data = {"id": "gs1", "name": "GS1", "rows": "invalid"}
     sanitized = Growspace.__pre_deserialize__(data)
     assert sanitized["rows"] == 3

--- a/tests/core/test_models_tank_water_history.py
+++ b/tests/core/test_models_tank_water_history.py
@@ -1,4 +1,5 @@
 """Tests for TankWaterHistory and TankWaterEvent models."""
+
 from custom_components.growspace_manager.models import (
     IrrigationTank,
     TankWaterEvent,

--- a/tests/core/test_notification_settings_payload.py
+++ b/tests/core/test_notification_settings_payload.py
@@ -13,7 +13,9 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 
-def create_coordinator(hass: HomeAssistant, options: dict[str, Any]) -> GrowspaceCoordinator:
+def create_coordinator(
+    hass: HomeAssistant, options: dict[str, Any]
+) -> GrowspaceCoordinator:
     """Build a real coordinator with the given config-entry options."""
     entry = MockConfigEntry(domain=DOMAIN, data={}, options=options)
     entry.add_to_hass(hass)

--- a/tests/core/test_nutrient_preset_migration.py
+++ b/tests/core/test_nutrient_preset_migration.py
@@ -45,10 +45,12 @@ def test_migration_full_match_resolves_all_items(
     inventory_with_two_stocks: NutrientInventory,
 ) -> None:
     """All name-based items are resolved to nutrient_id when names match inventory."""
-    preset = _make_preset([
-        {"name": "Grow A", "dose_ml_l": 2.0},
-        {"name": "Bloom B", "dose_ml_l": 1.5},
-    ])
+    preset = _make_preset(
+        [
+            {"name": "Grow A", "dose_ml_l": 2.0},
+            {"name": "Bloom B", "dose_ml_l": 1.5},
+        ]
+    )
     presets = {"preset-1": preset}
 
     result = _migrate_preset_items(presets, inventory_with_two_stocks)
@@ -62,10 +64,12 @@ def test_migration_partial_match_preserves_orphan_name(
     inventory_with_two_stocks: NutrientInventory,
 ) -> None:
     """Matched items get nutrient_id; unmatched items keep original name as nutrient_id."""
-    preset = _make_preset([
-        {"name": "Grow A", "dose_ml_l": 2.0},
-        {"name": "Unknown Cal Mag", "dose_ml_l": 0.5},
-    ])
+    preset = _make_preset(
+        [
+            {"name": "Grow A", "dose_ml_l": 2.0},
+            {"name": "Unknown Cal Mag", "dose_ml_l": 0.5},
+        ]
+    )
     presets = {"preset-1": preset}
 
     result = _migrate_preset_items(presets, inventory_with_two_stocks)
@@ -79,10 +83,12 @@ def test_migration_no_match_all_orphaned(
     inventory_with_two_stocks: NutrientInventory,
 ) -> None:
     """When no names match, all items are preserved with original name as nutrient_id."""
-    preset = _make_preset([
-        {"name": "Mystery A", "dose_ml_l": 1.0},
-        {"name": "Mystery B", "dose_ml_l": 2.0},
-    ])
+    preset = _make_preset(
+        [
+            {"name": "Mystery A", "dose_ml_l": 1.0},
+            {"name": "Mystery B", "dose_ml_l": 2.0},
+        ]
+    )
     presets = {"preset-1": preset}
 
     result = _migrate_preset_items(presets, inventory_with_two_stocks)
@@ -96,24 +102,31 @@ def test_migration_already_migrated_items_untouched(
     inventory_with_two_stocks: NutrientInventory,
 ) -> None:
     """Items that already have nutrient_id are not modified."""
-    preset = _make_preset([
-        {"nutrient_id": "uuid-grow-a", "dose_ml_l": 2.0},
-    ])
+    preset = _make_preset(
+        [
+            {"nutrient_id": "uuid-grow-a", "dose_ml_l": 2.0},
+        ]
+    )
     presets = {"preset-1": preset}
 
     result = _migrate_preset_items(presets, inventory_with_two_stocks)
 
-    assert result["preset-1"].items[0] == {"nutrient_id": "uuid-grow-a", "dose_ml_l": 2.0}
+    assert result["preset-1"].items[0] == {
+        "nutrient_id": "uuid-grow-a",
+        "dose_ml_l": 2.0,
+    }
 
 
 def test_migration_case_insensitive_name_match(
     inventory_with_two_stocks: NutrientInventory,
 ) -> None:
     """Name matching is case-insensitive."""
-    preset = _make_preset([
-        {"name": "grow a", "dose_ml_l": 2.0},
-        {"name": "BLOOM B", "dose_ml_l": 1.5},
-    ])
+    preset = _make_preset(
+        [
+            {"name": "grow a", "dose_ml_l": 2.0},
+            {"name": "BLOOM B", "dose_ml_l": 1.5},
+        ]
+    )
     presets = {"preset-1": preset}
 
     result = _migrate_preset_items(presets, inventory_with_two_stocks)

--- a/tests/core/test_service_error_handling.py
+++ b/tests/core/test_service_error_handling.py
@@ -42,7 +42,9 @@ async def test_handle_add_plant_wraps_error(
 ) -> None:
     """Test handle_add_plant wraps generic exceptions."""
     # Setup - simulate generic exception
-    mock_coordinator.services.plants.add_plant = AsyncMock(side_effect=Exception("Boom"))
+    mock_coordinator.services.plants.add_plant = AsyncMock(
+        side_effect=Exception("Boom")
+    )
 
     call = MagicMock()
     call.data = {
@@ -64,7 +66,9 @@ async def test_handle_add_plants_wraps_error(
 ) -> None:
     """Test handle_add_plants wraps generic exceptions."""
     # Setup - simulate exception in the loop (add_plant is called by add_plants)
-    mock_coordinator.services.plants.add_plant = AsyncMock(side_effect=Exception("Boom Batch"))
+    mock_coordinator.services.plants.add_plant = AsyncMock(
+        side_effect=Exception("Boom Batch")
+    )
     # Need to mock find_first_available_position to prevent early exit
     mock_coordinator.validator.find_first_available_position.return_value = (1, 1)
 
@@ -89,7 +93,9 @@ async def test_handle_water_plant_wraps_growspace_error(
 ) -> None:
     """Test handle_water_plant wraps GrowspaceError."""
     # Setup
-    mock_coordinator.services.plants.water_plant = AsyncMock(side_effect=GrowspaceError("Not Found"))
+    mock_coordinator.services.plants.water_plant = AsyncMock(
+        side_effect=GrowspaceError("Not Found")
+    )
 
     call = MagicMock()
     call.data = {"plant_id": "p1", "amount": 1.0}
@@ -103,7 +109,9 @@ async def test_handle_water_plant_wraps_generic_error(
 ) -> None:
     """Test handle_water_plant wraps generic exceptions."""
     # Setup
-    mock_coordinator.services.plants.water_plant = AsyncMock(side_effect=Exception("Pump Failure"))
+    mock_coordinator.services.plants.water_plant = AsyncMock(
+        side_effect=Exception("Pump Failure")
+    )
 
     call = MagicMock()
     call.data = {"plant_id": "p1", "amount": 1.0}
@@ -117,7 +125,9 @@ async def test_handle_water_growspace_wraps_error(
 ) -> None:
     """Test handle_water_growspace wraps exceptions."""
     # Setup
-    mock_coordinator.services.growspaces.water_growspace = AsyncMock(side_effect=Exception("Valve Error"))
+    mock_coordinator.services.growspaces.water_growspace = AsyncMock(
+        side_effect=Exception("Valve Error")
+    )
 
     call = MagicMock()
     call.data = {"growspace_id": "gs1", "amount_per_plant": 1.0}

--- a/tests/core/test_services_strain_library.py
+++ b/tests/core/test_services_strain_library.py
@@ -653,7 +653,9 @@ def test_downscale_logo_if_needed_large_rgba_to_monochrome() -> None:
     img = Image.frombytes("RGBA", (100, 100), os.urandom(100 * 100 * 4))
     buff = BytesIO()
     img.save(buff, format="PNG")
-    large_rgba_base64 = f"data:image/png;base64,{base64.b64encode(buff.getvalue()).decode()}"
+    large_rgba_base64 = (
+        f"data:image/png;base64,{base64.b64encode(buff.getvalue()).decode()}"
+    )
 
     # Ensure our constructed image is indeed large enough (> 25000 chars)
     assert len(large_rgba_base64) >= 25000

--- a/tests/core/test_storage_manager.py
+++ b/tests/core/test_storage_manager.py
@@ -45,7 +45,9 @@ def genetics_manager_mock():
 @pytest.fixture
 def storage(hass, repository_mock, nutrient_manager_mock, genetics_manager_mock):
     """Provide a StorageManager instance."""
-    return StorageManager(hass, repository_mock, nutrient_manager_mock, genetics_manager_mock)
+    return StorageManager(
+        hass, repository_mock, nutrient_manager_mock, genetics_manager_mock
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_subarea_manager.py
+++ b/tests/core/test_subarea_manager.py
@@ -1,4 +1,5 @@
 """Tests for subarea CRUD in GrowspaceManager."""
+
 from __future__ import annotations
 
 import asyncio

--- a/tests/core/test_tank_water_tracker.py
+++ b/tests/core/test_tank_water_tracker.py
@@ -1,4 +1,5 @@
 """Tests for TankWaterTracker."""
+
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
@@ -30,6 +31,7 @@ def _tracker(tank: IrrigationTank | None = None) -> TankWaterTracker:
 
 # ── snapshot recording ────────────────────────────────────────────────────────
 
+
 def test_record_first_snapshot_no_event():
     """First reading produces a snapshot but no event (no previous level)."""
     t = _tracker()
@@ -46,7 +48,7 @@ def test_consumption_event_recorded():
     assert len(events) == 1
     ev = events[0]
     assert ev["event_type"] == "consumption"
-    assert abs(ev["liters"] - 200.0 * 2.0 / 100.0) < 0.01   # 4 L
+    assert abs(ev["liters"] - 200.0 * 2.0 / 100.0) < 0.01  # 4 L
     assert ev["pct_delta"] == pytest.approx(-2.0)
 
 
@@ -57,7 +59,7 @@ def test_refill_event_recorded():
     events = t.tank.water_history.events
     assert len(events) == 1
     assert events[0]["event_type"] == "refill"
-    assert abs(events[0]["liters"] - 200.0 * 40.0 / 100.0) < 0.01   # 80 L
+    assert abs(events[0]["liters"] - 200.0 * 40.0 / 100.0) < 0.01  # 80 L
 
 
 def test_noise_below_floor_ignored():
@@ -87,6 +89,7 @@ def test_rolling_event_window_enforced():
 
 
 # ── aggregation helpers ───────────────────────────────────────────────────────
+
 
 def test_get_history_24h_returns_96_buckets():
     """Returns 96 15-minute buckets for the last 24 hours."""
@@ -141,6 +144,7 @@ def test_consumption_placed_in_correct_bucket():
 
 # ── _parse_ts: naive datetime gets UTC tzinfo ────────────────────────────────
 
+
 def test_parse_ts_naive_datetime_gets_utc():
     """_parse_ts must attach UTC tzinfo to naive ISO-8601 strings."""
     dt = _parse_ts("2026-03-22T10:00:00")  # no tzinfo
@@ -149,6 +153,7 @@ def test_parse_ts_naive_datetime_gets_utc():
 
 
 # ── edge cases: no reference_ts (uses datetime.now) ──────────────────────────
+
 
 def test_get_history_24h_no_reference_ts_uses_now():
     """get_history_24h without reference_ts falls back to datetime.now."""
@@ -243,6 +248,7 @@ def test_get_total_liters_7d_no_reference_ts():
 
 # ── small positive change below refill threshold is ignored ──────────────────
 
+
 def test_small_positive_change_below_refill_threshold_ignored():
     """A rise smaller than TANK_REFILL_THRESHOLD_PCT must not emit a refill event."""
     t = _tracker()
@@ -266,11 +272,17 @@ def test_partial_refill_updates_baseline_so_consumption_is_accurate():
     # Partial top-up: +2% — queues a pending peak, no event
     t.record_level(52.0, "2026-03-22T11:00:00+00:00")
     assert t.tank.water_history.events == [], "partial refill must not emit an event"
-    assert t.tank.last_recorded_level == pytest.approx(50.0), "trough must not advance on a minor rise"
+    assert t.tank.last_recorded_level == pytest.approx(50.0), (
+        "trough must not advance on a minor rise"
+    )
     # Second reading at the same level confirms the peak
     t.record_level(52.0, "2026-03-22T11:05:00+00:00")
-    assert t.tank.water_history.events == [], "confirmation reading must not emit an event"
-    assert t.tank.peak_level == pytest.approx(52.0), "peak_level must be confirmed after two readings"
+    assert t.tank.water_history.events == [], (
+        "confirmation reading must not emit an event"
+    )
+    assert t.tank.peak_level == pytest.approx(52.0), (
+        "peak_level must be confirmed after two readings"
+    )
     # Now a drop of 4% from 52% → 48% should record 4% * 200 L = 8 L, not 4 L
     t.record_level(48.0, "2026-03-22T12:00:00+00:00")
     assert len(t.tank.water_history.events) == 1
@@ -280,6 +292,7 @@ def test_partial_refill_updates_baseline_so_consumption_is_accurate():
 
 
 # ── consumption event without volume_liters falls back to pct_delta ──────────
+
 
 def test_consumption_without_volume_liters_uses_pct_delta():
     """When volume_liters is None the event liters field equals abs pct_delta."""
@@ -305,6 +318,7 @@ def test_refill_without_volume_liters_uses_pct_delta():
 
 # ── _fill_buckets edge cases ──────────────────────────────────────────────────
 
+
 def test_fill_buckets_ignores_events_outside_range():
     """Events outside the bucket window must not appear in any bucket."""
     t = _tracker()
@@ -328,10 +342,21 @@ def test_fill_buckets_refill_in_bucket():
 
 def test_fill_buckets_empty_buckets_list_is_safe():
     """_fill_buckets with an empty bucket list must not raise."""
-    _fill_buckets([], [{"timestamp": "2026-03-22T10:00:00+00:00", "event_type": "consumption", "liters": 5.0}], _BUCKET_15MIN)
+    _fill_buckets(
+        [],
+        [
+            {
+                "timestamp": "2026-03-22T10:00:00+00:00",
+                "event_type": "consumption",
+                "liters": 5.0,
+            }
+        ],
+        _BUCKET_15MIN,
+    )
 
 
 # ── HA subscription: async_setup / async_unsubscribe ─────────────────────────
+
 
 @pytest.mark.asyncio
 async def test_async_setup_subscribes_to_state_changes():
@@ -488,6 +513,7 @@ async def test_async_setup_on_change_not_called_when_none():
 
 # ── Timezone Tests ────────────────────────────────────────────────────────────
 
+
 def test_get_total_liters_today_timezone() -> None:
     """Test get_total_liters_today handles local timezone boundaries correctly.
 
@@ -549,13 +575,32 @@ def test_get_total_liters_7d_timezone() -> None:
 
 # ── stage aggregates ──────────────────────────────────────────────────────────
 
+
 def test_get_stage_aggregates_sums_consumption_by_stage():
     """Consumption events tagged with growth_stage are summed per stage."""
     t = _tracker()
     t.tank.water_history.events = [
-        {"timestamp": "2026-03-22T10:00:00+00:00", "event_type": "consumption", "pct_delta": -5.0, "liters": 10.0, "growth_stage": "veg"},
-        {"timestamp": "2026-03-22T11:00:00+00:00", "event_type": "consumption", "pct_delta": -3.0, "liters": 6.0, "growth_stage": "veg"},
-        {"timestamp": "2026-03-22T12:00:00+00:00", "event_type": "consumption", "pct_delta": -4.0, "liters": 8.0, "growth_stage": "flower_early"},
+        {
+            "timestamp": "2026-03-22T10:00:00+00:00",
+            "event_type": "consumption",
+            "pct_delta": -5.0,
+            "liters": 10.0,
+            "growth_stage": "veg",
+        },
+        {
+            "timestamp": "2026-03-22T11:00:00+00:00",
+            "event_type": "consumption",
+            "pct_delta": -3.0,
+            "liters": 6.0,
+            "growth_stage": "veg",
+        },
+        {
+            "timestamp": "2026-03-22T12:00:00+00:00",
+            "event_type": "consumption",
+            "pct_delta": -4.0,
+            "liters": 8.0,
+            "growth_stage": "flower_early",
+        },
     ]
     result = t.get_stage_aggregates()
     assert result == {"veg": pytest.approx(16.0), "flower_early": pytest.approx(8.0)}
@@ -565,8 +610,20 @@ def test_get_stage_aggregates_ignores_refill_events():
     """Refill events are excluded from stage aggregates."""
     t = _tracker()
     t.tank.water_history.events = [
-        {"timestamp": "2026-03-22T10:00:00+00:00", "event_type": "consumption", "pct_delta": -5.0, "liters": 10.0, "growth_stage": "veg"},
-        {"timestamp": "2026-03-22T11:00:00+00:00", "event_type": "refill", "pct_delta": 50.0, "liters": 100.0, "growth_stage": "veg"},
+        {
+            "timestamp": "2026-03-22T10:00:00+00:00",
+            "event_type": "consumption",
+            "pct_delta": -5.0,
+            "liters": 10.0,
+            "growth_stage": "veg",
+        },
+        {
+            "timestamp": "2026-03-22T11:00:00+00:00",
+            "event_type": "refill",
+            "pct_delta": 50.0,
+            "liters": 100.0,
+            "growth_stage": "veg",
+        },
     ]
     result = t.get_stage_aggregates()
     assert result == {"veg": pytest.approx(10.0)}
@@ -576,8 +633,19 @@ def test_get_stage_aggregates_ignores_events_without_stage():
     """Events without growth_stage are excluded from aggregates."""
     t = _tracker()
     t.tank.water_history.events = [
-        {"timestamp": "2026-03-22T10:00:00+00:00", "event_type": "consumption", "pct_delta": -5.0, "liters": 10.0, "growth_stage": "veg"},
-        {"timestamp": "2026-03-22T11:00:00+00:00", "event_type": "consumption", "pct_delta": -3.0, "liters": 6.0},
+        {
+            "timestamp": "2026-03-22T10:00:00+00:00",
+            "event_type": "consumption",
+            "pct_delta": -5.0,
+            "liters": 10.0,
+            "growth_stage": "veg",
+        },
+        {
+            "timestamp": "2026-03-22T11:00:00+00:00",
+            "event_type": "consumption",
+            "pct_delta": -3.0,
+            "liters": 6.0,
+        },
     ]
     result = t.get_stage_aggregates()
     assert result == {"veg": pytest.approx(10.0)}
@@ -590,6 +658,7 @@ def test_get_stage_aggregates_empty_events_returns_empty_dict():
 
 
 # ── stage_resolver tagging ────────────────────────────────────────────────────
+
 
 def test_consumption_event_tagged_with_stage_when_resolver_provided():
     """Consumption events get a growth_stage field when a stage_resolver is set."""

--- a/tests/core/test_temp_override.py
+++ b/tests/core/test_temp_override.py
@@ -8,9 +8,20 @@ from custom_components.growspace_manager.circulation_fan_coordinator import (
 
 
 @pytest.mark.parametrize(
-    ("current_temp", "low", "high", "hysteresis", "active", "direction",
-     "vpd_speed", "min_speed", "max_speed",
-     "expected_speed", "expected_active", "expected_direction"),
+    (
+        "current_temp",
+        "low",
+        "high",
+        "hysteresis",
+        "active",
+        "direction",
+        "vpd_speed",
+        "min_speed",
+        "max_speed",
+        "expected_speed",
+        "expected_active",
+        "expected_direction",
+    ),
     [
         # Both thresholds None → no override, VPD speed unchanged
         (25.0, None, None, 1.0, False, None, 50, 10, 90, 50, False, None),
@@ -64,8 +75,15 @@ def test_evaluate_temp_override(
 ) -> None:
     """Test evaluate_temp_override for all boundary and state transitions."""
     speed, new_active, new_direction = evaluate_temp_override(
-        current_temp, low, high, hysteresis, active, direction,
-        vpd_speed, min_speed, max_speed,
+        current_temp,
+        low,
+        high,
+        hysteresis,
+        active,
+        direction,
+        vpd_speed,
+        min_speed,
+        max_speed,
     )
     assert speed == expected_speed
     assert new_active == expected_active

--- a/tests/core/test_vpd_optimal_overrides_model.py
+++ b/tests/core/test_vpd_optimal_overrides_model.py
@@ -1,6 +1,5 @@
 """Tests for vpd_optimal_overrides field on EnvironmentConfig."""
 
-
 from custom_components.growspace_manager.models import EnvironmentConfig
 
 
@@ -29,7 +28,10 @@ def test_vpd_optimal_overrides_round_trip() -> None:
 def test_vpd_optimal_overrides_sparse_single_stage() -> None:
     """A single-stage override round-trips correctly."""
     overrides = {
-        "seedling": {"day": {"low": 0.3, "high": 0.7}, "night": {"low": 0.3, "high": 0.6}},
+        "seedling": {
+            "day": {"low": 0.3, "high": 0.7},
+            "night": {"low": 0.3, "high": 0.6},
+        },
     }
     config = EnvironmentConfig(vpd_optimal_overrides=overrides)
     restored = EnvironmentConfig.from_dict(config.to_dict())

--- a/tests/core/test_water_aggregation.py
+++ b/tests/core/test_water_aggregation.py
@@ -118,7 +118,10 @@ def test_tank_mode_adds_manual_on_top():
 
 def test_tank_mode_sums_across_multiple_trackers():
     gs = _growspace(tank_volume=200.0)
-    trackers = [_FakeTracker(today=2.0, since=10.0), _FakeTracker(today=3.0, since=15.0)]
+    trackers = [
+        _FakeTracker(today=2.0, since=10.0),
+        _FakeTracker(today=3.0, since=15.0),
+    ]
     figures = compute_growspace_water(gs, trackers, reference_date="2026-06-15")
     assert figures.today == 5.0
     assert figures.cycle == 25.0
@@ -168,6 +171,8 @@ def test_record_daily_water_keeps_sources_separate():
 def test_record_daily_water_ignores_nonpositive():
     gs = _growspace()
     record_daily_water(gs, 0.0, source=WATER_SOURCE_MANUAL, reference_date="2026-06-15")
-    record_daily_water(gs, -2.0, source=WATER_SOURCE_MANUAL, reference_date="2026-06-15")
+    record_daily_water(
+        gs, -2.0, source=WATER_SOURCE_MANUAL, reference_date="2026-06-15"
+    )
     assert gs.water_usage.total_liters == 0.0
     assert gs.water_usage.daily_readings == []

--- a/tests/domain/test_day_night.py
+++ b/tests/domain/test_day_night.py
@@ -27,8 +27,8 @@ def tracker() -> DayNightTracker:
         ("1.0", True),
         ("0.0", False),
         (STATE_ON, True),
-        (STATE_UNAVAILABLE, True),   # no valid sensors → default True
-        (STATE_UNKNOWN, True),       # no valid sensors → default True
+        (STATE_UNAVAILABLE, True),  # no valid sensors → default True
+        (STATE_UNKNOWN, True),  # no valid sensors → default True
     ],
 )
 def test_determine_reads_light_sensor_state(

--- a/tests/domain/test_drying_calculator.py
+++ b/tests/domain/test_drying_calculator.py
@@ -21,7 +21,9 @@ def test_constants_match_spec() -> None:
 def test_weight_lost_pct_basic() -> None:
     """Weight lost is correct given initial wet weight and current weight."""
     # 150g current out of 200g wet → 25% lost
-    assert compute_weight_lost_pct(wet_weight=200.0, current_weight=150.0) == pytest.approx(25.0)
+    assert compute_weight_lost_pct(
+        wet_weight=200.0, current_weight=150.0
+    ) == pytest.approx(25.0)
 
 
 def test_weight_lost_pct_no_wet_weight() -> None:

--- a/tests/domain/test_drying_models.py
+++ b/tests/domain/test_drying_models.py
@@ -1,6 +1,5 @@
 """Tests for DryingData model defaults and serialization."""
 
-
 from custom_components.growspace_manager.models import (
     DryingData,
     MoistureEntry,

--- a/tests/domain/test_environment_patch.py
+++ b/tests/domain/test_environment_patch.py
@@ -538,7 +538,9 @@ def test_control_flag_flips_mark_the_matching_controller_for_restart(
     controller instance never notices the flag changed and keeps controlling
     (or not controlling) the device with whatever it read at HA startup.
     """
-    verdict = apply_environment_patch(_lived_in_config(), EnvironmentPatch(values=values))
+    verdict = apply_environment_patch(
+        _lived_in_config(), EnvironmentPatch(values=values)
+    )
     assert verdict.controllers_to_restart == frozenset(expected_controllers)
 
 

--- a/tests/domain/test_light_schedule.py
+++ b/tests/domain/test_light_schedule.py
@@ -67,7 +67,9 @@ def test_photoperiod_hours_follow_entered_flower(
         ("06:30:00", 11.5, "18:00:00"),  # fractional hours
     ],
 )
-def test_resolve_cycle_end_time(lights_on: str, hours: float, expected_end: str) -> None:
+def test_resolve_cycle_end_time(
+    lights_on: str, hours: float, expected_end: str
+) -> None:
     """Cycle end is lights-on plus the photoperiod, wrapping across midnight."""
     assert resolve_cycle_end_time(lights_on, hours) == expected_end
 
@@ -79,7 +81,12 @@ def test_resolve_cycle_end_time(lights_on: str, hours: float, expected_end: str)
         ("06:00:00", "18:00:00", datetime(2026, 7, 3, 20, 0), False),  # post-cutoff
         ("06:00:00", "18:00:00", datetime(2026, 7, 3, 3, 0), False),  # pre-dawn
         ("20:00:00", "14:00:00", datetime(2026, 7, 3, 22, 0), True),  # wrap, after on
-        ("20:00:00", "14:00:00", datetime(2026, 7, 4, 2, 0), True),  # wrap, after midnight
+        (
+            "20:00:00",
+            "14:00:00",
+            datetime(2026, 7, 4, 2, 0),
+            True,
+        ),  # wrap, after midnight
         ("20:00:00", "14:00:00", datetime(2026, 7, 3, 16, 0), False),  # wrap, in gap
     ],
 )

--- a/tests/domain/test_moisture_band.py
+++ b/tests/domain/test_moisture_band.py
@@ -90,9 +90,7 @@ def test_valid_pairs_span_the_whole_permitted_range(
         pytest.param(60.1, "too_wet", id="just-above-maximum"),
     ],
 )
-def test_classification_boundaries_are_inclusive(
-    reading: float, expected: str
-) -> None:
+def test_classification_boundaries_are_inclusive(reading: float, expected: str) -> None:
     """A reading exactly on either bound sits inside the band."""
     assert DEFAULT_MOISTURE_BAND.classify(reading) == expected
 

--- a/tests/integration/test_ai_assistant.py
+++ b/tests/integration/test_ai_assistant.py
@@ -119,9 +119,7 @@ async def test_get_grow_advice_success(
     assistant: GrowAssistant, mock_hass: MagicMock
 ) -> None:
     """Test getting grow advice successfully."""
-    with patch(
-        "homeassistant.components.conversation.async_converse"
-    ) as mock_converse:
+    with patch("homeassistant.components.conversation.async_converse") as mock_converse:
         mock_result = MagicMock()
         mock_result.response.speech = {"plain": {"speech": "AI Advice"}}
         mock_converse.return_value = mock_result
@@ -146,9 +144,7 @@ async def test_get_grow_advice_empty_response(
     assistant: GrowAssistant, mock_hass: MagicMock
 ) -> None:
     """Test getting empty response from AI."""
-    with patch(
-        "homeassistant.components.conversation.async_converse"
-    ) as mock_converse:
+    with patch("homeassistant.components.conversation.async_converse") as mock_converse:
         mock_result = MagicMock()
         mock_result.response.speech = {"plain": {"speech": ""}}  # Empty
         mock_converse.return_value = mock_result
@@ -190,9 +186,7 @@ async def test_handle_analyze_all_growspaces(
     """Test handle_analyze_all_growspaces service."""
     call = ServiceCall(mock_hass, "gsm", "analyze", {}, context=MagicMock())
 
-    with patch(
-        "homeassistant.components.conversation.async_converse"
-    ) as mock_converse:
+    with patch("homeassistant.components.conversation.async_converse") as mock_converse:
         mock_result = MagicMock()
         mock_result.response.speech = {"plain": {"speech": "Analysis Report"}}
         mock_converse.return_value = mock_result
@@ -461,14 +455,14 @@ async def test_execute_conversation_truncates_response(
 ) -> None:
     """Test _execute_conversation truncates response when it exceeds max_length."""
     long_text = "word " * 100  # 500 chars
-    with patch(
-        "homeassistant.components.conversation.async_converse"
-    ) as mock_converse:
+    with patch("homeassistant.components.conversation.async_converse") as mock_converse:
         mock_result = MagicMock()
         mock_result.response.speech = {"plain": {"speech": long_text}}
         mock_converse.return_value = mock_result
 
-        result = await assistant._execute_conversation("prompt", "agent", 50, GROWSPACE_ID)
+        result = await assistant._execute_conversation(
+            "prompt", "agent", 50, GROWSPACE_ID
+        )
 
     assert len(result) <= 53  # max_length + "..."
     assert result.endswith("...")
@@ -493,11 +487,11 @@ async def test_handle_analyze_all_growspaces_truncates_response(
 ) -> None:
     """Test handle_analyze_all_growspaces truncates long AI responses."""
     long_text = "word " * 200
-    call = ServiceCall(mock_hass, "gsm", "analyze", {"max_length": 50}, context=MagicMock())
+    call = ServiceCall(
+        mock_hass, "gsm", "analyze", {"max_length": 50}, context=MagicMock()
+    )
 
-    with patch(
-        "homeassistant.components.conversation.async_converse"
-    ) as mock_converse:
+    with patch("homeassistant.components.conversation.async_converse") as mock_converse:
         mock_result = MagicMock()
         mock_result.response.speech = {"plain": {"speech": long_text}}
         mock_converse.return_value = mock_result
@@ -516,9 +510,7 @@ async def test_handle_analyze_all_growspaces_empty_ai_response(
     """Test handle_analyze_all_growspaces returns summary on empty AI response."""
     call = ServiceCall(mock_hass, "gsm", "analyze", {}, context=MagicMock())
 
-    with patch(
-        "homeassistant.components.conversation.async_converse"
-    ) as mock_converse:
+    with patch("homeassistant.components.conversation.async_converse") as mock_converse:
         mock_result = MagicMock()
         mock_result.response.speech = {}  # No plain speech
         mock_converse.return_value = mock_result
@@ -552,12 +544,20 @@ def test_build_facility_summary_with_issues_and_statuses() -> None:
         {
             "growspace": {"name": "Tent A"},
             "plants": {"count": 4},
-            "analysis": {"optimal": {"active": True}, "stress": {"active": False}, "mold_risk": {"active": False}},
+            "analysis": {
+                "optimal": {"active": True},
+                "stress": {"active": False},
+                "mold_risk": {"active": False},
+            },
         },
         {
             "growspace": {"name": "Tent B"},
             "plants": {"count": 2},
-            "analysis": {"optimal": {"active": False}, "stress": {"active": True}, "mold_risk": {"active": False}},
+            "analysis": {
+                "optimal": {"active": False},
+                "stress": {"active": True},
+                "mold_risk": {"active": False},
+            },
         },
     ]
     issues = ["Tent B: Stress detected - High VPD"]
@@ -589,9 +589,7 @@ async def test_handle_strain_recommendation_success(
     """Test handle_strain_recommendation returns AI response on success."""
     call = ServiceCall(mock_hass, "gsm", "recommend", {}, context=MagicMock())
 
-    with patch(
-        "homeassistant.components.conversation.async_converse"
-    ) as mock_converse:
+    with patch("homeassistant.components.conversation.async_converse") as mock_converse:
         mock_result = MagicMock()
         mock_result.response.speech = {"plain": {"speech": "Recommend Kush"}}
         mock_converse.return_value = mock_result
@@ -610,9 +608,7 @@ async def test_handle_strain_recommendation_empty_ai_response(
     """Test handle_strain_recommendation fallback on empty AI response."""
     call = ServiceCall(mock_hass, "gsm", "recommend", {}, context=MagicMock())
 
-    with patch(
-        "homeassistant.components.conversation.async_converse"
-    ) as mock_converse:
+    with patch("homeassistant.components.conversation.async_converse") as mock_converse:
         mock_result = MagicMock()
         mock_result.response.speech = {}
         mock_converse.return_value = mock_result
@@ -637,9 +633,7 @@ async def test_handle_strain_recommendation_with_growspace_error(
     )
     mock_coordinator._data_repository.get_growspace.return_value = None
 
-    with patch(
-        "homeassistant.components.conversation.async_converse"
-    ) as mock_converse:
+    with patch("homeassistant.components.conversation.async_converse") as mock_converse:
         mock_result = MagicMock()
         mock_result.response.speech = {"plain": {"speech": "Advice without growspace"}}
         mock_converse.return_value = mock_result
@@ -656,11 +650,11 @@ async def test_handle_strain_recommendation_truncates_response(
 ) -> None:
     """Test handle_strain_recommendation truncates long AI responses."""
     long_text = "word " * 200
-    call = ServiceCall(mock_hass, "gsm", "recommend", {"max_length": 50}, context=MagicMock())
+    call = ServiceCall(
+        mock_hass, "gsm", "recommend", {"max_length": 50}, context=MagicMock()
+    )
 
-    with patch(
-        "homeassistant.components.conversation.async_converse"
-    ) as mock_converse:
+    with patch("homeassistant.components.conversation.async_converse") as mock_converse:
         mock_result = MagicMock()
         mock_result.response.speech = {"plain": {"speech": long_text}}
         mock_converse.return_value = mock_result
@@ -716,9 +710,7 @@ async def test_handle_strain_recommendation_successful_growspace_context(
         context=MagicMock(),
     )
 
-    with patch(
-        "homeassistant.components.conversation.async_converse"
-    ) as mock_converse:
+    with patch("homeassistant.components.conversation.async_converse") as mock_converse:
         mock_result = MagicMock()
         mock_result.response.speech = {"plain": {"speech": "Advice with context"}}
         mock_converse.return_value = mock_result

--- a/tests/integration/test_binary_sensor_coverage.py
+++ b/tests/integration/test_binary_sensor_coverage.py
@@ -57,7 +57,9 @@ def create_test_sensor(
         sensor.trend_analyzer = TrendAnalyzer(hass)
         sensor.strategy = strategy_class(
             env_config=sensor.env_config,
-            analyze_trend=lambda *args, **kwargs: sensor.async_analyze_sensor_trend(*args, **kwargs),
+            analyze_trend=lambda *args, **kwargs: sensor.async_analyze_sensor_trend(
+                *args, **kwargs
+            ),
             get_state=hass.states.get,
             get_growspace=lambda: coordinator.growspaces.get(growspace_id),
             get_notification_message=generate_notification_message,
@@ -345,7 +347,9 @@ async def test_optimal_sensor_event_category_rising_edge(
 
     # Mock strategy to return high probability on update forcing new_state=True
     with patch.object(
-        sensor.strategy, "async_evaluate", AsyncMock(return_value=([(0.9, 0.1)], [("reason", "high")]))
+        sensor.strategy,
+        "async_evaluate",
+        AsyncMock(return_value=([(0.9, 0.1)], [("reason", "high")])),
     ):
         sensor.prior = 0.9
         with patch.object(sensor, "async_write_ha_state"):
@@ -402,4 +406,3 @@ def test_light_verification_update_state_no_sensors(mock_coordinator) -> None:
 
 # NOTE: humidifier ON/OFF/None aggregation moved to the assembler suite
 # (tests/domain/test_environment_state_assembler.py).
-

--- a/tests/integration/test_binary_sensor_dry_cure.py
+++ b/tests/integration/test_binary_sensor_dry_cure.py
@@ -127,10 +127,7 @@ def test_get_growth_stage_info_dry_growspace(mock_coordinator) -> None:
     # This calls _get_growth_stage_info internally relies on coordinator.get_growspace_plants
     # We expect it to currently return the actual days (50), effectively failing the desired behavior
     # After the fix, it should return 0.
-    info = sensor.assembler._growth_stage_info(
-        mock_coordinator.growspaces["dry"]
-    )
-
+    info = sensor.assembler._growth_stage_info(mock_coordinator.growspaces["dry"])
 
     assert info["flower_days"] == -1
     assert info["veg_days"] == -1
@@ -155,8 +152,6 @@ def test_get_growth_stage_info_cure_growspace(mock_coordinator) -> None:
         mock_coordinator.growspaces["cure"].environment_config,
     )
 
-    info = sensor.assembler._growth_stage_info(
-        mock_coordinator.growspaces["cure"]
-    )
+    info = sensor.assembler._growth_stage_info(mock_coordinator.growspaces["cure"])
     assert info["flower_days"] == -1
     assert info["veg_days"] == -1

--- a/tests/integration/test_binary_sensor_logic.py
+++ b/tests/integration/test_binary_sensor_logic.py
@@ -26,7 +26,6 @@ from homeassistant.core import HomeAssistant
 MOCK_CONFIG_ENTRY_ID = "test_entry"
 
 
-
 def create_test_sensor(
     coordinator: MagicMock,
     growspace_id: str,
@@ -51,6 +50,7 @@ def create_test_sensor(
         get_plants=coordinator.get_growspace_plants,
         add_event=coordinator.add_event,
     )
+
 
 @pytest.fixture
 def mock_coordinator():

--- a/tests/integration/test_binary_sensor_unavailable_light.py
+++ b/tests/integration/test_binary_sensor_unavailable_light.py
@@ -57,7 +57,9 @@ def create_test_sensor(
         sensor.trend_analyzer = TrendAnalyzer(hass)
         sensor.strategy = strategy_class(
             env_config=sensor.env_config,
-            analyze_trend=lambda *args, **kwargs: sensor.async_analyze_sensor_trend(*args, **kwargs),
+            analyze_trend=lambda *args, **kwargs: sensor.async_analyze_sensor_trend(
+                *args, **kwargs
+            ),
             get_state=hass.states.get,
             get_growspace=lambda: coordinator.growspaces.get(growspace_id),
             get_notification_message=generate_notification_message,

--- a/tests/integration/test_coordinator_coverage.py
+++ b/tests/integration/test_coordinator_coverage.py
@@ -34,7 +34,6 @@ async def test_coordinator_getters_setters(coordinator: GrowspaceCoordinator) ->
     """Test various property getters and setters in GrowspaceCoordinator."""
 
 
-
 @pytest.mark.asyncio
 async def test_nutrient_inventory_loaded(coordinator: GrowspaceCoordinator) -> None:
     """Test on_nutrient_inventory_loaded."""

--- a/tests/integration/test_coordinator_pump_logic.py
+++ b/tests/integration/test_coordinator_pump_logic.py
@@ -74,7 +74,9 @@ async def test_async_update_irrigation_config_normalizes_empty_strings(
     }
 
     # Execute
-    await coordinator.services.growspaces.update_irrigation_config(growspace_id, user_input)
+    await coordinator.services.growspaces.update_irrigation_config(
+        growspace_id, user_input
+    )
 
     # Assertions
     assert growspace.irrigation_config.irrigation_pump_entity == "switch.new_irrigation"

--- a/tests/integration/test_grow_light_ac_infinity.py
+++ b/tests/integration/test_grow_light_ac_infinity.py
@@ -291,9 +291,7 @@ async def test_schedule_matches_when_sunrise_disabled_and_switch_off(
         ac_infinity_schedule_matches,
     )
 
-    _hass_with_states(
-        mock_hass, _matching_states() | {"switch.port_sunrise": "off"}
-    )
+    _hass_with_states(mock_hass, _matching_states() | {"switch.port_sunrise": "off"})
     assert (
         ac_infinity_schedule_matches(
             mock_hass,

--- a/tests/integration/test_growspace_config_handler_coverage.py
+++ b/tests/integration/test_growspace_config_handler_coverage.py
@@ -418,4 +418,3 @@ async def test_async_update_growspace_success(
         name="Updated GS No Dims",
         rows=5,
     )
-

--- a/tests/integration/test_ipm_logic.py
+++ b/tests/integration/test_ipm_logic.py
@@ -81,9 +81,13 @@ async def test_ipm_preset_visible_after_storage_load_sync(
     mock_coordinator._nutrient_manager.ipm_presets = fresh_presets
 
     # Apply the fix: re-point ipm_service at the same dict.
-    mock_coordinator.ipm_service.ipm_presets = mock_coordinator._nutrient_manager.ipm_presets
+    mock_coordinator.ipm_service.ipm_presets = (
+        mock_coordinator._nutrient_manager.ipm_presets
+    )
 
-    items = [{"name": "Neem Oil", "dose_amount": 5.0, "dose_unit": "ml/L", "phi_days": 0}]
+    items = [
+        {"name": "Neem Oil", "dose_amount": 5.0, "dose_unit": "ml/L", "phi_days": 0}
+    ]
     preset = await mock_coordinator.services.config.save_ipm_preset(
         name="Neem Spray", type="foliar", items=items
     )
@@ -140,7 +144,9 @@ async def test_async_apply_ipm_to_growspace(
     events = async_capture_events(mock_coordinator.hass, EVENT_GROWSPACE_LOG_ENTRY)
 
     # Execute
-    affected = await mock_coordinator.services.plants.apply_ipm("ipm1", growspace_id="gs1")
+    affected = await mock_coordinator.services.plants.apply_ipm(
+        "ipm1", growspace_id="gs1"
+    )
 
     # Verify return
     assert set(affected) == {"p1", "p2"}
@@ -216,4 +222,6 @@ async def test_async_apply_ipm_errors(mock_coordinator: GrowspaceCoordinator) ->
 
     # Missing preset
     with pytest.raises(KeyError):
-        await mock_coordinator.services.plants.apply_ipm("missing_id", growspace_id="gs1")
+        await mock_coordinator.services.plants.apply_ipm(
+            "missing_id", growspace_id="gs1"
+        )

--- a/tests/integration/test_irrigation_config_handler_coverage.py
+++ b/tests/integration/test_irrigation_config_handler_coverage.py
@@ -155,7 +155,9 @@ async def test_async_step_configure_irrigation_errors(
 
     # Restore entry, no growspace
     handler.config_entry = MagicMock()
-    handler.config_entry.runtime_data.services.growspaces.get_growspace.return_value = None
+    handler.config_entry.runtime_data.services.growspaces.get_growspace.return_value = (
+        None
+    )
     result = await handler.async_step_configure_irrigation()
     assert result == {"type": "abort"}
 

--- a/tests/integration/test_irrigation_config_volume_mode_flow.py
+++ b/tests/integration/test_irrigation_config_volume_mode_flow.py
@@ -40,8 +40,8 @@ def handler(mock_coordinator: MagicMock) -> IrrigationConfigHandler:
     coordinator.async_commit = AsyncMock()
     coordinator.async_request_refresh = AsyncMock()
     # The facade's get_growspace delegates to the data repository.
-    coordinator._data_repository.get_growspace.side_effect = (
-        lambda gid: coordinator.growspaces.get(gid)
+    coordinator._data_repository.get_growspace.side_effect = lambda gid: (
+        coordinator.growspaces.get(gid)
     )
 
     config_entry = MagicMock()

--- a/tests/integration/test_irrigation_coordinator_coverage.py
+++ b/tests/integration/test_irrigation_coordinator_coverage.py
@@ -307,7 +307,9 @@ async def test_async_add_schedule_item_invalid_time_format(
     coordinator = IrrigationCoordinator(
         mock_hass, mock_config_entry, GROWSPACE_ID, mock_main_coordinator
     )
-    with pytest.raises(ValueError, match="Invalid time '25:00:00': hours must be 00-23"):
+    with pytest.raises(
+        ValueError, match="Invalid time '25:00:00': hours must be 00-23"
+    ):
         await coordinator.async_add_schedule_item("irrigation_times", "25:00:00", 30)
 
 
@@ -319,7 +321,9 @@ async def test_compute_cycle_volume_liters_non_zero(
         mock_hass, mock_config_entry, GROWSPACE_ID, mock_main_coordinator
     )
     # Set pump flow rate
-    mock_main_coordinator.growspaces[GROWSPACE_ID].irrigation_config.pump_flow_rate_ml_per_sec = 10.0
+    mock_main_coordinator.growspaces[
+        GROWSPACE_ID
+    ].irrigation_config.pump_flow_rate_ml_per_sec = 10.0
     volume = coordinator._compute_cycle_volume_liters(30)
     assert volume == 0.3
 
@@ -331,9 +335,9 @@ async def test_is_lights_dark_no_sensors(
     coordinator = IrrigationCoordinator(
         mock_hass, mock_config_entry, GROWSPACE_ID, mock_main_coordinator
     )
-    mock_main_coordinator.growspaces[GROWSPACE_ID].environment_config = EnvironmentConfig(
-        light_sensors=[]
-    )
+    mock_main_coordinator.growspaces[
+        GROWSPACE_ID
+    ].environment_config = EnvironmentConfig(light_sensors=[])
     assert coordinator._is_lights_dark() is False
 
 
@@ -344,7 +348,9 @@ async def test_check_safety_guards_max_cycles_reached(
     coordinator = IrrigationCoordinator(
         mock_hass, mock_config_entry, GROWSPACE_ID, mock_main_coordinator
     )
-    mock_main_coordinator.growspaces[GROWSPACE_ID].irrigation_config.max_cycles_per_day = 2
+    mock_main_coordinator.growspaces[
+        GROWSPACE_ID
+    ].irrigation_config.max_cycles_per_day = 2
     coordinator._cycles_today = 2
 
     reason = coordinator._check_safety_guards(30)
@@ -359,9 +365,13 @@ async def test_check_safety_guards_volume_cap_exceeded(
         mock_hass, mock_config_entry, GROWSPACE_ID, mock_main_coordinator
     )
     # cap = 1.0 Litres
-    mock_main_coordinator.growspaces[GROWSPACE_ID].irrigation_config.daily_volume_cap_liters = 1.0
+    mock_main_coordinator.growspaces[
+        GROWSPACE_ID
+    ].irrigation_config.daily_volume_cap_liters = 1.0
     # flow rate = 100 ml/s -> 30s cycle is 3.0 Litres
-    mock_main_coordinator.growspaces[GROWSPACE_ID].irrigation_config.pump_flow_rate_ml_per_sec = 100.0
+    mock_main_coordinator.growspaces[
+        GROWSPACE_ID
+    ].irrigation_config.pump_flow_rate_ml_per_sec = 100.0
     coordinator._volume_dispensed_today = 0.0
 
     reason = coordinator._check_safety_guards(30)
@@ -376,10 +386,14 @@ async def test_run_pump_cycle_safety_guard_blocks(
         mock_hass, mock_config_entry, GROWSPACE_ID, mock_main_coordinator
     )
     # Exceed cycles limit to trigger guard failure
-    mock_main_coordinator.growspaces[GROWSPACE_ID].irrigation_config.max_cycles_per_day = 2
+    mock_main_coordinator.growspaces[
+        GROWSPACE_ID
+    ].irrigation_config.max_cycles_per_day = 2
     coordinator._cycles_today = 2
 
-    with patch("custom_components.growspace_manager.irrigation_coordinator._LOGGER") as mock_logger:
+    with patch(
+        "custom_components.growspace_manager.irrigation_coordinator._LOGGER"
+    ) as mock_logger:
         await coordinator._run_pump_cycle(
             "irrigation", "switch.irrigation_pump", 30, {"time": "10:00:00"}
         )
@@ -397,7 +411,10 @@ async def test_run_pump_cycle_safety_guard_blocks(
         assert call_args[0][0] == "growspace_manager_log_entry"
         event_data = call_args[0][1]
         assert event_data["growspace_id"] == GROWSPACE_ID
-        assert event_data["message"] == "Irrigation skipped — Daily cycle limit reached (2/2)"
+        assert (
+            event_data["message"]
+            == "Irrigation skipped — Daily cycle limit reached (2/2)"
+        )
         assert event_data["category"] == "irrigation_error"
         assert "timestamp" in event_data
 
@@ -428,7 +445,9 @@ async def test_next_scheduled_cycle_no_times(
     coordinator = IrrigationCoordinator(
         mock_hass, mock_config_entry, GROWSPACE_ID, mock_main_coordinator
     )
-    mock_main_coordinator.growspaces[GROWSPACE_ID].irrigation_config.irrigation_times = []
+    mock_main_coordinator.growspaces[
+        GROWSPACE_ID
+    ].irrigation_config.irrigation_times = []
     assert coordinator.next_scheduled_cycle is None
 
 
@@ -440,10 +459,12 @@ async def test_next_scheduled_cycle_parsing_and_skipping(
         mock_hass, mock_config_entry, GROWSPACE_ID, mock_main_coordinator
     )
     # Configure mix of valid/invalid times
-    mock_main_coordinator.growspaces[GROWSPACE_ID].irrigation_config.irrigation_times = [
-        {"time": 123},               # non-string -> skip
+    mock_main_coordinator.growspaces[
+        GROWSPACE_ID
+    ].irrigation_config.irrigation_times = [
+        {"time": 123},  # non-string -> skip
         {"time": "invalid_format"},  # invalid string -> raise ValueError -> skip
-        {"time": "12:00"},           # 5-character string -> format to 12:00:00 -> parse
+        {"time": "12:00"},  # 5-character string -> format to 12:00:00 -> parse
     ]
 
     next_cycle = coordinator.next_scheduled_cycle
@@ -459,7 +480,9 @@ async def test_async_manual_run_no_duration(
         mock_hass, mock_config_entry, GROWSPACE_ID, mock_main_coordinator
     )
     # Set both configured duration and passed duration to None/0
-    mock_main_coordinator.growspaces[GROWSPACE_ID].irrigation_config.irrigation_duration = 0
+    mock_main_coordinator.growspaces[
+        GROWSPACE_ID
+    ].irrigation_config.irrigation_duration = 0
 
     with pytest.raises(ServiceValidationError) as excinfo:
         await coordinator.async_manual_run(None)
@@ -485,14 +508,19 @@ async def test_async_manual_run_cancels_running_irrigation(
         def __await__(self) -> Any:
             async def _inner() -> None:
                 raise asyncio.CancelledError
+
             return _inner().__await__()
 
     mock_running_task = CancelableAwaitable()
     coordinator._running_tasks["irrigation"] = mock_running_task
 
     # Provide configured pump switch entity and standard duration
-    mock_main_coordinator.growspaces[GROWSPACE_ID].irrigation_config.irrigation_pump_entity = "switch.pump"
-    mock_main_coordinator.growspaces[GROWSPACE_ID].irrigation_config.irrigation_duration = 30
+    mock_main_coordinator.growspaces[
+        GROWSPACE_ID
+    ].irrigation_config.irrigation_pump_entity = "switch.pump"
+    mock_main_coordinator.growspaces[
+        GROWSPACE_ID
+    ].irrigation_config.irrigation_duration = 30
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
         await coordinator.async_manual_run(15)
@@ -504,4 +532,3 @@ async def test_async_manual_run_cancels_running_irrigation(
         # Allow the background task to complete so the coroutine is not leaked
         with contextlib.suppress(asyncio.CancelledError, Exception):
             await new_task
-

--- a/tests/integration/test_managers_aliases.py
+++ b/tests/integration/test_managers_aliases.py
@@ -115,7 +115,9 @@ async def test_plant_manager_aliases(plant_manager, growspace_manager):
     # handle_transition_plant_stage
     plant_manager.transition_plant_stage.reset_mock()
     await plant_manager.handle_transition_plant_stage("p1", PlantStage.FLOWER)
-    plant_manager.transition_plant_stage.assert_called_once_with("p1", PlantStage.FLOWER)
+    plant_manager.transition_plant_stage.assert_called_once_with(
+        "p1", PlantStage.FLOWER
+    )
 
     # handle_update_plant
     plant_manager.update_plant.reset_mock()

--- a/tests/integration/test_notification_config_handler_coverage.py
+++ b/tests/integration/test_notification_config_handler_coverage.py
@@ -142,7 +142,9 @@ async def test_async_step_edit_timed_notification_not_found(
 ) -> None:
     coordinator = handler.config_entry.runtime_data
     coordinator.services = MagicMock()
-    coordinator.services.notifications.get_timed_notifications = MagicMock(return_value=[])
+    coordinator.services.notifications.get_timed_notifications = MagicMock(
+        return_value=[]
+    )
     handler.flow.async_abort = MagicMock(return_value={"type": "abort"})
     result = await handler.async_step_edit_timed_notification()
     assert result == {"type": "abort"}

--- a/tests/integration/test_optimistic_events.py
+++ b/tests/integration/test_optimistic_events.py
@@ -91,9 +91,7 @@ async def test_async_update_plant_fires_event(
         stage="flower",
     )
     mock_coordinator._data_repository.add_plant(updated_plant)
-    mock_coordinator._plant_manager.lifecycle_manager.async_update_plant.return_value = (
-        updated_plant
-    )
+    mock_coordinator._plant_manager.lifecycle_manager.async_update_plant.return_value = updated_plant
 
     fired_events = []
 
@@ -127,9 +125,7 @@ async def test_async_remove_plant_fires_event(
         plant_id="test_plant", growspace_id="test_gs", strain="Test Strain"
     )
     mock_coordinator._data_repository.add_plant(plant)
-    mock_coordinator._plant_manager.lifecycle_manager.async_remove_plant.return_value = (
-        True
-    )
+    mock_coordinator._plant_manager.lifecycle_manager.async_remove_plant.return_value = True
 
     fired_events = []
 

--- a/tests/integration/test_overview_attributes.py
+++ b/tests/integration/test_overview_attributes.py
@@ -145,7 +145,9 @@ async def test_environment_attributes_includes_circulation_fan_config(hass) -> N
     dialog re-opens with the correct enabled state instead of falling back to False."""
     builder = GrowspaceViewModelBuilder(hass)
 
-    fan_cfg = CirculationFanConfig(enabled=True, vpd_target=1.2, min_speed=30, max_speed=90)
+    fan_cfg = CirculationFanConfig(
+        enabled=True, vpd_target=1.2, min_speed=30, max_speed=90
+    )
 
     mock_env = MagicMock()
     mock_env.temperature_sensor = None

--- a/tests/integration/test_plant_lifecycle_coverage.py
+++ b/tests/integration/test_plant_lifecycle_coverage.py
@@ -30,7 +30,9 @@ def repository_mock():
     mock.get_plant.return_value = None
     mock.has_plant.return_value = False
     mock.has_growspace.side_effect = lambda gid: gid == "test_growspace"
-    mock.get_growspace.side_effect = lambda gid: Growspace(id=gid, name=gid) if gid == "test_growspace" else None
+    mock.get_growspace.side_effect = lambda gid: (
+        Growspace(id=gid, name=gid) if gid == "test_growspace" else None
+    )
     return mock
 
 

--- a/tests/integration/test_plant_services_coverage.py
+++ b/tests/integration/test_plant_services_coverage.py
@@ -23,16 +23,16 @@ async def test_handle_add_timeline_note_service_call() -> None:
     strain_library = MagicMock()
 
     mock_call = MagicMock(spec=ServiceCall)
-    mock_call.data = {
-        ATTR_PLANT_ID: "plant1",
-        ATTR_NOTES: "Service call note"
-    }
+    mock_call.data = {ATTR_PLANT_ID: "plant1", ATTR_NOTES: "Service call note"}
 
-    with patch(
-        "custom_components.growspace_manager.services.plant_facade._ensure_plant_loaded"
-    ), patch(
-        "custom_components.growspace_manager.services.plant_facade._resolve_plant_id",
-        return_value="plant1",
+    with (
+        patch(
+            "custom_components.growspace_manager.services.plant_facade._ensure_plant_loaded"
+        ),
+        patch(
+            "custom_components.growspace_manager.services.plant_facade._resolve_plant_id",
+            return_value="plant1",
+        ),
     ):
         await PlantFacade(coordinator).add_timeline_note_from_call(
             hass, strain_library, mock_call
@@ -81,9 +81,6 @@ async def test_handle_add_plants_success() -> None:
     assert args["phenotype"] == "Strain A #10"
 
 
-
-
-
 @pytest.mark.asyncio
 async def test_handle_harvest_plant_not_loaded() -> None:
     """Test handle_harvest_plant when plant is not loaded."""
@@ -100,7 +97,9 @@ async def test_handle_harvest_plant_not_loaded() -> None:
     call = MagicMock(spec=ServiceCall)
     call.data = {ATTR_PLANT_ID: "plant1"}
 
-    with pytest.raises(ServiceValidationError, match=".*not found and could not be reloaded.*"):
+    with pytest.raises(
+        ServiceValidationError, match=".*not found and could not be reloaded.*"
+    ):
         await handle_harvest_plant(hass, coordinator, strain_library, call)
 
 

--- a/tests/integration/test_reset_plant_last_watered.py
+++ b/tests/integration/test_reset_plant_last_watered.py
@@ -85,7 +85,9 @@ class TestResetLastWateredFacade:
     ) -> None:
         """Unknown plant ID raises ServiceValidationError, not a silent no-op."""
         with pytest.raises(ServiceValidationError):
-            await coordinator_with_plant.services.plants.reset_last_watered("no-such-plant")
+            await coordinator_with_plant.services.plants.reset_last_watered(
+                "no-such-plant"
+            )
 
 
 class TestResetLastWateredHandler:

--- a/tests/integration/test_safety_guard_enforcement.py
+++ b/tests/integration/test_safety_guard_enforcement.py
@@ -288,7 +288,9 @@ async def test_volume_cap_not_applied_when_flow_rate_is_zero(
     mock_main_coordinator: MagicMock,
 ) -> None:
     """When pump_flow_rate_ml_per_sec == 0, volume cap check is skipped (unknown flow)."""
-    mock_main_coordinator.growspaces[GROWSPACE_ID].irrigation_config.pump_flow_rate_ml_per_sec = 0.0
+    mock_main_coordinator.growspaces[
+        GROWSPACE_ID
+    ].irrigation_config.pump_flow_rate_ml_per_sec = 0.0
     irrigation_coordinator._volume_dispensed_today = 0.99  # Near the cap
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
@@ -340,7 +342,8 @@ async def test_logbook_start_event_fired_when_enabled(
 
     # At least the start event should carry the growspace_id
     start_events = [
-        c for c in fire_calls
+        c
+        for c in fire_calls
         if c.args[0] == EVENT_GROWSPACE_LOG_ENTRY
         and c.args[1].get(ATTR_GROWSPACE_ID) == GROWSPACE_ID
     ]
@@ -361,7 +364,8 @@ async def test_logbook_skip_event_fired_on_cycle_limit_skip(
 
     fire_calls = mock_hass.bus.async_fire.call_args_list
     skip_events = [
-        c for c in fire_calls
+        c
+        for c in fire_calls
         if c.args[0] == EVENT_GROWSPACE_LOG_ENTRY
         and c.args[1].get(ATTR_GROWSPACE_ID) == GROWSPACE_ID
     ]
@@ -382,7 +386,8 @@ async def test_logbook_skip_event_fired_on_volume_cap_skip(
 
     fire_calls = mock_hass.bus.async_fire.call_args_list
     skip_events = [
-        c for c in fire_calls
+        c
+        for c in fire_calls
         if c.args[0] == EVENT_GROWSPACE_LOG_ENTRY
         and c.args[1].get(ATTR_GROWSPACE_ID) == GROWSPACE_ID
     ]
@@ -395,7 +400,9 @@ async def test_no_logbook_events_when_disabled(
     mock_main_coordinator: MagicMock,
 ) -> None:
     """No logbook events are fired when log_to_logbook=False."""
-    mock_main_coordinator.growspaces[GROWSPACE_ID].irrigation_config.log_to_logbook = False
+    mock_main_coordinator.growspaces[
+        GROWSPACE_ID
+    ].irrigation_config.log_to_logbook = False
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
         await irrigation_coordinator._run_pump_cycle(
@@ -404,7 +411,8 @@ async def test_no_logbook_events_when_disabled(
 
     # No logbook events should be fired
     logbook_calls = [
-        c for c in mock_hass.bus.async_fire.call_args_list
+        c
+        for c in mock_hass.bus.async_fire.call_args_list
         if c.args[0] == EVENT_GROWSPACE_LOG_ENTRY
     ]
     assert len(logbook_calls) == 0

--- a/tests/integration/test_sensor_groups.py
+++ b/tests/integration/test_sensor_groups.py
@@ -1,6 +1,5 @@
 """Test Sensor Group functionality."""
 
-
 from custom_components.growspace_manager.models import EnvironmentConfig, SensorGroup
 
 

--- a/tests/integration/test_service_error_handling_coverage.py
+++ b/tests/integration/test_service_error_handling_coverage.py
@@ -148,7 +148,9 @@ async def test_ipm_error_handling(mock_hass, mock_coordinator) -> None:
         await config_facade.remove_ipm_preset_from_call(mock_hass, call)
 
     # Apply IPM - GrowspaceError
-    mock_coordinator.services.plants.apply_ipm.side_effect = GrowspaceError("Apply failed")
+    mock_coordinator.services.plants.apply_ipm.side_effect = GrowspaceError(
+        "Apply failed"
+    )
     with pytest.raises(ServiceValidationError, match="Apply failed"):
         await config_facade.apply_ipm_from_call(mock_hass, call)
 
@@ -167,47 +169,55 @@ async def test_irrigation_error_handling(
     call = MagicMock(spec=ServiceCall)
     call.data = {ATTR_GROWSPACE_ID: "gs1", ATTR_TIME: "08:00:00"}
 
-    mock_coordinator._subsystem_manager.irrigation_coordinators = {"gs1": mock_irrigation_coordinator}
+    mock_coordinator._subsystem_manager.irrigation_coordinators = {
+        "gs1": mock_irrigation_coordinator
+    }
     # Set Settings - GrowspaceError
-    mock_coordinator.services.growspaces.set_irrigation_settings.side_effect = GrowspaceError(
-        "Set failed"
+    mock_coordinator.services.growspaces.set_irrigation_settings.side_effect = (
+        GrowspaceError("Set failed")
     )
     with pytest.raises(ServiceValidationError, match="Set failed"):
         await handle_set_irrigation_settings(mock_hass, mock_coordinator, call)
 
     # Set Settings - Generic Exception
-    mock_coordinator.services.growspaces.set_irrigation_settings.side_effect = Exception("Crash")
+    mock_coordinator.services.growspaces.set_irrigation_settings.side_effect = (
+        Exception("Crash")
+    )
     with pytest.raises(ServiceValidationError, match="Operation failed"):
         await handle_set_irrigation_settings(mock_hass, mock_coordinator, call)
 
     # Add Irrigation Time - GrowspaceError
     # Test add_irrigation_schedule_item error
-    mock_coordinator.services.growspaces.add_irrigation_schedule_item.side_effect = GrowspaceError("Add failed")
+    mock_coordinator.services.growspaces.add_irrigation_schedule_item.side_effect = (
+        GrowspaceError("Add failed")
+    )
     with pytest.raises(ServiceValidationError, match="Add failed"):
         await handle_add_irrigation_time(mock_hass, mock_coordinator, call)
 
     # Test remove_irrigation_schedule_item error
-    mock_coordinator.services.growspaces.remove_irrigation_schedule_item.side_effect = GrowspaceError("Remove failed")
+    mock_coordinator.services.growspaces.remove_irrigation_schedule_item.side_effect = (
+        GrowspaceError("Remove failed")
+    )
     with pytest.raises(ServiceValidationError, match="Remove failed"):
         await handle_remove_irrigation_time(mock_hass, mock_coordinator, call)
 
     # Remove Irrigation Time - Generic Exception
-    mock_coordinator.services.growspaces.remove_irrigation_schedule_item.side_effect = Exception(
-        "Crash"
+    mock_coordinator.services.growspaces.remove_irrigation_schedule_item.side_effect = (
+        Exception("Crash")
     )
     with pytest.raises(ServiceValidationError, match="Operation failed"):
         await handle_remove_irrigation_time(mock_hass, mock_coordinator, call)
 
     # Add Drain Time - GrowspaceError
-    mock_coordinator.services.growspaces.add_irrigation_schedule_item.side_effect = GrowspaceError(
-        "Add failed"
+    mock_coordinator.services.growspaces.add_irrigation_schedule_item.side_effect = (
+        GrowspaceError("Add failed")
     )
     with pytest.raises(ServiceValidationError, match="Add failed"):
         await handle_add_drain_time(mock_hass, mock_coordinator, call)
 
     # Add Drain Time - Generic Exception
-    mock_coordinator.services.growspaces.add_irrigation_schedule_item.side_effect = Exception(
-        "Crash"
+    mock_coordinator.services.growspaces.add_irrigation_schedule_item.side_effect = (
+        Exception("Crash")
     )
     with pytest.raises(ServiceValidationError, match="Operation failed"):
         await handle_add_drain_time(mock_hass, mock_coordinator, call)
@@ -220,8 +230,8 @@ async def test_irrigation_error_handling(
         await handle_remove_drain_time(mock_hass, mock_coordinator, call)
 
     # Remove Drain Time - Generic Exception
-    mock_coordinator.services.growspaces.remove_irrigation_schedule_item.side_effect = Exception(
-        "Crash"
+    mock_coordinator.services.growspaces.remove_irrigation_schedule_item.side_effect = (
+        Exception("Crash")
     )
     with pytest.raises(ServiceValidationError, match="Operation failed"):
         await handle_remove_drain_time(mock_hass, mock_coordinator, call)
@@ -241,20 +251,24 @@ async def test_nutrient_error_handling(mock_hass, mock_coordinator) -> None:
         await handle_save_nutrient_preset(mock_hass, mock_coordinator, call)
 
     # Save Nutrient - Generic Exception
-    mock_coordinator.services.config.save_nutrient_preset.side_effect = Exception("Crash")
+    mock_coordinator.services.config.save_nutrient_preset.side_effect = Exception(
+        "Crash"
+    )
     with pytest.raises(ServiceValidationError, match="Operation failed"):
         await handle_save_nutrient_preset(mock_hass, mock_coordinator, call)
 
     # Remove Nutrient - GrowspaceError
     call.data = {ATTR_PRESET_ID: "n1"}
-    mock_coordinator.services.config.remove_nutrient_preset.side_effect = GrowspaceError(
-        "Remove failed"
+    mock_coordinator.services.config.remove_nutrient_preset.side_effect = (
+        GrowspaceError("Remove failed")
     )
     with pytest.raises(ServiceValidationError, match="Remove failed"):
         await handle_remove_nutrient_preset(mock_hass, mock_coordinator, call)
 
     # Remove Nutrient - Generic Exception
-    mock_coordinator.services.config.remove_nutrient_preset.side_effect = Exception("Crash")
+    mock_coordinator.services.config.remove_nutrient_preset.side_effect = Exception(
+        "Crash"
+    )
     with pytest.raises(ServiceValidationError, match="Operation failed"):
         await handle_remove_nutrient_preset(mock_hass, mock_coordinator, call)
 
@@ -266,7 +280,9 @@ async def test_training_error_handling(mock_hass, mock_coordinator) -> None:
     call.data = {ATTR_TECHNIQUE: "topping"}
 
     plant_facade = PlantFacade(mock_coordinator)
-    plant_facade.log_training_event = mock_coordinator.services.plants.log_training_event
+    plant_facade.log_training_event = (
+        mock_coordinator.services.plants.log_training_event
+    )
 
     # Log Training - GrowspaceError
     mock_coordinator.services.plants.log_training_event.side_effect = GrowspaceError(
@@ -301,7 +317,9 @@ async def test_irrigation_watering_error_handling(mock_hass, mock_coordinator) -
     assert result == {"plants_watered": 5}
 
     # Water Plant - GrowspaceError
-    mock_coordinator.services.plants.water_plant.side_effect = GrowspaceError("Water failed")
+    mock_coordinator.services.plants.water_plant.side_effect = GrowspaceError(
+        "Water failed"
+    )
     with pytest.raises(ServiceValidationError, match="Water failed"):
         await handle_water_plant(mock_hass, mock_coordinator, call)
 
@@ -318,6 +336,8 @@ async def test_irrigation_watering_error_handling(mock_hass, mock_coordinator) -
         await handle_water_growspace(mock_hass, mock_coordinator, call)
 
     # Water Growspace - Generic Exception
-    mock_coordinator.services.growspaces.water_growspace.side_effect = Exception("Crash")
+    mock_coordinator.services.growspaces.water_growspace.side_effect = Exception(
+        "Crash"
+    )
     with pytest.raises(ServiceValidationError, match="Operation failed"):
         await handle_water_growspace(mock_hass, mock_coordinator, call)

--- a/tests/integration/test_services_growspace_coverage.py
+++ b/tests/integration/test_services_growspace_coverage.py
@@ -169,20 +169,26 @@ async def test_resize_growspace_with_invalid_plants(service, repository_mock) ->
 
 def test_generate_unique_name(service, repository_mock) -> None:
     """Test unique name generation."""
-    _setup_growspaces(repository_mock, {
-        "gs1": Growspace(id="gs1", name="Test"),
-        "gs2": Growspace(id="gs2", name="Test 1"),
-    })
+    _setup_growspaces(
+        repository_mock,
+        {
+            "gs1": Growspace(id="gs1", name="Test"),
+            "gs2": Growspace(id="gs2", name="Test 1"),
+        },
+    )
     assert service.generate_unique_name("Test") == "Test 2"
     assert service.generate_unique_name("New") == "New"
 
 
 def test_get_sorted_growspace_options(service, repository_mock) -> None:
     """Test getting sorted growspace options."""
-    _setup_growspaces(repository_mock, {
-        "gs1": Growspace(id="gs1", name="B"),
-        "gs2": Growspace(id="gs2", name="A"),
-    })
+    _setup_growspaces(
+        repository_mock,
+        {
+            "gs1": Growspace(id="gs1", name="B"),
+            "gs2": Growspace(id="gs2", name="A"),
+        },
+    )
     # Mock repository behavior
     repository_mock.get_sorted_growspace_options.return_value = [
         ("gs2", "A"),

--- a/tests/integration/test_storage_manager_extra.py
+++ b/tests/integration/test_storage_manager_extra.py
@@ -30,9 +30,13 @@ def genetics_manager_mock():
 
 
 @pytest.fixture
-def storage(hass: HomeAssistant, repository_mock, nutrient_manager_mock, genetics_manager_mock):
+def storage(
+    hass: HomeAssistant, repository_mock, nutrient_manager_mock, genetics_manager_mock
+):
     """Provide a StorageManager instance."""
-    return StorageManager(hass, repository_mock, nutrient_manager_mock, genetics_manager_mock)
+    return StorageManager(
+        hass, repository_mock, nutrient_manager_mock, genetics_manager_mock
+    )
 
 
 def test_load_plants_generic_exception(storage, repository_mock) -> None:

--- a/tests/integration/test_strain_library_coverage.py
+++ b/tests/integration/test_strain_library_coverage.py
@@ -359,7 +359,10 @@ async def test_import_seedfinder_empty_name_node(mock_hass) -> None:
             {"name": "", "parents": []},
         ],
     }
-    with patch.object(lib, "load", new=AsyncMock()), patch.object(lib, "_rebuild_strain_ancestry", new=AsyncMock()):
+    with (
+        patch.object(lib, "load", new=AsyncMock()),
+        patch.object(lib, "_rebuild_strain_ancestry", new=AsyncMock()),
+    ):
         await lib.async_import_seedfinder_lineage_tree("Root Strain", tree)
 
     # lineage_by_node is empty (only parent had empty name) → early return before any execute
@@ -378,7 +381,10 @@ async def test_import_seedfinder_no_lineage_nodes(mock_hass) -> None:
 
     # Tree with only the root and no parents — lineage_by_node will be empty
     tree = {"name": "Lone Strain", "parents": []}
-    with patch.object(lib, "load", new=AsyncMock()), patch.object(lib, "_rebuild_strain_ancestry", new=AsyncMock()):
+    with (
+        patch.object(lib, "load", new=AsyncMock()),
+        patch.object(lib, "_rebuild_strain_ancestry", new=AsyncMock()),
+    ):
         await lib.async_import_seedfinder_lineage_tree("Lone Strain", tree)
 
     # No DB inserts/updates should occur after the early return
@@ -399,10 +405,17 @@ async def test_import_seedfinder_leaf_parent_url_stored(mock_hass) -> None:
     tree = {
         "name": "Root",
         "parents": [
-            {"name": "LeafParent", "url": "https://seedfinder.eu/strain/LeafParent", "parents": []},
+            {
+                "name": "LeafParent",
+                "url": "https://seedfinder.eu/strain/LeafParent",
+                "parents": [],
+            },
         ],
     }
-    with patch.object(lib, "load", new=AsyncMock()), patch.object(lib, "_rebuild_strain_ancestry", new=AsyncMock()):
+    with (
+        patch.object(lib, "load", new=AsyncMock()),
+        patch.object(lib, "_rebuild_strain_ancestry", new=AsyncMock()),
+    ):
         # No scraper — leaf_parent_urls collected but not fetched
         await lib.async_import_seedfinder_lineage_tree("Root", tree)
 
@@ -423,7 +436,11 @@ async def test_import_seedfinder_scraper_fetches_leaf_parent(mock_hass) -> None:
     tree = {
         "name": "Root",
         "parents": [
-            {"name": "LeafParent", "url": "https://seedfinder.eu/strain/LeafParent", "parents": []},
+            {
+                "name": "LeafParent",
+                "url": "https://seedfinder.eu/strain/LeafParent",
+                "parents": [],
+            },
         ],
     }
 
@@ -437,8 +454,13 @@ async def test_import_seedfinder_scraper_fetches_leaf_parent(mock_hass) -> None:
         }
     )
 
-    with patch.object(lib, "load", new=AsyncMock()), patch.object(lib, "_rebuild_strain_ancestry", new=AsyncMock()):
-        await lib.async_import_seedfinder_lineage_tree("Root", tree, scraper=mock_scraper)
+    with (
+        patch.object(lib, "load", new=AsyncMock()),
+        patch.object(lib, "_rebuild_strain_ancestry", new=AsyncMock()),
+    ):
+        await lib.async_import_seedfinder_lineage_tree(
+            "Root", tree, scraper=mock_scraper
+        )
 
     mock_scraper.async_get_strain_details.assert_awaited_once()
 
@@ -456,16 +478,27 @@ async def test_import_seedfinder_scraper_error_silenced(mock_hass) -> None:
     tree = {
         "name": "Root",
         "parents": [
-            {"name": "LeafParent", "url": "https://seedfinder.eu/strain/LeafParent", "parents": []},
+            {
+                "name": "LeafParent",
+                "url": "https://seedfinder.eu/strain/LeafParent",
+                "parents": [],
+            },
         ],
     }
 
     mock_scraper = AsyncMock()
-    mock_scraper.async_get_strain_details = AsyncMock(side_effect=ValueError("scrape failed"))
+    mock_scraper.async_get_strain_details = AsyncMock(
+        side_effect=ValueError("scrape failed")
+    )
 
-    with patch.object(lib, "load", new=AsyncMock()), patch.object(lib, "_rebuild_strain_ancestry", new=AsyncMock()):
+    with (
+        patch.object(lib, "load", new=AsyncMock()),
+        patch.object(lib, "_rebuild_strain_ancestry", new=AsyncMock()),
+    ):
         # Should not raise
-        await lib.async_import_seedfinder_lineage_tree("Root", tree, scraper=mock_scraper)
+        await lib.async_import_seedfinder_lineage_tree(
+            "Root", tree, scraper=mock_scraper
+        )
 
 
 def test_get_strain_lineage_tree_cache_hit(mock_hass) -> None:
@@ -477,7 +510,12 @@ def test_get_strain_lineage_tree_cache_hit(mock_hass) -> None:
 
     lib.get_strain_lineage_tree("Cached Strain")
     # Manually place a different value in the cache to confirm cache is returned
-    lib._lineage_cache["Cached Strain"] = {"name": "FROM_CACHE", "parents": [], "source": "library", "generation": ""}
+    lib._lineage_cache["Cached Strain"] = {
+        "name": "FROM_CACHE",
+        "parents": [],
+        "source": "library",
+        "generation": "",
+    }
 
     result2 = lib.get_strain_lineage_tree("Cached Strain")
     assert result2["name"] == "FROM_CACHE"
@@ -510,7 +548,11 @@ def test_get_strain_lineage_tree_non_library_parent_with_phenotype(mock_hass) ->
         "Child": {
             "meta": {
                 "lineage_tree": [
-                    {"name": "ExternalParent", "source": "seedfinder", "phenotype": "PX"},
+                    {
+                        "name": "ExternalParent",
+                        "source": "seedfinder",
+                        "phenotype": "PX",
+                    },
                 ]
             },
             "phenotypes": {},
@@ -599,7 +641,9 @@ async def test_rebuild_ancestry_with_ancestors(mock_hass) -> None:
 
 
 @pytest.mark.asyncio
-async def test_import_seedfinder_scraper_skips_already_resolved_parent(mock_hass) -> None:
+async def test_import_seedfinder_scraper_skips_already_resolved_parent(
+    mock_hass,
+) -> None:
     """Test scraper skips leaf parents already in lineage_by_node (line 1003).
 
     GrandParent appears as a leaf-with-URL in one branch (→ leaf_parent_urls)
@@ -620,7 +664,11 @@ async def test_import_seedfinder_scraper_skips_already_resolved_parent(mock_hass
                 # ParentA has GrandParent as a leaf (URL, no children) → leaf_parent_urls
                 "name": "ParentA",
                 "parents": [
-                    {"name": "GrandParent", "url": "https://seedfinder.eu/strain/GrandParent", "parents": []},
+                    {
+                        "name": "GrandParent",
+                        "url": "https://seedfinder.eu/strain/GrandParent",
+                        "parents": [],
+                    },
                 ],
             },
             {
@@ -639,8 +687,13 @@ async def test_import_seedfinder_scraper_skips_already_resolved_parent(mock_hass
     mock_scraper = AsyncMock()
     mock_scraper.async_get_strain_details = AsyncMock()
 
-    with patch.object(lib, "load", new=AsyncMock()), patch.object(lib, "_rebuild_strain_ancestry", new=AsyncMock()):
-        await lib.async_import_seedfinder_lineage_tree("Root", tree, scraper=mock_scraper)
+    with (
+        patch.object(lib, "load", new=AsyncMock()),
+        patch.object(lib, "_rebuild_strain_ancestry", new=AsyncMock()),
+    ):
+        await lib.async_import_seedfinder_lineage_tree(
+            "Root", tree, scraper=mock_scraper
+        )
 
     # GrandParent was already resolved from the tree — scraper should NOT be called for it
     mock_scraper.async_get_strain_details.assert_not_awaited()

--- a/tests/integration/test_strain_library_services.py
+++ b/tests/integration/test_strain_library_services.py
@@ -447,6 +447,7 @@ async def test_handle_update_strain_meta_value_error(
             mock_hass, mock_coordinator, mock_strain_library, mock_call
         )
 
+
 @pytest.mark.asyncio
 async def test_handle_update_strain_meta_with_none_values(
     mock_hass, mock_coordinator, mock_strain_library, mock_call

--- a/tests/integration/test_training_logic.py
+++ b/tests/integration/test_training_logic.py
@@ -49,7 +49,9 @@ def mock_coordinator(hass: HomeAssistant, mock_plants):
     # Use real coordinator instead of MagicMock to support delegation to services
     entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
     entry.add_to_hass(hass)
-    coordinator = GrowspaceCoordinator.build(hass, entry, data={}, strain_library=MagicMock())
+    coordinator = GrowspaceCoordinator.build(
+        hass, entry, data={}, strain_library=MagicMock()
+    )
 
     # Set up plants
     coordinator._data_repository.load_plants(mock_plants)

--- a/tests/integration/test_watering_feature.py
+++ b/tests/integration/test_watering_feature.py
@@ -50,30 +50,36 @@ def watering_coordinator(hass: HomeAssistant) -> GrowspaceCoordinator:
     coordinator = create_test_coordinator(hass)
 
     # Manually add a growspace and plant for testing
-    coordinator._data_repository.add_growspace(Growspace(
-        id="test_gs",
-        name="Test Growspace",
-        rows=3,
-        plants_per_row=3,
-    ))
+    coordinator._data_repository.add_growspace(
+        Growspace(
+            id="test_gs",
+            name="Test Growspace",
+            rows=3,
+            plants_per_row=3,
+        )
+    )
 
-    coordinator._data_repository.add_plant(create_plant(
-        plant_id="test_plant",
-        growspace_id="test_gs",
-        strain="Test Strain",
-        phenotype="Phenotype A",
-        row=1,
-        col=1,
-    ))
+    coordinator._data_repository.add_plant(
+        create_plant(
+            plant_id="test_plant",
+            growspace_id="test_gs",
+            strain="Test Strain",
+            phenotype="Phenotype A",
+            row=1,
+            col=1,
+        )
+    )
 
-    coordinator._data_repository.add_plant(create_plant(
-        plant_id="test_plant_2",
-        growspace_id="test_gs",
-        strain="Test Strain 2",
-        phenotype="Phenotype B",
-        row=2,
-        col=1,
-    ))
+    coordinator._data_repository.add_plant(
+        create_plant(
+            plant_id="test_plant_2",
+            growspace_id="test_gs",
+            strain="Test Strain 2",
+            phenotype="Phenotype B",
+            row=2,
+            col=1,
+        )
+    )
 
     return coordinator
 
@@ -170,7 +176,9 @@ class TestAsyncWaterPlant:
         """Test that watering a nonexistent plant raises an error."""
 
         with pytest.raises(PlantNotFoundError):
-            await watering_coordinator.services.plants.water_plant("nonexistent", amount=1.0)
+            await watering_coordinator.services.plants.water_plant(
+                "nonexistent", amount=1.0
+            )
 
 
 class TestAsyncWaterGrowspace:

--- a/tests/logic/conftest.py
+++ b/tests/logic/conftest.py
@@ -65,8 +65,12 @@ def mock_coordinator():
     coordinator._growspace_manager.async_update_growspace = AsyncMock()
     coordinator._growspace_manager.async_remove_growspace = AsyncMock()
     coordinator._growspace_manager.async_update_environment_config = AsyncMock()
-    coordinator._growspace_manager.ensure_special_growspace = MagicMock(return_value="special_gs")
-    coordinator._growspace_manager.get_sorted_growspace_options = MagicMock(return_value=[])
+    coordinator._growspace_manager.ensure_special_growspace = MagicMock(
+        return_value="special_gs"
+    )
+    coordinator._growspace_manager.get_sorted_growspace_options = MagicMock(
+        return_value=[]
+    )
 
     # Clone manager methods
     coordinator.clone_manager.async_take_clones = AsyncMock(return_value=["clone_1"])

--- a/tests/logic/test_acclimation_transitions.py
+++ b/tests/logic/test_acclimation_transitions.py
@@ -90,6 +90,7 @@ def test_clone_acclimation_vpd_stress():
 
 def test_stage_transition_logic():
     """Verify the stage transition factors for seedling acclimation."""
+
     def sc(seedling: int) -> tuple[str, str, float]:
         r = classify_stages(StageDays(seedling=seedling))
         return r.stage_a, r.stage_b, r.factor

--- a/tests/logic/test_bayesian_evaluator.py
+++ b/tests/logic/test_bayesian_evaluator.py
@@ -407,6 +407,7 @@ async def test_async_evaluate_stress_trend(
     expected_reason,
 ) -> None:
     """Test all branches of async_evaluate_stress_trend."""
+
     async def side_effect(sensor_id, duration, threshold):
         if manual_analysis_result and sensor_id == f"sensor.{test_sensor_key}":
             return manual_analysis_result

--- a/tests/logic/test_environment_analyzer.py
+++ b/tests/logic/test_environment_analyzer.py
@@ -50,11 +50,22 @@ def test_classify_stages_display_stage_via_domain() -> None:
     """Test that classify_stages produces the correct display_stage for all branches."""
     assert classify_stages(StageDays(cure=5)).display_stage == BayesianStage.CURE
     assert classify_stages(StageDays(dry=5)).display_stage == BayesianStage.DRY
-    assert classify_stages(StageDays(flower=10)).display_stage == BayesianStage.FLOWER_EARLY
-    assert classify_stages(StageDays(flower=DEFAULT_FLOWER_EARLY_DAYS + 5)).display_stage == BayesianStage.FLOWER_MID
-    assert classify_stages(StageDays(flower=DEFAULT_FLOWER_EARLY_DAYS + 30)).display_stage == BayesianStage.FLOWER_LATE
+    assert (
+        classify_stages(StageDays(flower=10)).display_stage
+        == BayesianStage.FLOWER_EARLY
+    )
+    assert (
+        classify_stages(StageDays(flower=DEFAULT_FLOWER_EARLY_DAYS + 5)).display_stage
+        == BayesianStage.FLOWER_MID
+    )
+    assert (
+        classify_stages(StageDays(flower=DEFAULT_FLOWER_EARLY_DAYS + 30)).display_stage
+        == BayesianStage.FLOWER_LATE
+    )
     assert classify_stages(StageDays(veg=10)).display_stage == BayesianStage.VEG
-    assert classify_stages(StageDays(seedling=5)).display_stage == BayesianStage.SEEDLING
+    assert (
+        classify_stages(StageDays(seedling=5)).display_stage == BayesianStage.SEEDLING
+    )
     assert classify_stages(StageDays(clone=5)).display_stage == BayesianStage.CLONE
     assert classify_stages(StageDays()).display_stage == BayesianStage.EMPTY
 

--- a/tests/logic/test_evaluate_optimal_vpd_overrides.py
+++ b/tests/logic/test_evaluate_optimal_vpd_overrides.py
@@ -60,6 +60,7 @@ def _seedling_standard_state(vpd: float) -> EnvironmentState:
 
 # ── Custom veg override ──────────────────────────────────────────────────────
 
+
 def test_vpd_inside_custom_veg_window_but_outside_default_is_optimal() -> None:
     """VPD 1.1 is outside the default veg window (0.5–0.9) but inside custom (0.5–1.2).
 
@@ -73,7 +74,9 @@ def test_vpd_inside_custom_veg_window_but_outside_default_is_optimal() -> None:
 
     observations, reasons = evaluate_optimal_vpd(state, env_config)
 
-    assert reasons == [], f"VPD 1.1 should be optimal under custom veg override; reasons={reasons}"
+    assert reasons == [], (
+        f"VPD 1.1 should be optimal under custom veg override; reasons={reasons}"
+    )
     assert observations[0] != PROB_VPD_STRESS_OUT_OF_RANGE
 
 
@@ -90,11 +93,14 @@ def test_vpd_inside_default_veg_window_but_outside_custom_is_not_optimal() -> No
 
     observations, reasons = evaluate_optimal_vpd(state, env_config)
 
-    assert len(reasons) == 1, f"VPD 0.8 should be not-optimal under custom narrow window; reasons={reasons}"
+    assert len(reasons) == 1, (
+        f"VPD 0.8 should be not-optimal under custom narrow window; reasons={reasons}"
+    )
     assert observations[0] == PROB_VPD_STRESS_OUT_OF_RANGE
 
 
 # ── No override → default behaviour ─────────────────────────────────────────
+
 
 def test_no_override_uses_default_thresholds_optimal() -> None:
     """Without any override, VPD 0.7 is optimal under veg defaults."""
@@ -113,6 +119,7 @@ def test_no_override_uses_default_thresholds_not_optimal() -> None:
 
 # ── Acclimation stage is never overridden ────────────────────────────────────
 
+
 def test_acclimation_seedling_ignores_seedling_override() -> None:
     """BayesianStage.SEEDLING (acclimation dome) is never overridden.
 
@@ -120,7 +127,10 @@ def test_acclimation_seedling_ignores_seedling_override() -> None:
     override with a high-VPD window (1.0–2.0) must NOT affect this sub-stage.
     """
     overrides = {
-        "seedling": {"day": {"low": 1.0, "high": 2.0}, "night": {"low": 0.9, "high": 1.8}},
+        "seedling": {
+            "day": {"low": 1.0, "high": 2.0},
+            "night": {"low": 0.9, "high": 1.8},
+        },
     }
     env_config = {"vpd_optimal_overrides": overrides}
     state = _seedling_acclimation_state(vpd=0.2)
@@ -134,6 +144,7 @@ def test_acclimation_seedling_ignores_seedling_override() -> None:
 
 # ── SEEDLING_STANDARD uses the override ─────────────────────────────────────
 
+
 def test_seedling_standard_uses_seedling_override() -> None:
     """BayesianStage.SEEDLING_STANDARD (past acclimation) does use the 'seedling' override.
 
@@ -141,7 +152,10 @@ def test_seedling_standard_uses_seedling_override() -> None:
     but inside the custom override (0.9–1.1), so it must be optimal.
     """
     overrides = {
-        "seedling": {"day": {"low": 0.9, "high": 1.1}, "night": {"low": 0.8, "high": 1.0}},
+        "seedling": {
+            "day": {"low": 0.9, "high": 1.1},
+            "night": {"low": 0.8, "high": 1.0},
+        },
     }
     env_config = {"vpd_optimal_overrides": overrides}
     state = _seedling_standard_state(vpd=1.0)

--- a/tests/logic/test_mold_risk_early_stages.py
+++ b/tests/logic/test_mold_risk_early_stages.py
@@ -22,7 +22,9 @@ def _make_mold_strategy(mock_sensor: MagicMock) -> MoldRiskEvaluatorStrategy:
 
     return MoldRiskEvaluatorStrategy(
         env_config=mock_sensor.env_config,
-        analyze_trend=AsyncMock(return_value={"trend": "stable", "crossed_threshold": False}),
+        analyze_trend=AsyncMock(
+            return_value={"trend": "stable", "crossed_threshold": False}
+        ),
         get_state=MagicMock(return_value=None),
         get_growspace=MagicMock(return_value=None),
         get_notification_message=lambda msg, reasons: "msg",

--- a/tests/logic/test_mold_risk_strategies.py
+++ b/tests/logic/test_mold_risk_strategies.py
@@ -25,7 +25,9 @@ def _make_mold_strategy(mock_sensor: MagicMock) -> MoldRiskEvaluatorStrategy:
     mock_growspace.name = "Test Growspace"
     return MoldRiskEvaluatorStrategy(
         env_config=mock_sensor.env_config,
-        analyze_trend=AsyncMock(return_value={"trend": "stable", "crossed_threshold": False}),
+        analyze_trend=AsyncMock(
+            return_value={"trend": "stable", "crossed_threshold": False}
+        ),
         get_state=MagicMock(return_value=None),
         get_growspace=MagicMock(return_value=mock_growspace),
         get_notification_message=MagicMock(return_value="msg"),
@@ -173,7 +175,9 @@ async def test_notification_title_generation(mock_sensor) -> None:
 
     strategy = MoldRiskEvaluatorStrategy(
         env_config=mock_sensor.env_config,
-        analyze_trend=AsyncMock(return_value={"trend": "stable", "crossed_threshold": False}),
+        analyze_trend=AsyncMock(
+            return_value={"trend": "stable", "crossed_threshold": False}
+        ),
         get_state=MagicMock(return_value=None),
         get_growspace=lambda: mock_growspace,
         get_notification_message=MagicMock(return_value="msg"),

--- a/tests/logic/test_mold_sensor_refactor.py
+++ b/tests/logic/test_mold_sensor_refactor.py
@@ -55,7 +55,9 @@ def create_test_sensor(
         sensor.trend_analyzer = TrendAnalyzer(hass)
         sensor.strategy = strategy_class(
             env_config=sensor.env_config,
-            analyze_trend=lambda *args, **kwargs: sensor.async_analyze_sensor_trend(*args, **kwargs),
+            analyze_trend=lambda *args, **kwargs: sensor.async_analyze_sensor_trend(
+                *args, **kwargs
+            ),
             get_state=hass.states.get,
             get_growspace=lambda: coordinator.growspaces.get(growspace_id),
             get_notification_message=generate_notification_message,

--- a/tests/logic/test_optimal_strategies.py
+++ b/tests/logic/test_optimal_strategies.py
@@ -31,7 +31,9 @@ async def test_optimal_conditions_notification(mock_sensor: MagicMock) -> None:
 
     strategy = OptimalConditionsEvaluatorStrategy(
         env_config=mock_sensor.env_config,
-        analyze_trend=AsyncMock(return_value={"trend": "stable", "crossed_threshold": False}),
+        analyze_trend=AsyncMock(
+            return_value={"trend": "stable", "crossed_threshold": False}
+        ),
         get_state=MagicMock(return_value=None),
         get_growspace=lambda: mock_growspace,
         get_notification_message=MagicMock(return_value="msg"),
@@ -49,7 +51,9 @@ async def test_optimal_conditions_notification(mock_sensor: MagicMock) -> None:
     # Test fallback name when get_growspace returns None
     strategy_no_growspace = OptimalConditionsEvaluatorStrategy(
         env_config=mock_sensor.env_config,
-        analyze_trend=AsyncMock(return_value={"trend": "stable", "crossed_threshold": False}),
+        analyze_trend=AsyncMock(
+            return_value={"trend": "stable", "crossed_threshold": False}
+        ),
         get_state=MagicMock(return_value=None),
         get_growspace=lambda: None,
         get_notification_message=MagicMock(return_value="msg"),
@@ -62,9 +66,7 @@ async def test_optimal_conditions_notification(mock_sensor: MagicMock) -> None:
 class DummyEvaluatorStrategy(BayesianEvaluatorStrategy):
     """Dummy strategy to test the base class methods."""
 
-    async def async_evaluate(
-        self, state: Any
-    ) -> tuple[Any, Any]:
+    async def async_evaluate(self, state: Any) -> tuple[Any, Any]:
         """Implement abstract method."""
         return [], []
 
@@ -73,7 +75,9 @@ def test_base_evaluator_strategy_notification_default(mock_sensor: MagicMock) ->
     """Test that the default base class implementation of get_notification_title_message returns None."""
     strategy = DummyEvaluatorStrategy(
         env_config=mock_sensor.env_config,
-        analyze_trend=AsyncMock(return_value={"trend": "stable", "crossed_threshold": False}),
+        analyze_trend=AsyncMock(
+            return_value={"trend": "stable", "crossed_threshold": False}
+        ),
         get_state=MagicMock(return_value=None),
         get_growspace=MagicMock(return_value=None),
         get_notification_message=MagicMock(return_value="msg"),
@@ -83,11 +87,15 @@ def test_base_evaluator_strategy_notification_default(mock_sensor: MagicMock) ->
 
 
 @pytest.mark.asyncio
-async def test_optimal_conditions_evaluate_missing_state_fields(mock_sensor: MagicMock) -> None:
+async def test_optimal_conditions_evaluate_missing_state_fields(
+    mock_sensor: MagicMock,
+) -> None:
     """Test async_evaluate early return when state fields are None."""
     strategy = OptimalConditionsEvaluatorStrategy(
         env_config=mock_sensor.env_config,
-        analyze_trend=AsyncMock(return_value={"trend": "stable", "crossed_threshold": False}),
+        analyze_trend=AsyncMock(
+            return_value={"trend": "stable", "crossed_threshold": False}
+        ),
         get_state=MagicMock(return_value=None),
         get_growspace=MagicMock(return_value=None),
         get_notification_message=MagicMock(return_value="msg"),
@@ -123,7 +131,9 @@ async def test_optimal_conditions_evaluate_success(mock_sensor: MagicMock) -> No
     """Test async_evaluate when all required fields are present."""
     strategy = OptimalConditionsEvaluatorStrategy(
         env_config=mock_sensor.env_config,
-        analyze_trend=AsyncMock(return_value={"trend": "stable", "crossed_threshold": False}),
+        analyze_trend=AsyncMock(
+            return_value={"trend": "stable", "crossed_threshold": False}
+        ),
         get_state=MagicMock(return_value=None),
         get_growspace=MagicMock(return_value=None),
         get_notification_message=MagicMock(return_value="msg"),
@@ -134,5 +144,3 @@ async def test_optimal_conditions_evaluate_success(mock_sensor: MagicMock) -> No
 
     assert isinstance(obs, list)
     assert isinstance(reasons, list)
-
-

--- a/tests/logic/test_plant_lifecycle_manager.py
+++ b/tests/logic/test_plant_lifecycle_manager.py
@@ -201,7 +201,10 @@ async def test_move_to_dry_growspace_device_id_ghosting(
     gs_service_mock.ensure_special_growspace.return_value = "dry_gs"
     mock_dry_gs = MagicMock()
     mock_dry_gs.device_id = None  # Crucial: destination has no device
-    repository_mock.get_growspace.side_effect = lambda gid: {"dry_gs": mock_dry_gs, "gs1": MagicMock()}.get(gid)
+    repository_mock.get_growspace.side_effect = lambda gid: {
+        "dry_gs": mock_dry_gs,
+        "gs1": MagicMock(),
+    }.get(gid)
     repository_mock.get_plant.return_value = plant
 
     await manager.move_to_dry_growspace("p1", plant, "2023-01-01")
@@ -346,7 +349,9 @@ async def test_promote_clone_target_full(manager, repository_mock) -> None:
 @pytest.mark.asyncio
 async def test_handle_transition_logic_kwargs(manager) -> None:
     """Test handle_transition_logic passes through kwargs correctly."""
-    with patch.object(manager, "transition_plant", new_callable=AsyncMock) as mock_harvest:
+    with patch.object(
+        manager, "transition_plant", new_callable=AsyncMock
+    ) as mock_harvest:
         # Call with keyword args only
         await manager.handle_transition_logic(plant_id="p1", custom_arg=True)
 

--- a/tests/logic/test_post_harvest_strategies.py
+++ b/tests/logic/test_post_harvest_strategies.py
@@ -30,7 +30,9 @@ async def test_post_harvest_missing_state_fields(mock_sensor: MagicMock) -> None
 
     strategy = DryingEvaluatorStrategy(
         env_config=mock_sensor.env_config,
-        analyze_trend=AsyncMock(return_value={"trend": "stable", "crossed_threshold": False}),
+        analyze_trend=AsyncMock(
+            return_value={"trend": "stable", "crossed_threshold": False}
+        ),
         get_state=MagicMock(return_value=None),
         get_growspace=lambda: mock_growspace,
         get_notification_message=MagicMock(return_value="msg"),
@@ -59,11 +61,15 @@ async def test_post_harvest_missing_state_fields(mock_sensor: MagicMock) -> None
 async def test_post_harvest_wrong_growspace_type(mock_sensor: MagicMock) -> None:
     """Test async_evaluate when growspace type does not match."""
     mock_growspace = MagicMock()
-    mock_growspace.growspace_type = GrowspaceType.VEG  # Wrong type for Drying which expects DRY
+    mock_growspace.growspace_type = (
+        GrowspaceType.VEG
+    )  # Wrong type for Drying which expects DRY
 
     strategy = DryingEvaluatorStrategy(
         env_config=mock_sensor.env_config,
-        analyze_trend=AsyncMock(return_value={"trend": "stable", "crossed_threshold": False}),
+        analyze_trend=AsyncMock(
+            return_value={"trend": "stable", "crossed_threshold": False}
+        ),
         get_state=MagicMock(return_value=None),
         get_growspace=lambda: mock_growspace,
         get_notification_message=MagicMock(return_value="msg"),
@@ -83,7 +89,9 @@ async def test_post_harvest_success(mock_sensor: MagicMock) -> None:
 
     strategy_dry = DryingEvaluatorStrategy(
         env_config=mock_sensor.env_config,
-        analyze_trend=AsyncMock(return_value={"trend": "stable", "crossed_threshold": False}),
+        analyze_trend=AsyncMock(
+            return_value={"trend": "stable", "crossed_threshold": False}
+        ),
         get_state=MagicMock(return_value=None),
         get_growspace=lambda: mock_growspace_dry,
         get_notification_message=MagicMock(return_value="msg"),
@@ -108,7 +116,9 @@ async def test_post_harvest_success(mock_sensor: MagicMock) -> None:
 
     strategy_cure = CuringEvaluatorStrategy(
         env_config=mock_sensor.env_config,
-        analyze_trend=AsyncMock(return_value={"trend": "stable", "crossed_threshold": False}),
+        analyze_trend=AsyncMock(
+            return_value={"trend": "stable", "crossed_threshold": False}
+        ),
         get_state=MagicMock(return_value=None),
         get_growspace=lambda: mock_growspace_cure,
         get_notification_message=MagicMock(return_value="msg"),

--- a/tests/logic/test_stress_strategies.py
+++ b/tests/logic/test_stress_strategies.py
@@ -27,7 +27,9 @@ def test_stress_notification(mock_sensor: MagicMock) -> None:
 
     strategy = StressEvaluatorStrategy(
         env_config=mock_sensor.env_config,
-        analyze_trend=AsyncMock(return_value={"trend": "stable", "crossed_threshold": False}),
+        analyze_trend=AsyncMock(
+            return_value={"trend": "stable", "crossed_threshold": False}
+        ),
         get_state=MagicMock(return_value=None),
         get_growspace=lambda: mock_growspace,
         get_notification_message=MagicMock(return_value="msg"),
@@ -44,7 +46,9 @@ def test_stress_notification(mock_sensor: MagicMock) -> None:
     # Test when growspace is None
     strategy_no_growspace = StressEvaluatorStrategy(
         env_config=mock_sensor.env_config,
-        analyze_trend=AsyncMock(return_value={"trend": "stable", "crossed_threshold": False}),
+        analyze_trend=AsyncMock(
+            return_value={"trend": "stable", "crossed_threshold": False}
+        ),
         get_state=MagicMock(return_value=None),
         get_growspace=lambda: None,
         get_notification_message=MagicMock(return_value="msg"),
@@ -60,7 +64,9 @@ async def test_stress_evaluate(mock_sensor: MagicMock) -> None:
     # Test with temperature_sensor = None (exercises False branch at line 56)
     strategy = StressEvaluatorStrategy(
         env_config=mock_sensor.env_config,
-        analyze_trend=AsyncMock(return_value={"trend": "stable", "crossed_threshold": False}),
+        analyze_trend=AsyncMock(
+            return_value={"trend": "stable", "crossed_threshold": False}
+        ),
         get_state=MagicMock(return_value=None),
         get_growspace=MagicMock(return_value=None),
         get_notification_message=MagicMock(return_value="msg"),
@@ -74,8 +80,15 @@ async def test_stress_evaluate(mock_sensor: MagicMock) -> None:
     # Test with temperature_sensor = "sensor.temp" (exercises True branch at line 56)
     mock_sensor.env_config.temperature_sensor = "sensor.temp"
 
-    with patch("custom_components.growspace_manager.strategies.stress.async_evaluate_stress_trend", new_callable=AsyncMock) as mock_trend_eval:
-        mock_trend_eval.return_value = ([("stress_trend", 0.7)], ["Temp trend high"], None)
+    with patch(
+        "custom_components.growspace_manager.strategies.stress.async_evaluate_stress_trend",
+        new_callable=AsyncMock,
+    ) as mock_trend_eval:
+        mock_trend_eval.return_value = (
+            [("stress_trend", 0.7)],
+            ["Temp trend high"],
+            None,
+        )
         obs, reasons = await strategy.async_evaluate(state)
         assert ("stress_trend", 0.7) in obs
         assert "Temp trend high" in reasons

--- a/tests/managers/test_lineage_manager.py
+++ b/tests/managers/test_lineage_manager.py
@@ -1,4 +1,3 @@
-
 from custom_components.growspace_manager.managers.lineage import StrainLineageManager
 
 STRAINS = {
@@ -20,8 +19,14 @@ STRAINS = {
 
 
 CYCLIC_STRAINS = {
-    "A": {"meta": {"lineage_tree": [{"name": "B", "source": "library"}]}, "phenotypes": {}},
-    "B": {"meta": {"lineage_tree": [{"name": "A", "source": "library"}]}, "phenotypes": {}},
+    "A": {
+        "meta": {"lineage_tree": [{"name": "B", "source": "library"}]},
+        "phenotypes": {},
+    },
+    "B": {
+        "meta": {"lineage_tree": [{"name": "A", "source": "library"}]},
+        "phenotypes": {},
+    },
 }
 
 

--- a/tests/managers/test_strain_analytics_manager.py
+++ b/tests/managers/test_strain_analytics_manager.py
@@ -1,4 +1,3 @@
-
 from custom_components.growspace_manager.managers.strain_analytics import (
     StrainAnalyticsManager,
 )
@@ -9,8 +8,18 @@ STRAINS_WITH_HARVESTS = {
         "phenotypes": {
             "Pheno1": {
                 "harvests": [
-                    {"veg_days": 30, "flower_days": 60, "dry_weight": 80.0, "wet_weight": 300.0},
-                    {"veg_days": 28, "flower_days": 63, "dry_weight": 90.0, "wet_weight": 320.0},
+                    {
+                        "veg_days": 30,
+                        "flower_days": 60,
+                        "dry_weight": 80.0,
+                        "wet_weight": 300.0,
+                    },
+                    {
+                        "veg_days": 28,
+                        "flower_days": 63,
+                        "dry_weight": 90.0,
+                        "wet_weight": 320.0,
+                    },
                 ]
             }
         },

--- a/tests/sensors/test_drying_sensors.py
+++ b/tests/sensors/test_drying_sensors.py
@@ -46,6 +46,7 @@ def _make_coordinator(plant: Plant) -> MagicMock:
 
 # --- DryingWeightSensor ---
 
+
 class TestDryingWeightSensor:
     def test_native_value_returns_latest_weight(self) -> None:
         """State is the most recent weight_log entry."""
@@ -113,6 +114,7 @@ class TestDryingWeightSensor:
 
 # --- DryingMoistureSensor ---
 
+
 class TestDryingMoistureSensor:
     def test_native_value_returns_latest_moisture(self) -> None:
         """State is the most recent moisture_log entry."""
@@ -133,6 +135,7 @@ class TestDryingMoistureSensor:
 
 
 # --- DryingReadyForCureSensor ---
+
 
 class TestDryingReadyForCureSensor:
     def test_is_on_when_moisture_at_threshold(self) -> None:

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -99,15 +99,15 @@ def mock_coordinator(mock_plant, mock_growspace):
     # Link data_repository methods to local mocks so ServiceFacade sees them
     mock_get_growspace_plants = MagicMock(
         name="get_growspace_plants",
-        side_effect=lambda gid: [p for p in coordinator.plants.values() if p.growspace_id == gid]
+        side_effect=lambda gid: [
+            p for p in coordinator.plants.values() if p.growspace_id == gid
+        ],
     )
     mock_get_plant = MagicMock(
-        name="get_plant",
-        side_effect=lambda pid: coordinator.plants.get(pid)
+        name="get_plant", side_effect=lambda pid: coordinator.plants.get(pid)
     )
     mock_get_growspace = MagicMock(
-        name="get_growspace",
-        side_effect=lambda gid: coordinator.growspaces.get(gid)
+        name="get_growspace", side_effect=lambda gid: coordinator.growspaces.get(gid)
     )
     mock_get_subareas = MagicMock(name="get_subareas", return_value=[])
 
@@ -116,7 +116,6 @@ def mock_coordinator(mock_plant, mock_growspace):
     coordinator._data_repository.get_growspace = mock_get_growspace
     coordinator._growspace_manager.get_subareas = mock_get_subareas
 
-
     # Initialize ServiceFacade, then wrap both the container and each sub-facade in
     # MagicMocks so tests can assert on calls (assert_called_once_with, etc.)
     facade = ServiceFacade(coordinator)
@@ -124,7 +123,9 @@ def mock_coordinator(mock_plant, mock_growspace):
     def _wrap_sub_facade(sub_facade):
         """Wrap a sub-facade so async methods are AsyncMocks."""
         wrapped = MagicMock(wraps=sub_facade)
-        for name, attr in inspect.getmembers(sub_facade, predicate=inspect.iscoroutinefunction):
+        for name, attr in inspect.getmembers(
+            sub_facade, predicate=inspect.iscoroutinefunction
+        ):
             setattr(wrapped, name, AsyncMock(side_effect=attr))
         return wrapped
 
@@ -142,19 +143,36 @@ def mock_coordinator(mock_plant, mock_growspace):
     type(coordinator).growspace_service = property(lambda self: self._growspace_manager)
     type(coordinator).plant_service = property(lambda self: self._plant_manager)
 
+    coordinator._growspace_manager.async_add_growspace = (
+        coordinator._growspace_manager.add_growspace
+    )
+    coordinator._growspace_manager.async_update_growspace = (
+        coordinator._growspace_manager.update_growspace
+    )
+    coordinator._growspace_manager.async_remove_growspace = (
+        coordinator._growspace_manager.remove_growspace
+    )
+    coordinator._growspace_manager.async_update_environment_config = (
+        coordinator._growspace_manager.update_environment_config
+    )
 
-    coordinator._growspace_manager.async_add_growspace = coordinator._growspace_manager.add_growspace
-    coordinator._growspace_manager.async_update_growspace = coordinator._growspace_manager.update_growspace
-    coordinator._growspace_manager.async_remove_growspace = coordinator._growspace_manager.remove_growspace
-    coordinator._growspace_manager.async_update_environment_config = coordinator._growspace_manager.update_environment_config
+    coordinator._nutrient_manager.async_commit_preset = (
+        coordinator._nutrient_manager.async_save_nutrient_preset
+    )
+    coordinator._nutrient_manager.async_remove_preset = (
+        coordinator._nutrient_manager.async_remove_nutrient_preset
+    )
 
-    coordinator._nutrient_manager.async_commit_preset = coordinator._nutrient_manager.async_save_nutrient_preset
-    coordinator._nutrient_manager.async_remove_preset = coordinator._nutrient_manager.async_remove_nutrient_preset
+    coordinator.training_manager.async_record_training = (
+        coordinator.training_service.async_log_training_event
+    )
 
-    coordinator.training_manager.async_record_training = coordinator.training_service.async_log_training_event
-
-    coordinator._growspace_manager.ensure_special_growspace = MagicMock(return_value="special_gs")
-    coordinator._growspace_manager.get_sorted_growspace_options = MagicMock(return_value=[])
+    coordinator._growspace_manager.ensure_special_growspace = MagicMock(
+        return_value="special_gs"
+    )
+    coordinator._growspace_manager.get_sorted_growspace_options = MagicMock(
+        return_value=[]
+    )
 
     # Utility methods
     coordinator.calculate_days = MagicMock(side_effect=DateTimeHelper.calculate_days)
@@ -165,10 +183,7 @@ def mock_coordinator(mock_plant, mock_growspace):
     coordinator._data_repository.get_plant.return_value = None
     coordinator._data_repository.get_growspace.return_value = None
 
-
-
     return coordinator
-
 
 
 @pytest.fixture

--- a/tests/services/test_config_facade_extensions.py
+++ b/tests/services/test_config_facade_extensions.py
@@ -23,7 +23,9 @@ def test_get_inventory_delegates_to_inventory_service() -> None:
     """get_inventory returns the result from inventory_service.get_inventory."""
     inventory = MagicMock()
     coordinator = _make_coordinator()
-    coordinator._nutrient_manager.inventory_service.get_inventory.return_value = inventory
+    coordinator._nutrient_manager.inventory_service.get_inventory.return_value = (
+        inventory
+    )
     facade = ConfigFacade(coordinator)
 
     result = facade.get_inventory()

--- a/tests/services/test_genetics_facade.py
+++ b/tests/services/test_genetics_facade.py
@@ -183,7 +183,9 @@ async def test_async_delete_pollination_delegates() -> None:
 
     await facade.async_delete_pollination("e1")
 
-    coordinator._genetics_manager.async_delete_pollination.assert_awaited_once_with("e1")
+    coordinator._genetics_manager.async_delete_pollination.assert_awaited_once_with(
+        "e1"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_growspace_facade_extensions.py
+++ b/tests/services/test_growspace_facade_extensions.py
@@ -52,7 +52,9 @@ def test_get_dehumidifier_coordinator_returns_coord_when_present() -> None:
     """Returns the dehumidifier coordinator for a known growspace."""
     dehum_coord = MagicMock()
     coordinator = _make_coordinator()
-    coordinator._subsystem_manager.get_dehumidifier_controller.return_value = dehum_coord
+    coordinator._subsystem_manager.get_dehumidifier_controller.return_value = (
+        dehum_coord
+    )
     facade = GrowspaceFacade(coordinator)
 
     result = facade.get_dehumidifier_coordinator("tent1")
@@ -85,7 +87,9 @@ def test_calculate_biological_metrics_delegates_to_environment_analyzer() -> Non
     result = facade.calculate_biological_metrics("tent1", growspace, days)
 
     assert result is metrics
-    coordinator.environment_analyzer.calculate_biological_metrics.assert_called_once_with(growspace, days)
+    coordinator.environment_analyzer.calculate_biological_metrics.assert_called_once_with(
+        growspace, days
+    )
 
 
 def test_calculate_biological_metrics_passes_stage_days_through() -> None:
@@ -98,4 +102,6 @@ def test_calculate_biological_metrics_passes_stage_days_through() -> None:
 
     facade.calculate_biological_metrics("tent1", growspace, days)
 
-    coordinator.environment_analyzer.calculate_biological_metrics.assert_called_once_with(growspace, days)
+    coordinator.environment_analyzer.calculate_biological_metrics.assert_called_once_with(
+        growspace, days
+    )

--- a/tests/services/test_irrigation_coordinator.py
+++ b/tests/services/test_irrigation_coordinator.py
@@ -473,9 +473,7 @@ async def test_async_remove_schedule_item(
 
         # An invalid time is a loud failure, matching the add path
         with pytest.raises(ValueError):
-            await coordinator.async_remove_schedule_item(
-                "irrigation_times", "99:99:99"
-            )
+            await coordinator.async_remove_schedule_item("irrigation_times", "99:99:99")
 
 
 async def test_async_add_schedule_item_validation_error(
@@ -1102,7 +1100,9 @@ async def test_async_manual_run_raises_when_no_pump_configured(
     coordinator = IrrigationCoordinator(
         mock_hass, mock_config_entry, GROWSPACE_ID, mock_main_coordinator
     )
-    coordinator._main_coordinator.growspaces[GROWSPACE_ID].irrigation_config.irrigation_pump_entity = None
+    coordinator._main_coordinator.growspaces[
+        GROWSPACE_ID
+    ].irrigation_config.irrigation_pump_entity = None
 
     with pytest.raises(ServiceValidationError, match="No irrigation pump"):
         await coordinator.async_manual_run(duration=30)
@@ -1139,7 +1139,9 @@ async def test_last_cycle_timestamp_set_after_run_pump_cycle(
             return_value=True,
         ),
     ):
-        await coordinator._run_pump_cycle("irrigation", "switch.irrigation_pump", 30, {})
+        await coordinator._run_pump_cycle(
+            "irrigation", "switch.irrigation_pump", 30, {}
+        )
 
     assert coordinator.last_cycle_timestamp is not None
 
@@ -1404,7 +1406,9 @@ async def test_low_tank_skip_fires_persistent_notification(
         for c in mock_hass.services.async_call.call_args_list
         if c.args[:2] == ("persistent_notification", "create")
     ]
-    assert len(notification_calls) >= 1, "No persistent notification was fired for low tank skip"
+    assert len(notification_calls) >= 1, (
+        "No persistent notification was fired for low tank skip"
+    )
 
 
 async def test_low_tank_skip_also_applies_to_manual_run(

--- a/tests/services/test_notification_batching.py
+++ b/tests/services/test_notification_batching.py
@@ -35,7 +35,9 @@ def make_snapshot(
         probability=probability,
         threshold=0.8,
         is_on=is_on,
-        reasons=reasons if reasons is not None else [(0.9, "Reason A"), (0.8, "Reason B")],
+        reasons=reasons
+        if reasons is not None
+        else [(0.9, "Reason A"), (0.8, "Reason B")],
         sensor_states=sensor_states if sensor_states is not None else {"temp": 25.0},
         lights_on=None,
         notification_title=notification_title,
@@ -99,13 +101,19 @@ async def test_multiple_sensors_aggregation(manager, hass: HomeAssistant) -> Non
     _store(
         manager,
         make_snapshot(
-            "stress", sensor_name="Sensor 1", reasons=[(0.9, "Hot")], sensor_states={"temp": 30}
+            "stress",
+            sensor_name="Sensor 1",
+            reasons=[(0.9, "Hot")],
+            sensor_states={"temp": 30},
         ),
     )
     _store(
         manager,
         make_snapshot(
-            "mold", sensor_name="Sensor 2", reasons=[(0.8, "Dry")], sensor_states={"hum": 20}
+            "mold",
+            sensor_name="Sensor 2",
+            reasons=[(0.8, "Dry")],
+            sensor_states={"hum": 20},
         ),
     )
 

--- a/tests/services/test_notification_rewriter.py
+++ b/tests/services/test_notification_rewriter.py
@@ -36,7 +36,9 @@ def rewriter(mock_hass: MagicMock) -> AINotificationRewriter:
     return AINotificationRewriter(mock_hass)
 
 
-def _make_converse_result(speech: str | None, error_code: str | None = None) -> MagicMock:
+def _make_converse_result(
+    speech: str | None, error_code: str | None = None
+) -> MagicMock:
     result = MagicMock()
     result.response.error_code = error_code
     result.response.response_type = None
@@ -54,7 +56,9 @@ async def test_async_rewrite_success(rewriter: AINotificationRewriter) -> None:
         new_callable=AsyncMock,
         return_value=_make_converse_result("Ahoy! Test Message Rewrite"),
     ):
-        result = await rewriter.async_rewrite("Original", "Tent", None, AI_SETTINGS_BASE)
+        result = await rewriter.async_rewrite(
+            "Original", "Tent", None, AI_SETTINGS_BASE
+        )
 
     assert result == "Ahoy! Test Message Rewrite"
 
@@ -63,9 +67,7 @@ async def test_async_rewrite_on_cooldown(rewriter: AINotificationRewriter) -> No
     """Test returns original message when on AI rate-limit cooldown."""
     rewriter._ai_cooldown_until = dt_util.utcnow() + timedelta(minutes=10)
 
-    result = await rewriter.async_rewrite(
-        "Original", "Tent", None, AI_SETTINGS_BASE
-    )
+    result = await rewriter.async_rewrite("Original", "Tent", None, AI_SETTINGS_BASE)
 
     assert result == "Original"
 
@@ -81,7 +83,9 @@ async def test_async_rewrite_rate_limit_sets_cooldown(
         new_callable=AsyncMock,
         return_value=mock_result,
     ):
-        result = await rewriter.async_rewrite("Original", "Tent", None, AI_SETTINGS_BASE)
+        result = await rewriter.async_rewrite(
+            "Original", "Tent", None, AI_SETTINGS_BASE
+        )
 
     assert result == "Original"
     assert rewriter._ai_cooldown_until is not None
@@ -91,7 +95,9 @@ async def test_async_rewrite_non_rate_limit_error_no_cooldown(
     rewriter: AINotificationRewriter,
 ) -> None:
     """Test non-rate-limit error logs warning but does not set cooldown."""
-    mock_result = _make_converse_result("Some error occurred", error_code="some_other_error")
+    mock_result = _make_converse_result(
+        "Some error occurred", error_code="some_other_error"
+    )
 
     with (
         patch(
@@ -103,7 +109,9 @@ async def test_async_rewrite_non_rate_limit_error_no_cooldown(
             "custom_components.growspace_manager.notification_rewriter._LOGGER.warning"
         ) as mock_warn,
     ):
-        result = await rewriter.async_rewrite("Original", "Tent", None, AI_SETTINGS_BASE)
+        result = await rewriter.async_rewrite(
+            "Original", "Tent", None, AI_SETTINGS_BASE
+        )
         mock_warn.assert_called()
 
     assert result == "Original"
@@ -124,7 +132,9 @@ async def test_async_rewrite_empty_speech_returns_original(
         new_callable=AsyncMock,
         return_value=mock_result,
     ):
-        result = await rewriter.async_rewrite("Original", "Tent", None, AI_SETTINGS_BASE)
+        result = await rewriter.async_rewrite(
+            "Original", "Tent", None, AI_SETTINGS_BASE
+        )
 
     assert result == "Original"
 
@@ -138,7 +148,9 @@ async def test_async_rewrite_none_result_returns_original(
         new_callable=AsyncMock,
         return_value=None,
     ):
-        result = await rewriter.async_rewrite("Original", "Tent", None, AI_SETTINGS_BASE)
+        result = await rewriter.async_rewrite(
+            "Original", "Tent", None, AI_SETTINGS_BASE
+        )
 
     assert result == "Original"
 
@@ -152,7 +164,9 @@ async def test_async_rewrite_exception_returns_original(
         new_callable=AsyncMock,
         side_effect=ValueError("AI Error"),
     ):
-        result = await rewriter.async_rewrite("Original", "Tent", None, AI_SETTINGS_BASE)
+        result = await rewriter.async_rewrite(
+            "Original", "Tent", None, AI_SETTINGS_BASE
+        )
 
     assert result == "Original"
 
@@ -233,6 +247,8 @@ async def test_async_rewrite_truncation_too_long(
         new_callable=AsyncMock,
         return_value=_make_converse_result(very_long_response),
     ):
-        result = await rewriter.async_rewrite("Original Message", "Tent", None, ai_settings)
+        result = await rewriter.async_rewrite(
+            "Original Message", "Tent", None, ai_settings
+        )
 
     assert result == "Original Message"

--- a/tests/services/test_nutrient_inventory_websocket.py
+++ b/tests/services/test_nutrient_inventory_websocket.py
@@ -156,7 +156,5 @@ async def test_websocket_remove_nutrient_stock(
     msg = await client.receive_json()
     assert msg["success"]
 
-    mock_coordinator.services.config.remove_stock.assert_called_with(
-        "test_nutrient"
-    )
+    mock_coordinator.services.config.remove_stock.assert_called_with("test_nutrient")
     mock_coordinator.async_commit.assert_called()

--- a/tests/services/test_nutrient_presets.py
+++ b/tests/services/test_nutrient_presets.py
@@ -116,7 +116,8 @@ class TestNutrientPresetCoordinator:
         """Test removing a nutrient preset."""
         # First save a preset
         preset = await preset_coordinator.services.config.save_nutrient_preset(
-            name="To Remove", nutrients=[{"nutrient_id": "id-nutrient", "dose_ml_l": 1.0}]
+            name="To Remove",
+            nutrients=[{"nutrient_id": "id-nutrient", "dose_ml_l": 1.0}],
         )
         preset_id = preset.id
 
@@ -242,7 +243,8 @@ class TestWateringWithPresets:
     ) -> None:
         """Test watering a plant using a nutrient preset."""
         preset = await preset_coordinator.services.config.save_nutrient_preset(
-            name="Test Preset", nutrients=[{"nutrient_id": "id-calmag", "dose_ml_l": 2.0}]
+            name="Test Preset",
+            nutrients=[{"nutrient_id": "id-calmag", "dose_ml_l": 2.0}],
         )
 
         # Water with 2.0L using preset (should result in 4.0ml CalMag)

--- a/tests/services/test_plant_cloning_handlers.py
+++ b/tests/services/test_plant_cloning_handlers.py
@@ -22,7 +22,9 @@ def coordinator() -> MagicMock:
     mock = MagicMock()
     mock.plants = {}
     mock.services = MagicMock()
-    mock.services.plants.take_clones = AsyncMock(return_value=[MagicMock(), MagicMock()])
+    mock.services.plants.take_clones = AsyncMock(
+        return_value=[MagicMock(), MagicMock()]
+    )
     mock.services.plants.promote_clone = AsyncMock()
     return mock
 
@@ -58,7 +60,9 @@ async def test_take_clone_raises_when_mother_missing(coordinator: MagicMock) -> 
 
 
 @pytest.mark.asyncio
-async def test_take_clone_raises_when_num_clones_not_positive(coordinator: MagicMock) -> None:
+async def test_take_clone_raises_when_num_clones_not_positive(
+    coordinator: MagicMock,
+) -> None:
     """Handler rejects non-positive num_clones before touching the coordinator."""
     coordinator.plants["m1"] = MagicMock()
     call = MagicMock()
@@ -88,5 +92,7 @@ async def test_move_clone_raises_when_ids_missing(coordinator: MagicMock) -> Non
     call = MagicMock()
     call.data = {ATTR_PLANT_ID: "clone1"}
 
-    with pytest.raises(ServiceValidationError, match="Missing plant_id or target_growspace_id"):
+    with pytest.raises(
+        ServiceValidationError, match="Missing plant_id or target_growspace_id"
+    ):
         await handle_move_clone(MagicMock(), coordinator, MagicMock(), call)

--- a/tests/services/test_plant_lifecycle_handlers.py
+++ b/tests/services/test_plant_lifecycle_handlers.py
@@ -27,7 +27,9 @@ def coordinator() -> MagicMock:
 
 
 @pytest.mark.asyncio
-async def test_transition_plant_stage_delegates_to_facade(coordinator: MagicMock) -> None:
+async def test_transition_plant_stage_delegates_to_facade(
+    coordinator: MagicMock,
+) -> None:
     """Handler passes plant_id and new_stage to the facade."""
     coordinator.plants["p1"] = MagicMock()
     call = MagicMock()
@@ -43,7 +45,9 @@ async def test_transition_plant_stage_delegates_to_facade(coordinator: MagicMock
 
 
 @pytest.mark.asyncio
-async def test_transition_plant_stage_raises_when_plant_missing(coordinator: MagicMock) -> None:
+async def test_transition_plant_stage_raises_when_plant_missing(
+    coordinator: MagicMock,
+) -> None:
     """Handler raises ServiceValidationError when plant_id is not in coordinator."""
     call = MagicMock()
     call.data = {ATTR_PLANT_ID: "ghost", ATTR_NEW_STAGE: "flower"}
@@ -76,7 +80,9 @@ async def test_harvest_plant_delegates_to_facade(coordinator: MagicMock) -> None
 
 
 @pytest.mark.asyncio
-async def test_harvest_plant_raises_when_plant_id_missing(coordinator: MagicMock) -> None:
+async def test_harvest_plant_raises_when_plant_id_missing(
+    coordinator: MagicMock,
+) -> None:
     """Harvest handler raises when plant_id field is absent from call data."""
     call = MagicMock()
     call.data = {}

--- a/tests/services/test_plant_metrics_service.py
+++ b/tests/services/test_plant_metrics_service.py
@@ -1,4 +1,5 @@
 """Tests for Growspace Manager plant metrics services."""
+
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/services/test_plant_scoring.py
+++ b/tests/services/test_plant_scoring.py
@@ -32,7 +32,9 @@ def mock_strain_library():
 
 def test_score_plant_schema_accepts_null_scores():
     """Schema must accept None for score fields (frontend sends null for unset scores)."""
-    result = SCORE_PLANT_SCHEMA({"plant_id": "abc", "vigor": None, "internodal_spacing": None})
+    result = SCORE_PLANT_SCHEMA(
+        {"plant_id": "abc", "vigor": None, "internodal_spacing": None}
+    )
     assert result["vigor"] is None
     assert result["internodal_spacing"] is None
 

--- a/tests/services/test_plant_services.py
+++ b/tests/services/test_plant_services.py
@@ -1243,7 +1243,9 @@ async def test_move_plant_exception(
     """Test exception handling in move_plant."""
     mock_coordinator.plants = {"plant_1": mock_plant}
     mock_coordinator.growspaces = {"gs1": mock_growspace}
-    mock_coordinator._plant_manager.move_plant.side_effect = GrowspaceError("Test error")
+    mock_coordinator._plant_manager.move_plant.side_effect = GrowspaceError(
+        "Test error"
+    )
     mock_coordinator.get_growspace_plants = Mock(return_value=[mock_plant])
 
     call = ServiceCall(

--- a/tests/services/test_plant_spatial_handlers.py
+++ b/tests/services/test_plant_spatial_handlers.py
@@ -64,7 +64,9 @@ async def test_switch_plants_raises_when_plant2_missing(coordinator: MagicMock) 
 
 
 @pytest.mark.asyncio
-async def test_move_plant_to_empty_position_delegates_move(coordinator: MagicMock) -> None:
+async def test_move_plant_to_empty_position_delegates_move(
+    coordinator: MagicMock,
+) -> None:
     """When target position is empty, calls move_plant on the facade."""
     plant = MagicMock(row=1, col=1, growspace_id="gs1", strain="Test")
     coordinator.plants = {"p1": plant}

--- a/tests/services/test_print_label_rework.py
+++ b/tests/services/test_print_label_rework.py
@@ -56,6 +56,7 @@ def _niimbot_density(mock_hass: MagicMock) -> int:
 # Tracer bullet: logo field
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_logo_excluded_when_fields_logo_false(
     mock_hass: MagicMock,
@@ -67,11 +68,13 @@ async def test_logo_excluded_when_fields_logo_false(
         "custom_components.growspace_manager.services.strain_library.get_url",
         return_value="http://ha.local",
     ):
-        call = _make_call({
-            "strain": "Vitamin Z",
-            "breeder_logo": "data:image/png;base64,abc",
-            "fields": {"logo": False},
-        })
+        call = _make_call(
+            {
+                "strain": "Vitamin Z",
+                "breeder_logo": "data:image/png;base64,abc",
+                "fields": {"logo": False},
+            }
+        )
         await handle_print_label(mock_hass, mock_coordinator, mock_strain_library, call)
 
     payload = _niimbot_payload(mock_hass)
@@ -82,6 +85,7 @@ async def test_logo_excluded_when_fields_logo_false(
 # ---------------------------------------------------------------------------
 # Field visibility: QR code
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_qr_excluded_when_fields_qr_false(
@@ -133,6 +137,7 @@ async def test_qr_included_by_default_when_plant_id_present(
 # Field visibility: multiline info rows (phenotype, breeder, lineage)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_phenotype_excluded_from_multiline_when_fields_phenotype_false(
     mock_hass: MagicMock,
@@ -144,11 +149,13 @@ async def test_phenotype_excluded_from_multiline_when_fields_phenotype_false(
         "custom_components.growspace_manager.services.strain_library.get_url",
         return_value="http://ha.local",
     ):
-        call = _make_call({
-            "strain": "Vitamin Z",
-            "phenotype": "S1",
-            "fields": {"phenotype": False},
-        })
+        call = _make_call(
+            {
+                "strain": "Vitamin Z",
+                "phenotype": "S1",
+                "fields": {"phenotype": False},
+            }
+        )
         await handle_print_label(mock_hass, mock_coordinator, mock_strain_library, call)
 
     payload = _niimbot_payload(mock_hass)
@@ -171,10 +178,12 @@ async def test_logo_included_by_default_when_breeder_logo_present(
         "custom_components.growspace_manager.services.strain_library.get_url",
         return_value="http://ha.local",
     ):
-        call = _make_call({
-            "strain": "Vitamin Z",
-            "breeder_logo": "data:image/png;base64,abc",
-        })
+        call = _make_call(
+            {
+                "strain": "Vitamin Z",
+                "breeder_logo": "data:image/png;base64,abc",
+            }
+        )
         await handle_print_label(mock_hass, mock_coordinator, mock_strain_library, call)
 
     payload = _niimbot_payload(mock_hass)
@@ -184,6 +193,7 @@ async def test_logo_included_by_default_when_breeder_logo_present(
 # ---------------------------------------------------------------------------
 # Density mapping
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_density_low_maps_to_3(
@@ -252,6 +262,7 @@ async def test_density_defaults_to_5_when_absent(
 # ---------------------------------------------------------------------------
 # QR target URL
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_qr_target_web_uses_ha_base_url(

--- a/tests/services/test_print_label_size_scaling.py
+++ b/tests/services/test_print_label_size_scaling.py
@@ -124,13 +124,17 @@ async def test_explicit_50x30_matches_default_output(
 ) -> None:
     """Explicit label_size='50x30' produces the same output as omitting label_size."""
     call_default = _make_call({"strain": "Blue Dream"})
-    await handle_print_label(mock_hass, mock_coordinator, mock_strain_library, call_default)
+    await handle_print_label(
+        mock_hass, mock_coordinator, mock_strain_library, call_default
+    )
     sd_default = _niimbot_service_data(mock_hass)
 
     mock_hass.services.async_call.reset_mock()
 
     call_explicit = _make_call({"strain": "Blue Dream", "label_size": "50x30"})
-    await handle_print_label(mock_hass, mock_coordinator, mock_strain_library, call_explicit)
+    await handle_print_label(
+        mock_hass, mock_coordinator, mock_strain_library, call_explicit
+    )
     sd_explicit = _niimbot_service_data(mock_hass)
 
     assert sd_explicit["width"] == sd_default["width"]

--- a/tests/services/test_seedfinder_scraper.py
+++ b/tests/services/test_seedfinder_scraper.py
@@ -540,9 +540,7 @@ async def test_async_get_strain_details_comp_overrides_metrics(
 
 
 def test_parse_basic_info_with_h1_and_breeder(scraper: SeedfinderScraper) -> None:
-    soup = _soup(
-        '<h1>Blue Dream</h1><a href="/breeder/humboldt/">Humboldt Seed Co</a>'
-    )
+    soup = _soup('<h1>Blue Dream</h1><a href="/breeder/humboldt/">Humboldt Seed Co</a>')
     name, breeder = scraper._parse_basic_info(soup)
     assert name == "Blue Dream"
     assert breeder == "Humboldt Seed Co"
@@ -569,7 +567,7 @@ def test_parse_basic_info_no_breeder_link(scraper: SeedfinderScraper) -> None:
 
 def test_parse_image_alpine_absolute(scraper: SeedfinderScraper) -> None:
     soup = _soup(
-        '<img :src="selectedIndex === -1 ? \'https://cdn.example.com/img.jpg\' : images[selectedIndex].big" />'
+        "<img :src=\"selectedIndex === -1 ? 'https://cdn.example.com/img.jpg' : images[selectedIndex].big\" />"
     )
     url = scraper._parse_image(soup, "Strain")
     assert url == "https://cdn.example.com/img.jpg"
@@ -577,7 +575,7 @@ def test_parse_image_alpine_absolute(scraper: SeedfinderScraper) -> None:
 
 def test_parse_image_alpine_relative(scraper: SeedfinderScraper) -> None:
     soup = _soup(
-        '<img :src="selectedIndex === -1 ? \'/storage/pics/img.jpg\' : images[selectedIndex].big" />'
+        "<img :src=\"selectedIndex === -1 ? '/storage/pics/img.jpg' : images[selectedIndex].big\" />"
     )
     url = scraper._parse_image(soup, "Strain")
     assert url == f"{BASE_URL}/storage/pics/img.jpg"
@@ -606,7 +604,7 @@ def test_parse_image_alpine_404_placeholder_returns_none(
 ) -> None:
     """Alpine.js :src with =404 placeholder is rejected."""
     soup = _soup(
-        '<img :src="selectedIndex === -1 ? \'/storage/pics/00breeder/=404\' : images[selectedIndex].big" />'
+        "<img :src=\"selectedIndex === -1 ? '/storage/pics/00breeder/=404' : images[selectedIndex].big\" />"
     )
     url = scraper._parse_image(soup, "Strain")
     assert url is None
@@ -626,7 +624,9 @@ def test_parse_image_fallback_src_404_placeholder_returns_none(
 # ---------------------------------------------------------------------------
 
 
-def test_parse_composition_sativa_indica_percentages(scraper: SeedfinderScraper) -> None:
+def test_parse_composition_sativa_indica_percentages(
+    scraper: SeedfinderScraper,
+) -> None:
     soup = _soup(
         "<h2>Basic Strain Information</h2><div>70% sativa, 30% indica text here</div>"
     )
@@ -683,25 +683,19 @@ def test_parse_composition_pure_sativa(scraper: SeedfinderScraper) -> None:
 
 
 def test_parse_composition_indicadominiert(scraper: SeedfinderScraper) -> None:
-    soup = _soup(
-        "<h2>Grundlegende Information</h2><div>indicadominiert pflanze</div>"
-    )
+    soup = _soup("<h2>Grundlegende Information</h2><div>indicadominiert pflanze</div>")
     data = scraper._parse_composition(soup)
     assert data["indica"] == 70
 
 
 def test_parse_composition_reine_indica(scraper: SeedfinderScraper) -> None:
-    soup = _soup(
-        "<h2>Grundlegende Information</h2><div>reine indica pflanze</div>"
-    )
+    soup = _soup("<h2>Grundlegende Information</h2><div>reine indica pflanze</div>")
     data = scraper._parse_composition(soup)
     assert data["indica"] == 100
 
 
 def test_parse_composition_reine_sativa(scraper: SeedfinderScraper) -> None:
-    soup = _soup(
-        "<h2>Grundlegende Information</h2><div>reine sativa pflanze</div>"
-    )
+    soup = _soup("<h2>Grundlegende Information</h2><div>reine sativa pflanze</div>")
     data = scraper._parse_composition(soup)
     assert data["sativa"] == 100
 
@@ -1121,7 +1115,7 @@ def test_parse_lineage_to_tree_generic_term_skipped(
 ) -> None:
     """Generic terms trigger fallback to other links in the li."""
     soup = _soup(
-        '<li>'
+        "<li>"
         '<a class="font-bold" href="/a/">specified above »»»</a>'
         '<a href="/strain-info/real-strain/">Real Strain</a>'
         "</li>"
@@ -1166,9 +1160,7 @@ def test_parse_lineage_to_tree_nested_parents(scraper: SeedfinderScraper) -> Non
 def test_parse_lineage_to_tree_strips_arrows_and_brackets(
     scraper: SeedfinderScraper,
 ) -> None:
-    soup = _soup(
-        '<li><a class="font-bold" href="/s/">Name [auto] (clone) »»»</a></li>'
-    )
+    soup = _soup('<li><a class="font-bold" href="/s/">Name [auto] (clone) »»»</a></li>')
     li = soup.find("li")
     result = scraper._parse_lineage_to_tree(li)
     assert result["name"] == "Name"
@@ -1312,7 +1304,9 @@ def test_parse_recursive_partial_paren_not_stripped(
 # ---------------------------------------------------------------------------
 
 
-def test_parse_images_extracts_full_gallery_from_alpine_xdata(scraper: SeedfinderScraper) -> None:
+def test_parse_images_extracts_full_gallery_from_alpine_xdata(
+    scraper: SeedfinderScraper,
+) -> None:
     """_parse_images returns all gallery URLs from Alpine.js x-data, not just the first."""
     html = """
     <div x-data='{"selectedIndex": -1, "images": [{"big": "https://cdn.example.com/1.jpg", "thumb": "https://cdn.example.com/1t.jpg"}, {"big": "https://cdn.example.com/2.jpg", "thumb": "https://cdn.example.com/2t.jpg"}, {"big": "/storage/pics/3.jpg", "thumb": "/storage/pics/3t.jpg"}]}'>
@@ -1328,7 +1322,9 @@ def test_parse_images_extracts_full_gallery_from_alpine_xdata(scraper: Seedfinde
     ]
 
 
-def test_parse_images_extracts_galerie_img_tags_when_no_xdata(scraper: SeedfinderScraper) -> None:
+def test_parse_images_extracts_galerie_img_tags_when_no_xdata(
+    scraper: SeedfinderScraper,
+) -> None:
     """_parse_images collects all /storage/pics/galerie/ img tags (older pages like Sunset Paradise)."""
     html = """
     <a href="/gallery/1"><img src="/storage/pics/galerie/Paradise_Seeds/Sunset_Paradise/img1.jpg" alt="1"></a>
@@ -1369,22 +1365,28 @@ def test_parse_images_caps_at_10(scraper: SeedfinderScraper) -> None:
     assert len(urls) == 10
 
 
-def test_parse_images_falls_back_to_parse_image_when_no_galerie(scraper: SeedfinderScraper) -> None:
+def test_parse_images_falls_back_to_parse_image_when_no_galerie(
+    scraper: SeedfinderScraper,
+) -> None:
     """_parse_images falls back to the single-image path when no galerie tags found."""
-    html = '<img :src="selectedIndex === -1 ? \'https://cdn.example.com/official.jpg\' : images[selectedIndex].big" />'
+    html = "<img :src=\"selectedIndex === -1 ? 'https://cdn.example.com/official.jpg' : images[selectedIndex].big\" />"
     soup = _soup(html)
     urls = scraper._parse_images(soup)
     assert urls == ["https://cdn.example.com/official.jpg"]
 
 
-def test_parse_images_returns_empty_list_when_no_images(scraper: SeedfinderScraper) -> None:
+def test_parse_images_returns_empty_list_when_no_images(
+    scraper: SeedfinderScraper,
+) -> None:
     """_parse_images returns [] when no image data is found at all."""
     soup = _soup("<div>no images here</div>")
     urls = scraper._parse_images(soup)
     assert urls == []
 
 
-def test_parse_images_alpine_js_syntax_unquoted_keys(scraper: SeedfinderScraper) -> None:
+def test_parse_images_alpine_js_syntax_unquoted_keys(
+    scraper: SeedfinderScraper,
+) -> None:
     """Strategy 1 works when x-data uses JS object literal syntax (unquoted keys, single quotes)."""
     html = """
     <div x-data="{selectedIndex: -1, images: [{big: 'https://cdn.example.com/1.jpg'}, {big: '/storage/pics/galerie/B/S/2.jpg'}]}">

--- a/tests/services/test_strain_ancestry.py
+++ b/tests/services/test_strain_ancestry.py
@@ -70,8 +70,16 @@ def test_collect_ancestors_single_level() -> None:
     node = {
         "name": "Gelato",
         "parents": [
-            {"name": "Thin Mint GSC", "url": "https://seedfinder.eu/tmc", "parents": []},
-            {"name": "Sunset Sherbet", "url": "https://seedfinder.eu/ss", "parents": []},
+            {
+                "name": "Thin Mint GSC",
+                "url": "https://seedfinder.eu/tmc",
+                "parents": [],
+            },
+            {
+                "name": "Sunset Sherbet",
+                "url": "https://seedfinder.eu/ss",
+                "parents": [],
+            },
         ],
     }
     result = _collect_ancestors(node)
@@ -150,7 +158,11 @@ async def test_ancestry_populated_on_add_strain(strain_library: StrainLibrary) -
         "name": "Gelato",
         "url": None,
         "parents": [
-            {"name": "Thin Mint GSC", "url": "https://seedfinder.eu/tmc", "parents": []},
+            {
+                "name": "Thin Mint GSC",
+                "url": "https://seedfinder.eu/tmc",
+                "parents": [],
+            },
             {"name": "Sunset Sherbet", "url": None, "parents": []},
         ],
     }
@@ -229,7 +241,9 @@ async def test_ancestry_not_populated_without_lineage_tree(
     """Adding a strain without lineage_tree leaves ancestry table empty."""
     await strain_library.add_strain("Blue Dream")
 
-    async with strain_library._db.execute("SELECT COUNT(*) as n FROM strain_ancestry") as cursor:
+    async with strain_library._db.execute(
+        "SELECT COUNT(*) as n FROM strain_ancestry"
+    ) as cursor:
         row = await cursor.fetchone()
 
     assert row["n"] == 0
@@ -268,7 +282,9 @@ async def test_get_strains_by_ancestor(strain_library: StrainLibrary) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_strains_by_ancestor_returns_depth(strain_library: StrainLibrary) -> None:
+async def test_get_strains_by_ancestor_returns_depth(
+    strain_library: StrainLibrary,
+) -> None:
     """Result includes depth field indicating how far the ancestor is."""
     tree = {
         "name": "Gelato",

--- a/tests/services/test_strain_library.py
+++ b/tests/services/test_strain_library.py
@@ -992,12 +992,21 @@ async def test_analytics_snapshot(strain_library: StrainLibrary, snapshot) -> No
 
 # --- Image Gallery ---
 
+
 @pytest.mark.asyncio
 async def test_add_strain_with_images_gallery(strain_library: StrainLibrary) -> None:
     """Phenotype data contains the full images array after add_strain with images."""
     images = [
-        {"path": "/local/growspace_manager/strains/og-kush_default_a.webp", "crop_meta": None, "is_thumbnail": True},
-        {"path": "/local/growspace_manager/strains/og-kush_default_b.webp", "crop_meta": {"x": 50, "y": 50, "scale": 1.2}, "is_thumbnail": False},
+        {
+            "path": "/local/growspace_manager/strains/og-kush_default_a.webp",
+            "crop_meta": None,
+            "is_thumbnail": True,
+        },
+        {
+            "path": "/local/growspace_manager/strains/og-kush_default_b.webp",
+            "crop_meta": {"x": 50, "y": 50, "scale": 1.2},
+            "is_thumbnail": False,
+        },
     ]
 
     await strain_library.add_strain(strain="OG Kush", images=images)
@@ -1025,7 +1034,9 @@ async def test_images_gallery_replace_all(strain_library: StrainLibrary) -> None
 
 
 @pytest.mark.asyncio
-async def test_migration_image_path_to_images_gallery(strain_library: StrainLibrary) -> None:
+async def test_migration_image_path_to_images_gallery(
+    strain_library: StrainLibrary,
+) -> None:
     """Phenotypes with image_path but no images get migrated to the gallery format on load."""
     # Simulate pre-gallery data: insert directly into DB leaving images NULL
     await strain_library._db.execute(
@@ -1048,31 +1059,50 @@ async def test_migration_image_path_to_images_gallery(strain_library: StrainLibr
     pheno = strain_library.strains["Blue Dream"]["phenotypes"]["default"]
     assert "images" in pheno
     assert len(pheno["images"]) == 1
-    assert pheno["images"][0]["path"] == "/local/growspace_manager/strains/blue-dream.webp"
+    assert (
+        pheno["images"][0]["path"] == "/local/growspace_manager/strains/blue-dream.webp"
+    )
     assert pheno["images"][0]["is_thumbnail"] is True
     assert pheno["images"][0]["crop_meta"] == {"x": 50, "y": 50, "scale": 1.0}
 
 
 # --- Thumbnail resolution ---
 
+
 @pytest.mark.asyncio
 async def test_resolve_thumbnail_own_images(strain_library: StrainLibrary) -> None:
     """resolve_thumbnail returns the thumbnail entry from the phenotype's own gallery."""
     images = [
         {"path": "/local/a.webp", "crop_meta": None, "is_thumbnail": False},
-        {"path": "/local/b.webp", "crop_meta": {"x": 30, "y": 70, "scale": 1.1}, "is_thumbnail": True},
+        {
+            "path": "/local/b.webp",
+            "crop_meta": {"x": 30, "y": 70, "scale": 1.1},
+            "is_thumbnail": True,
+        },
     ]
     await strain_library.add_strain(strain="OG Kush", images=images)
 
     thumbnail = strain_library.resolve_thumbnail("OG Kush", "default")
-    assert thumbnail == {"path": "/local/b.webp", "crop_meta": {"x": 30, "y": 70, "scale": 1.1}, "is_thumbnail": True}
+    assert thumbnail == {
+        "path": "/local/b.webp",
+        "crop_meta": {"x": 30, "y": 70, "scale": 1.1},
+        "is_thumbnail": True,
+    }
 
 
 @pytest.mark.asyncio
-async def test_resolve_thumbnail_falls_back_to_default_phenotype(strain_library: StrainLibrary) -> None:
+async def test_resolve_thumbnail_falls_back_to_default_phenotype(
+    strain_library: StrainLibrary,
+) -> None:
     """resolve_thumbnail falls back to 'default' sibling when phenotype has no images."""
-    default_image = {"path": "/local/default.webp", "crop_meta": None, "is_thumbnail": True}
-    await strain_library.add_strain(strain="OG Kush", phenotype=None, images=[default_image])
+    default_image = {
+        "path": "/local/default.webp",
+        "crop_meta": None,
+        "is_thumbnail": True,
+    }
+    await strain_library.add_strain(
+        strain="OG Kush", phenotype=None, images=[default_image]
+    )
     await strain_library.add_strain(strain="OG Kush", phenotype="Pheno A")
 
     thumbnail = strain_library.resolve_thumbnail("OG Kush", "Pheno A")
@@ -1080,11 +1110,15 @@ async def test_resolve_thumbnail_falls_back_to_default_phenotype(strain_library:
 
 
 @pytest.mark.asyncio
-async def test_resolve_thumbnail_falls_back_alphabetical_when_no_default(strain_library: StrainLibrary) -> None:
+async def test_resolve_thumbnail_falls_back_alphabetical_when_no_default(
+    strain_library: StrainLibrary,
+) -> None:
     """resolve_thumbnail falls back alphabetically when 'default' has no images."""
     bravo_image = {"path": "/local/bravo.webp", "crop_meta": None, "is_thumbnail": True}
     await strain_library.add_strain(strain="OG Kush", phenotype="Bravo")
-    await strain_library.add_strain(strain="OG Kush", phenotype="Alpha", images=[bravo_image])
+    await strain_library.add_strain(
+        strain="OG Kush", phenotype="Alpha", images=[bravo_image]
+    )
     await strain_library.add_strain(strain="OG Kush", phenotype="Zeta")
 
     # Zeta has no images, default has no images — should get Alpha's thumbnail (first alphabetically)
@@ -1093,6 +1127,7 @@ async def test_resolve_thumbnail_falls_back_alphabetical_when_no_default(strain_
 
 
 # --- Additional Targeted Coverage Tests ---
+
 
 @pytest.mark.asyncio
 async def test_db_migration_harvests_columns(mock_hass, mock_image_manager) -> None:
@@ -1142,7 +1177,6 @@ async def test_db_migration_harvests_columns(mock_hass, mock_image_manager) -> N
         await library.async_close()
 
 
-
 @pytest.mark.asyncio
 async def test_async_migrate_image_gallery_no_db(mock_hass: MagicMock) -> None:
     """Verify that _async_migrate_image_gallery exits early when db is None."""
@@ -1153,16 +1187,22 @@ async def test_async_migrate_image_gallery_no_db(mock_hass: MagicMock) -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_migrate_image_gallery_operational_error(strain_library: StrainLibrary) -> None:
+async def test_async_migrate_image_gallery_operational_error(
+    strain_library: StrainLibrary,
+) -> None:
     """Verify that _async_migrate_image_gallery handles operational error gracefully."""
     with patch.object(
-        strain_library._db, "execute", side_effect=aiosqlite.OperationalError("Mock database error")
+        strain_library._db,
+        "execute",
+        side_effect=aiosqlite.OperationalError("Mock database error"),
     ):
         await strain_library._async_migrate_image_gallery()
 
 
 @pytest.mark.asyncio
-async def test_async_migrate_image_gallery_invalid_crop_json(strain_library: StrainLibrary) -> None:
+async def test_async_migrate_image_gallery_invalid_crop_json(
+    strain_library: StrainLibrary,
+) -> None:
     """Verify that _async_migrate_image_gallery handles invalid crop JSON gracefully."""
     await strain_library._db.execute(
         "INSERT OR IGNORE INTO strains (strain_name) VALUES (?)", ("Blue Dream",)
@@ -1209,13 +1249,17 @@ async def test_load_with_invalid_images_json(strain_library: StrainLibrary) -> N
 
 
 @pytest.mark.asyncio
-async def test_resolve_thumbnail_nonexistent_strain(strain_library: StrainLibrary) -> None:
+async def test_resolve_thumbnail_nonexistent_strain(
+    strain_library: StrainLibrary,
+) -> None:
     """Verify resolve_thumbnail returns None when strain does not exist."""
     assert strain_library.resolve_thumbnail("Nonexistent Strain", "default") is None
 
 
 @pytest.mark.asyncio
-async def test_resolve_thumbnail_no_thumbnail_fallback(strain_library: StrainLibrary) -> None:
+async def test_resolve_thumbnail_no_thumbnail_fallback(
+    strain_library: StrainLibrary,
+) -> None:
     """Verify resolve_thumbnail falls back to the first image when no thumbnail is specified."""
     images = [
         {"path": "/local/first.webp", "crop_meta": None, "is_thumbnail": False},

--- a/tests/services/test_strain_library_refinements.py
+++ b/tests/services/test_strain_library_refinements.py
@@ -16,6 +16,7 @@ def mock_hass():
     hass.async_add_executor_job = AsyncMock(side_effect=lambda f, *args: f(*args))
     return hass
 
+
 @pytest.fixture
 def mock_image_manager():
     """Fixture for a mock ImageManager."""
@@ -26,6 +27,7 @@ def mock_image_manager():
     manager.async_setup = AsyncMock()
     return manager
 
+
 @pytest.fixture
 def mock_import_export_manager():
     """Fixture for a mock ImportExportManager."""
@@ -33,6 +35,7 @@ def mock_import_export_manager():
     manager.export_library = AsyncMock(return_value="/path/to/export.zip")
     manager.import_library = AsyncMock(return_value={})
     return manager
+
 
 @pytest.fixture
 async def strain_library(mock_hass, mock_image_manager, mock_import_export_manager):
@@ -43,14 +46,24 @@ async def strain_library(mock_hass, mock_image_manager, mock_import_export_manag
         return await real_connect(":memory:", **kwargs)
 
     with (
-        patch("custom_components.growspace_manager.strain_library.ImageManager", return_value=mock_image_manager),
-        patch("custom_components.growspace_manager.strain_library.ImportExportManager", return_value=mock_import_export_manager),
-        patch("custom_components.growspace_manager.strain_library.aiosqlite.connect", side_effect=mock_connect),
+        patch(
+            "custom_components.growspace_manager.strain_library.ImageManager",
+            return_value=mock_image_manager,
+        ),
+        patch(
+            "custom_components.growspace_manager.strain_library.ImportExportManager",
+            return_value=mock_import_export_manager,
+        ),
+        patch(
+            "custom_components.growspace_manager.strain_library.aiosqlite.connect",
+            side_effect=mock_connect,
+        ),
     ):
         library = StrainLibrary(mock_hass)
         await library.async_setup()
         yield library
         await library.async_close()
+
 
 @pytest.mark.asyncio
 async def test_add_strain_0_percentages(strain_library: StrainLibrary) -> None:
@@ -91,16 +104,18 @@ async def test_add_strain_0_percentages(strain_library: StrainLibrary) -> None:
     assert meta["sativa_percentage"] == 0
     assert meta["indica_percentage"] == 100
 
+
 @pytest.mark.asyncio
-async def test_export_filters_stubs(strain_library: StrainLibrary, mock_import_export_manager) -> None:
+async def test_export_filters_stubs(
+    strain_library: StrainLibrary, mock_import_export_manager
+) -> None:
     """Test that is_stub strains are excluded from exports."""
     # Add a real strain
     await strain_library.add_strain(strain="Real Strain", breeder="Real")
 
     # Add a stub strain (simulating ancestor resolution)
     await strain_library._db.execute(
-        "INSERT INTO strains (strain_name, is_stub) VALUES (?, ?)",
-        ("Stub Strain", 1)
+        "INSERT INTO strains (strain_name, is_stub) VALUES (?, ?)", ("Stub Strain", 1)
     )
     await strain_library._db.commit()
     await strain_library.load()

--- a/tests/services/test_tank_monitor.py
+++ b/tests/services/test_tank_monitor.py
@@ -155,9 +155,7 @@ async def test_no_subscription_for_growspace_without_environment_config(
 ) -> None:
     """Growspace with no EnvironmentConfig registers no state listeners."""
     coordinator = MagicMock()
-    coordinator.growspaces = {
-        "gs_noenv": Growspace(id="gs_noenv", name="No Env")
-    }
+    coordinator.growspaces = {"gs_noenv": Growspace(id="gs_noenv", name="No Env")}
     monitor = TankLevelMonitor(hass, coordinator, notify)
     callbacks = await _start_and_get_callback(monitor)
 

--- a/tests/test_briefing_scheduler.py
+++ b/tests/test_briefing_scheduler.py
@@ -21,6 +21,7 @@ from homeassistant.util import dt as dt_util
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(autouse=True)
 def patch_store():
     """Patch Store so construction doesn't require a real hass instance."""
@@ -36,7 +37,9 @@ def mock_hass() -> MagicMock:
     """Minimal Home Assistant mock."""
     hass = MagicMock(spec=HomeAssistant)
     hass.loop = asyncio.get_event_loop()
-    hass.async_create_task = MagicMock(side_effect=lambda coro: asyncio.ensure_future(coro))
+    hass.async_create_task = MagicMock(
+        side_effect=lambda coro: asyncio.ensure_future(coro)
+    )
     return hass
 
 
@@ -61,6 +64,7 @@ def mock_coordinator(mock_hass: MagicMock) -> MagicMock:
 # Cycle 1 — Initialisation
 # ---------------------------------------------------------------------------
 
+
 def test_briefing_scheduler_initializes(
     mock_hass: MagicMock, mock_coordinator: MagicMock
 ) -> None:
@@ -73,6 +77,7 @@ def test_briefing_scheduler_initializes(
 # ---------------------------------------------------------------------------
 # Cycle 2 — Interval trigger
 # ---------------------------------------------------------------------------
+
 
 def test_start_registers_interval_listener(
     mock_hass: MagicMock, mock_coordinator: MagicMock
@@ -118,8 +123,16 @@ async def test_interval_callback_generates_briefing(
     scheduler._store.async_save = AsyncMock()
 
     with patch.object(
-        scheduler, "_generate_briefing", new_callable=AsyncMock,
-        return_value={"generated_at": 1234.0, "summary_text": "All good", "ai_available": True, "kpis": [], "recommendations": []}
+        scheduler,
+        "_generate_briefing",
+        new_callable=AsyncMock,
+        return_value={
+            "generated_at": 1234.0,
+            "summary_text": "All good",
+            "ai_available": True,
+            "kpis": [],
+            "recommendations": [],
+        },
     ) as mock_gen:
         await scheduler._async_on_interval(None)
 
@@ -132,12 +145,14 @@ async def test_interval_callback_generates_briefing(
 # Cycle 3 — Entity event trigger + debounce
 # ---------------------------------------------------------------------------
 
+
 def test_start_registers_entity_listener_when_entities_configured(
     mock_hass: MagicMock, mock_coordinator: MagicMock
 ) -> None:
     """start() registers async_track_state_change_event when trigger entities are set."""
     mock_coordinator.options["ai_settings"]["briefing_trigger_entities"] = [
-        "binary_sensor.tent1_door", "binary_sensor.tent2_door"
+        "binary_sensor.tent1_door",
+        "binary_sensor.tent2_door",
     ]
     scheduler = BriefingScheduler(mock_hass, mock_coordinator)
 
@@ -253,6 +268,7 @@ async def test_rapid_entity_changes_are_debounced(
 # Cycle 4 — Manual refresh (force_refresh=True)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_get_briefing_force_refresh_bypasses_cache(
     mock_hass: MagicMock, mock_coordinator: MagicMock
@@ -262,12 +278,26 @@ async def test_get_briefing_force_refresh_bypasses_cache(
     scheduler._store = MagicMock()
     scheduler._store.async_save = AsyncMock()
 
-    stale = {"generated_at": 1.0, "summary_text": "Stale", "ai_available": False, "kpis": [], "recommendations": []}
-    fresh = {"generated_at": 2.0, "summary_text": "Fresh", "ai_available": True, "kpis": [], "recommendations": []}
+    stale = {
+        "generated_at": 1.0,
+        "summary_text": "Stale",
+        "ai_available": False,
+        "kpis": [],
+        "recommendations": [],
+    }
+    fresh = {
+        "generated_at": 2.0,
+        "summary_text": "Fresh",
+        "ai_available": True,
+        "kpis": [],
+        "recommendations": [],
+    }
 
     scheduler._cached_briefing = stale
 
-    with patch.object(scheduler, "_generate_briefing", new_callable=AsyncMock, return_value=fresh):
+    with patch.object(
+        scheduler, "_generate_briefing", new_callable=AsyncMock, return_value=fresh
+    ):
         result = await scheduler.async_get_briefing(force_refresh=True)
 
     assert result["summary_text"] == "Fresh"
@@ -281,10 +311,18 @@ async def test_get_briefing_returns_cache_when_available(
     scheduler = BriefingScheduler(mock_hass, mock_coordinator)
     scheduler._store = MagicMock()
 
-    cached = {"generated_at": 999.0, "summary_text": "Cached", "ai_available": True, "kpis": [], "recommendations": []}
+    cached = {
+        "generated_at": 999.0,
+        "summary_text": "Cached",
+        "ai_available": True,
+        "kpis": [],
+        "recommendations": [],
+    }
     scheduler._cached_briefing = cached
 
-    with patch.object(scheduler, "_generate_briefing", new_callable=AsyncMock) as mock_gen:
+    with patch.object(
+        scheduler, "_generate_briefing", new_callable=AsyncMock
+    ) as mock_gen:
         result = await scheduler.async_get_briefing(force_refresh=False)
 
     mock_gen.assert_not_called()
@@ -297,11 +335,19 @@ async def test_get_briefing_loads_from_store_when_no_cache(
 ) -> None:
     """get_briefing() loads persisted briefing from Store when in-memory cache is cold."""
     scheduler = BriefingScheduler(mock_hass, mock_coordinator)
-    stored = {"generated_at": 50.0, "summary_text": "Stored", "ai_available": True, "kpis": [], "recommendations": []}
+    stored = {
+        "generated_at": 50.0,
+        "summary_text": "Stored",
+        "ai_available": True,
+        "kpis": [],
+        "recommendations": [],
+    }
     scheduler._store = MagicMock()
     scheduler._store.async_load = AsyncMock(return_value=stored)
 
-    with patch.object(scheduler, "_generate_briefing", new_callable=AsyncMock) as mock_gen:
+    with patch.object(
+        scheduler, "_generate_briefing", new_callable=AsyncMock
+    ) as mock_gen:
         result = await scheduler.async_get_briefing(force_refresh=False)
 
     mock_gen.assert_not_called()
@@ -332,7 +378,9 @@ async def test_get_briefing_discards_stored_briefing_with_old_kpis_format(
     scheduler._store.async_load = AsyncMock(return_value=old_format)
     scheduler._store.async_save = AsyncMock()
 
-    with patch.object(scheduler, "_generate_briefing", new_callable=AsyncMock, return_value=fresh) as mock_gen:
+    with patch.object(
+        scheduler, "_generate_briefing", new_callable=AsyncMock, return_value=fresh
+    ) as mock_gen:
         result = await scheduler.async_get_briefing(force_refresh=False)
 
     mock_gen.assert_called_once()
@@ -342,6 +390,7 @@ async def test_get_briefing_discards_stored_briefing_with_old_kpis_format(
 # ---------------------------------------------------------------------------
 # Cycle 5 — AI unavailable → Bayesian fallback
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_generate_briefing_ai_unavailable_returns_bayesian(
@@ -411,6 +460,7 @@ async def test_generate_briefing_includes_required_fields(
 # Cycle 6 — Listener cleanup on unload
 # ---------------------------------------------------------------------------
 
+
 def test_async_stop_cancels_all_listeners(
     mock_hass: MagicMock, mock_coordinator: MagicMock
 ) -> None:
@@ -456,6 +506,7 @@ def test_async_stop_is_idempotent(
 # Cycle 7 — Bayesian summary content
 # ---------------------------------------------------------------------------
 
+
 def _make_sensor_state(active: bool, reasons: list[str]) -> MagicMock:
     state = MagicMock()
     state.state = "on" if active else "off"
@@ -475,7 +526,9 @@ def _setup_bayesian_states(
 
     states = {
         f"binary_sensor.{DOMAIN}_{growspace_id}_stress": _make_sensor_state(*stress),
-        f"binary_sensor.{DOMAIN}_{growspace_id}_mold_risk": _make_sensor_state(*mold_risk),
+        f"binary_sensor.{DOMAIN}_{growspace_id}_mold_risk": _make_sensor_state(
+            *mold_risk
+        ),
         f"binary_sensor.{DOMAIN}_{growspace_id}_optimal": _make_sensor_state(*optimal),
     }
     mock_hass.states = MagicMock()
@@ -571,6 +624,7 @@ def test_bayesian_summary_mold_risk_active_detected(
 # Cycle 8 — _read_bayesian_states with real sensor state
 # ---------------------------------------------------------------------------
 
+
 def test_read_bayesian_states_returns_active_true_when_sensor_on(
     mock_hass: MagicMock, mock_coordinator: MagicMock
 ) -> None:
@@ -596,6 +650,7 @@ def test_read_bayesian_states_returns_active_true_when_sensor_on(
 # ---------------------------------------------------------------------------
 # Cycle 9 — _collect_kpis with growspace VPD + water data
 # ---------------------------------------------------------------------------
+
 
 def test_collect_kpis_includes_avg_vpd_from_growspace_env_state(
     mock_hass: MagicMock, mock_coordinator: MagicMock
@@ -664,6 +719,7 @@ def test_collect_kpis_includes_water_use_when_nonzero(
 # Cycle 10 — _generate_briefing AI success path
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_generate_briefing_ai_success_returns_ai_available_true(
     mock_hass: MagicMock, mock_coordinator: MagicMock
@@ -676,7 +732,17 @@ async def test_generate_briefing_ai_success_returns_ai_available_true(
         scheduler,
         "_generate_ai_content",
         new_callable=AsyncMock,
-        return_value=("Plants are thriving.", [{"title": "Water now", "description": "Plants need water.", "impact": "high", "suggested_action": {}}]),
+        return_value=(
+            "Plants are thriving.",
+            [
+                {
+                    "title": "Water now",
+                    "description": "Plants need water.",
+                    "impact": "high",
+                    "suggested_action": {},
+                }
+            ],
+        ),
     ):
         briefing = await scheduler._generate_briefing()
 
@@ -689,6 +755,7 @@ async def test_generate_briefing_ai_success_returns_ai_available_true(
 # Cycle 11 — _generate_ai_content response parsing
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_generate_ai_content_parses_summary_and_recommendations(
     mock_hass: MagicMock, mock_coordinator: MagicMock
@@ -696,7 +763,14 @@ async def test_generate_ai_content_parses_summary_and_recommendations(
     """_generate_ai_content parses SUMMARY: and RECOMMENDATIONS: from AI speech."""
     import json
 
-    recs = [{"title": "Lower VPD", "description": "VPD is above target range.", "impact": "high", "suggested_action": {}}]
+    recs = [
+        {
+            "title": "Lower VPD",
+            "description": "VPD is above target range.",
+            "impact": "high",
+            "suggested_action": {},
+        }
+    ]
     speech_text = f"SUMMARY: All healthy. RECOMMENDATIONS: {json.dumps(recs)}"
 
     mock_result = MagicMock()

--- a/tests/test_genetics_manager.py
+++ b/tests/test_genetics_manager.py
@@ -43,18 +43,22 @@ def manager(save_callback: AsyncMock) -> GeneticsManager:
 def manager_with_plants(save_callback: AsyncMock) -> GeneticsManager:
     """GeneticsManager with two plants pre-loaded (donor + receiver)."""
     repo = GrowspaceRepository()
-    repo.add_plant(Plant(
-        plant_id="plant-donor",
-        growspace_id="gs-1",
-        genetics=PlantGenetics(strain_name="Pollen Donor"),
-        stage="flower",
-    ))
-    repo.add_plant(Plant(
-        plant_id="plant-receiver",
-        growspace_id="gs-1",
-        genetics=PlantGenetics(strain_name="Female Receiver"),
-        stage="flower",
-    ))
+    repo.add_plant(
+        Plant(
+            plant_id="plant-donor",
+            growspace_id="gs-1",
+            genetics=PlantGenetics(strain_name="Pollen Donor"),
+            stage="flower",
+        )
+    )
+    repo.add_plant(
+        Plant(
+            plant_id="plant-receiver",
+            growspace_id="gs-1",
+            genetics=PlantGenetics(strain_name="Female Receiver"),
+            stage="flower",
+        )
+    )
     return GeneticsManager(repository=repo, save_callback=save_callback)
 
 
@@ -386,7 +390,9 @@ class TestLogPollination:
     ) -> None:
         """log_pollination raises if receiver plant has already been harvested."""
 
-        manager_with_plants.repository.require_plant("plant-receiver").stage = "harvested"
+        manager_with_plants.repository.require_plant(
+            "plant-receiver"
+        ).stage = "harvested"
 
         with pytest.raises(ServiceValidationError, match="harvested"):
             await manager_with_plants.async_log_pollination(
@@ -553,12 +559,14 @@ class TestScorePhenotype:
     def manager_with_plant(self, save_callback: AsyncMock) -> GeneticsManager:
         """GeneticsManager with a single scoreable plant."""
         repo = GrowspaceRepository()
-        repo.add_plant(Plant(
-            plant_id="plant-score",
-            growspace_id="gs",
-            genetics=PlantGenetics(strain_name="Test"),
-            stage="flower",
-        ))
+        repo.add_plant(
+            Plant(
+                plant_id="plant-score",
+                growspace_id="gs",
+                genetics=PlantGenetics(strain_name="Test"),
+                stage="flower",
+            )
+        )
         return GeneticsManager(repository=repo, save_callback=save_callback)
 
     async def test_updates_phenotype_score_fields(
@@ -689,18 +697,22 @@ class TestUpdatePollination:
     @pytest.fixture
     def manager_with_event(self, manager: GeneticsManager) -> GeneticsManager:
         """Manager pre-loaded with one pollination event and two plants."""
-        manager.repository.add_plant(Plant(
-            plant_id="plant-donor",
-            growspace_id="gs-1",
-            genetics=PlantGenetics(strain_name="Pollen Donor"),
-            stage="flower",
-        ))
-        manager.repository.add_plant(Plant(
-            plant_id="plant-receiver",
-            growspace_id="gs-1",
-            genetics=PlantGenetics(strain_name="Female Receiver"),
-            stage="flower",
-        ))
+        manager.repository.add_plant(
+            Plant(
+                plant_id="plant-donor",
+                growspace_id="gs-1",
+                genetics=PlantGenetics(strain_name="Pollen Donor"),
+                stage="flower",
+            )
+        )
+        manager.repository.add_plant(
+            Plant(
+                plant_id="plant-receiver",
+                growspace_id="gs-1",
+                genetics=PlantGenetics(strain_name="Female Receiver"),
+                stage="flower",
+            )
+        )
         event = PollinationEvent(
             event_id="evt-1",
             date="2026-01-10",
@@ -753,19 +765,29 @@ class TestUpdatePollination:
                 event_id="nonexistent", date="2026-01-01"
             )
 
-    async def test_updates_donor_plant_id(self, manager_with_event: GeneticsManager) -> None:
+    async def test_updates_donor_plant_id(
+        self, manager_with_event: GeneticsManager
+    ) -> None:
         """Updating donor_plant_id changes the field."""
         await manager_with_event.async_update_pollination(
             event_id="evt-1", donor_plant_id="plant-donor"
         )
-        assert manager_with_event.pollination_events["evt-1"].donor_plant_id == "plant-donor"
+        assert (
+            manager_with_event.pollination_events["evt-1"].donor_plant_id
+            == "plant-donor"
+        )
 
-    async def test_updates_receiver_plant_id(self, manager_with_event: GeneticsManager) -> None:
+    async def test_updates_receiver_plant_id(
+        self, manager_with_event: GeneticsManager
+    ) -> None:
         """Updating receiver_plant_id changes the field."""
         await manager_with_event.async_update_pollination(
             event_id="evt-1", receiver_plant_id="plant-receiver"
         )
-        assert manager_with_event.pollination_events["evt-1"].receiver_plant_id == "plant-receiver"
+        assert (
+            manager_with_event.pollination_events["evt-1"].receiver_plant_id
+            == "plant-receiver"
+        )
 
     async def test_library_keyed_donor_accepted_on_update(
         self, manager_with_event: GeneticsManager
@@ -774,7 +796,10 @@ class TestUpdatePollination:
         await manager_with_event.async_update_pollination(
             event_id="evt-1", donor_plant_id="OG Kush||pheno-A"
         )
-        assert manager_with_event.pollination_events["evt-1"].donor_plant_id == "OG Kush||pheno-A"
+        assert (
+            manager_with_event.pollination_events["evt-1"].donor_plant_id
+            == "OG Kush||pheno-A"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -813,9 +838,9 @@ class TestDeletePollination:
         self, manager_with_event: GeneticsManager
     ) -> None:
         """Events with a linked seed batch can still be deleted."""
-        manager_with_event.pollination_events["evt-del"].result_seed_batch_id = (
-            "batch-xyz"
-        )
+        manager_with_event.pollination_events[
+            "evt-del"
+        ].result_seed_batch_id = "batch-xyz"
         await manager_with_event.async_delete_pollination(event_id="evt-del")
         assert "evt-del" not in manager_with_event.pollination_events
 
@@ -849,18 +874,22 @@ def manager_with_strain_lib(
 ) -> GeneticsManager:
     """GeneticsManager with two plants and injected StrainLibrary mock."""
     repo = GrowspaceRepository()
-    repo.add_plant(Plant(
-        plant_id="plant-donor",
-        growspace_id="gs-1",
-        genetics=PlantGenetics(strain_name="Pollen Donor"),
-        stage="flower",
-    ))
-    repo.add_plant(Plant(
-        plant_id="plant-receiver",
-        growspace_id="gs-1",
-        genetics=PlantGenetics(strain_name="Seed Mother"),
-        stage="flower",
-    ))
+    repo.add_plant(
+        Plant(
+            plant_id="plant-donor",
+            growspace_id="gs-1",
+            genetics=PlantGenetics(strain_name="Pollen Donor"),
+            stage="flower",
+        )
+    )
+    repo.add_plant(
+        Plant(
+            plant_id="plant-receiver",
+            growspace_id="gs-1",
+            genetics=PlantGenetics(strain_name="Seed Mother"),
+            stage="flower",
+        )
+    )
     return GeneticsManager(
         repository=repo,
         save_callback=save_callback,
@@ -900,18 +929,22 @@ async def test_harvest_seeds_not_misclassified_as_bx_due_to_prior_event(
     event and treat the donor as a parent of the receiver, producing BX instead of F1.
     """
     repo = GrowspaceRepository()
-    repo.add_plant(Plant(
-        plant_id="plant-a",
-        growspace_id="gs-1",
-        genetics=PlantGenetics(strain_name="Strain A"),
-        stage="flower",
-    ))
-    repo.add_plant(Plant(
-        plant_id="plant-b",
-        growspace_id="gs-1",
-        genetics=PlantGenetics(strain_name="Strain B"),
-        stage="flower",
-    ))
+    repo.add_plant(
+        Plant(
+            plant_id="plant-a",
+            growspace_id="gs-1",
+            genetics=PlantGenetics(strain_name="Strain A"),
+            stage="flower",
+        )
+    )
+    repo.add_plant(
+        Plant(
+            plant_id="plant-b",
+            growspace_id="gs-1",
+            genetics=PlantGenetics(strain_name="Strain B"),
+            stage="flower",
+        )
+    )
     mgr = GeneticsManager(
         repository=repo,
         save_callback=save_callback,
@@ -1073,10 +1106,13 @@ async def test_update_seed_batch_reclassifies_on_parent_change(
 @pytest.mark.parametrize(
     ("key", "expected"),
     [
-        ("plain-plant-id", "plain-plant-id"),          # no separator → return as-is
-        ("Gorilla Glue||default", "Gorilla Glue"),     # default phenotype → strain only
-        ("Gorilla Glue||", "Gorilla Glue"),            # empty phenotype → strain only
-        ("Gorilla Glue||#4", "Gorilla Glue (#4)"),     # named phenotype → strain (phenotype)
+        ("plain-plant-id", "plain-plant-id"),  # no separator → return as-is
+        ("Gorilla Glue||default", "Gorilla Glue"),  # default phenotype → strain only
+        ("Gorilla Glue||", "Gorilla Glue"),  # empty phenotype → strain only
+        (
+            "Gorilla Glue||#4",
+            "Gorilla Glue (#4)",
+        ),  # named phenotype → strain (phenotype)
     ],
 )
 def test_parse_strain_library_key(key: str, expected: str) -> None:
@@ -1094,12 +1130,14 @@ class TestSowSeed:
     @pytest.fixture
     def manager_with_batch_and_plant(self, save_callback: AsyncMock) -> GeneticsManager:
         repo = GrowspaceRepository()
-        repo.add_plant(Plant(
-            plant_id="plant-1",
-            growspace_id="gs-1",
-            genetics=PlantGenetics(strain_name="OG Kush"),
-            stage="seedling",
-        ))
+        repo.add_plant(
+            Plant(
+                plant_id="plant-1",
+                growspace_id="gs-1",
+                genetics=PlantGenetics(strain_name="OG Kush"),
+                stage="seedling",
+            )
+        )
         mgr = GeneticsManager(repository=repo, save_callback=save_callback)
         mgr.seed_batches["batch-1"] = SeedBatch(
             batch_id="batch-1",
@@ -1164,12 +1202,14 @@ class TestSetPlantSex:
     @pytest.fixture
     def manager_with_plant(self, save_callback: AsyncMock) -> GeneticsManager:
         repo = GrowspaceRepository()
-        repo.add_plant(Plant(
-            plant_id="plant-1",
-            growspace_id="gs-1",
-            genetics=PlantGenetics(strain_name="Blue Dream"),
-            stage="veg",
-        ))
+        repo.add_plant(
+            Plant(
+                plant_id="plant-1",
+                growspace_id="gs-1",
+                genetics=PlantGenetics(strain_name="Blue Dream"),
+                stage="veg",
+            )
+        )
         return GeneticsManager(repository=repo, save_callback=save_callback)
 
     async def test_sets_sex_and_saves(
@@ -1243,18 +1283,22 @@ class TestGetLineageTree:
     def manager_with_cross(self, save_callback: AsyncMock) -> GeneticsManager:
         """Manager with a donor, a receiver, and one pollination event linking them."""
         repo = GrowspaceRepository()
-        repo.add_plant(Plant(
-            plant_id="donor-1",
-            growspace_id="gs-1",
-            genetics=PlantGenetics(strain_name="Pollen Donor"),
-            stage="flower",
-        ))
-        repo.add_plant(Plant(
-            plant_id="receiver-1",
-            growspace_id="gs-1",
-            genetics=PlantGenetics(strain_name="Female Receiver"),
-            stage="flower",
-        ))
+        repo.add_plant(
+            Plant(
+                plant_id="donor-1",
+                growspace_id="gs-1",
+                genetics=PlantGenetics(strain_name="Pollen Donor"),
+                stage="flower",
+            )
+        )
+        repo.add_plant(
+            Plant(
+                plant_id="receiver-1",
+                growspace_id="gs-1",
+                genetics=PlantGenetics(strain_name="Female Receiver"),
+                stage="flower",
+            )
+        )
         mgr = GeneticsManager(repository=repo, save_callback=save_callback)
         mgr.pollination_events["evt-1"] = PollinationEvent(
             event_id="evt-1",

--- a/tests/test_genetics_services.py
+++ b/tests/test_genetics_services.py
@@ -616,8 +616,8 @@ class TestHandleDeletePollination:
         genetics_manager: AsyncMock,
     ) -> None:
         """ServiceValidationError from manager propagates to caller."""
-        genetics_manager.async_delete_pollination.side_effect = (
-            ServiceValidationError("Pollination event 'x' not found")
+        genetics_manager.async_delete_pollination.side_effect = ServiceValidationError(
+            "Pollination event 'x' not found"
         )
         call = _make_call(event_id="x")
         with pytest.raises(ServiceValidationError, match="not found"):
@@ -775,4 +775,3 @@ class TestHandleUnlinkSeedBatch:
         )
         with pytest.raises(ServiceValidationError, match="not found"):
             await handle_unlink_seed_batch(mock_hass, mock_coordinator, call)
-

--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -74,7 +74,9 @@ def test_rgb_to_hsv_ocv_pure_red_outside_green_band():
     arr = np.array([[[220, 20, 20]]], dtype=np.uint8)
     hsv = _rgb_to_hsv_ocv(arr)
     h = int(hsv[0, 0, 0])
-    assert not (_GREEN_LOWER[0] <= h <= _GREEN_UPPER[0]), f"Red hue {h} should not be in green range"
+    assert not (_GREEN_LOWER[0] <= h <= _GREEN_UPPER[0]), (
+        f"Red hue {h} should not be in green range"
+    )
 
 
 def test_rgb_to_hsv_ocv_gray_low_saturation():
@@ -82,7 +84,9 @@ def test_rgb_to_hsv_ocv_gray_low_saturation():
     arr = np.array([[[128, 128, 128]]], dtype=np.uint8)
     hsv = _rgb_to_hsv_ocv(arr)
     s = int(hsv[0, 0, 1])
-    assert s < _GREEN_LOWER[1], f"Gray saturation {s} should be below green floor {_GREEN_LOWER[1]}"
+    assert s < _GREEN_LOWER[1], (
+        f"Gray saturation {s} should be below green floor {_GREEN_LOWER[1]}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -254,7 +258,10 @@ def test_process_snapshot_old_pillow_font_fallback():
             raise TypeError("load_default() got an unexpected keyword argument 'size'")
         return original_load_default()
 
-    with patch("custom_components.growspace_manager.image_processor.ImageFont.load_default", side_effect=_raise_on_size):
+    with patch(
+        "custom_components.growspace_manager.image_processor.ImageFont.load_default",
+        side_effect=_raise_on_size,
+    ):
         out_bytes, _ = GrowspaceImageProcessor().process_snapshot(data)
 
     assert len(out_bytes) > 0

--- a/tests/test_lineage_classifier.py
+++ b/tests/test_lineage_classifier.py
@@ -1,4 +1,5 @@
 """Tests for lineage_classifier — pure functions, no HA dependencies."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -12,6 +13,7 @@ from custom_components.growspace_manager.managers.lineage_classifier import (
 # ---------------------------------------------------------------------------
 # _parse_generation
 # ---------------------------------------------------------------------------
+
 
 def test_parse_generation_f2():
     assert _parse_generation("F2") == ("F", 2)
@@ -40,6 +42,7 @@ def test_parse_generation_lowercase():
 # ---------------------------------------------------------------------------
 # _is_ancestor
 # ---------------------------------------------------------------------------
+
 
 def test_is_ancestor_direct_parent():
     tree = {"name": "Child", "parents": [{"name": "Parent A", "parents": []}]}
@@ -82,6 +85,7 @@ def test_is_ancestor_empty_parents():
 # classify_lineage — selfing (Sx)
 # ---------------------------------------------------------------------------
 
+
 def test_classify_s1_same_name():
     tree = {"name": "Strain A", "parents": [], "generation": ""}
     assert classify_lineage("Strain A", "Strain A", tree, tree) == "S1"
@@ -115,6 +119,7 @@ def test_classify_s1_takes_priority_over_ancestor_check():
 # classify_lineage — backcrossing (BXx)
 # ---------------------------------------------------------------------------
 
+
 def test_classify_bx1_parent_is_direct_ancestor_of_child():
     mother_tree = {"name": "OG Kush", "parents": [], "generation": ""}
     f1_tree = {
@@ -140,7 +145,9 @@ def test_classify_bx1_child_is_crossed_to_grandparent():
         ],
         "generation": "F2",
     }
-    assert classify_lineage("Skunk #1", "Deep Cross", grandparent_tree, f2_tree) == "BX1"
+    assert (
+        classify_lineage("Skunk #1", "Deep Cross", grandparent_tree, f2_tree) == "BX1"
+    )
 
 
 def test_classify_bx2_from_bx1_progeny():
@@ -186,6 +193,7 @@ def test_classify_bx1_legacy_bx_string_treated_as_bx1():
 # ---------------------------------------------------------------------------
 # classify_lineage — filial generations (Fx)
 # ---------------------------------------------------------------------------
+
 
 def test_classify_f2_siblings_share_identical_parents():
     sibling_a = {
@@ -289,6 +297,7 @@ def test_classify_f2_not_triggered_when_parents_differ():
 # ---------------------------------------------------------------------------
 # classify_lineage — outcross (F1)
 # ---------------------------------------------------------------------------
+
 
 def test_classify_f1_no_shared_ancestry():
     tree_a = {"name": "OG Kush", "parents": [], "generation": ""}

--- a/tests/test_photoperiod_flip_checker.py
+++ b/tests/test_photoperiod_flip_checker.py
@@ -32,7 +32,9 @@ def mock_coordinator(mock_hass: MagicMock) -> MagicMock:
 
     created_coroutines = []
 
-    def async_create_background_task(hass: HomeAssistant, coro: object, name: str) -> MagicMock:
+    def async_create_background_task(
+        hass: HomeAssistant, coro: object, name: str
+    ) -> MagicMock:
         created_coroutines.append(coro)
         return MagicMock()
 
@@ -61,7 +63,9 @@ def _make_growspace(
     gs.notification_target = notification_target
     gs.irrigation_strategy.auto_light_tracking = auto_light_tracking
     gs.environment_config.growlight_config.enabled = growlight_active
-    gs.environment_config.growlight_entities = ["switch.grow"] if growlight_active else []
+    gs.environment_config.growlight_entities = (
+        ["switch.grow"] if growlight_active else []
+    )
     gs.environment_config.growlight_ac_infinity_devices = []
     return gs
 
@@ -110,7 +114,9 @@ async def test_notification_sent_when_flower_start_is_today(
         await _run_immediate_check(mock_coordinator)
 
     mock_coordinator.services.notifications.manager.async_send_notification.assert_called_once()
-    _, kwargs = mock_coordinator.services.notifications.manager.async_send_notification.call_args
+    _, kwargs = (
+        mock_coordinator.services.notifications.manager.async_send_notification.call_args
+    )
     assert kwargs["tier"] == NotificationTier.PHOTOPERIOD_FLIP
 
 
@@ -257,24 +263,30 @@ async def test_midnight_callback_reschedules_for_next_day(
         captured_callback = cb
         return MagicMock()
 
-    with patch(
-        "custom_components.growspace_manager.photoperiod_flip_checker.async_track_point_in_utc_time",
-        side_effect=capture_timer,
-    ), patch(
-        "custom_components.growspace_manager.photoperiod_flip_checker.ha_now",
-        return_value=TODAY_DT,
+    with (
+        patch(
+            "custom_components.growspace_manager.photoperiod_flip_checker.async_track_point_in_utc_time",
+            side_effect=capture_timer,
+        ),
+        patch(
+            "custom_components.growspace_manager.photoperiod_flip_checker.ha_now",
+            return_value=TODAY_DT,
+        ),
     ):
         checker.schedule_growspace("tent1")
 
     assert captured_callback is not None
 
     # Fire the midnight callback; it should re-register a new timer
-    with patch(
-        "custom_components.growspace_manager.photoperiod_flip_checker.async_track_point_in_utc_time",
-        side_effect=capture_timer,
-    ), patch(
-        "custom_components.growspace_manager.photoperiod_flip_checker.ha_now",
-        return_value=TODAY_DT,
+    with (
+        patch(
+            "custom_components.growspace_manager.photoperiod_flip_checker.async_track_point_in_utc_time",
+            side_effect=capture_timer,
+        ),
+        patch(
+            "custom_components.growspace_manager.photoperiod_flip_checker.ha_now",
+            return_value=TODAY_DT,
+        ),
     ):
         await captured_callback(TODAY_DT)
 
@@ -299,12 +311,15 @@ def test_schedule_all_growspaces_registers_timer_per_growspace(
 
     checker = PhotoperiodFlipChecker(mock_hass, mock_coordinator)
 
-    with patch(
-        "custom_components.growspace_manager.photoperiod_flip_checker.async_track_point_in_utc_time",
-        return_value=MagicMock(),
-    ), patch(
-        "custom_components.growspace_manager.photoperiod_flip_checker.ha_now",
-        return_value=TODAY_DT,
+    with (
+        patch(
+            "custom_components.growspace_manager.photoperiod_flip_checker.async_track_point_in_utc_time",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "custom_components.growspace_manager.photoperiod_flip_checker.ha_now",
+            return_value=TODAY_DT,
+        ),
     ):
         checker.schedule_all_growspaces()
 
@@ -321,12 +336,15 @@ def test_async_stop_cancels_all_timers(
     unsub = MagicMock()
     checker = PhotoperiodFlipChecker(mock_hass, mock_coordinator)
 
-    with patch(
-        "custom_components.growspace_manager.photoperiod_flip_checker.async_track_point_in_utc_time",
-        return_value=unsub,
-    ), patch(
-        "custom_components.growspace_manager.photoperiod_flip_checker.ha_now",
-        return_value=TODAY_DT,
+    with (
+        patch(
+            "custom_components.growspace_manager.photoperiod_flip_checker.async_track_point_in_utc_time",
+            return_value=unsub,
+        ),
+        patch(
+            "custom_components.growspace_manager.photoperiod_flip_checker.ha_now",
+            return_value=TODAY_DT,
+        ),
     ):
         checker.schedule_all_growspaces()
 
@@ -427,7 +445,9 @@ async def test_midnight_callback_handles_exception(
 
     checker = PhotoperiodFlipChecker(mock_hass, mock_coordinator)
 
-    with patch.object(checker, "_check_growspace", side_effect=ValueError("Test exception")):
+    with patch.object(
+        checker, "_check_growspace", side_effect=ValueError("Test exception")
+    ):
         callback = checker._create_callback("tent1")
 
         with (

--- a/tests/test_strain_lineage_tree.py
+++ b/tests/test_strain_lineage_tree.py
@@ -6,6 +6,7 @@ import pytest
 @pytest.mark.asyncio
 async def test_update_strain_lineage_tree_stores_parents_and_derives_flat_lineage():
     from custom_components.growspace_manager.strain_library import StrainLibrary
+
     hass = MagicMock()
     hass.config.path.return_value = "/tmp/test_strain_lib.db"
     lib = StrainLibrary(hass)
@@ -26,9 +27,11 @@ async def test_update_strain_lineage_tree_stores_parents_and_derives_flat_lineag
     sql_calls = [str(c) for c in call_args]
     assert any("lineage_tree" in s for s in sql_calls)
 
+
 @pytest.mark.asyncio
 async def test_update_strain_lineage_tree_single_parent():
     from custom_components.growspace_manager.strain_library import StrainLibrary
+
     hass = MagicMock()
     hass.config.path.return_value = "/tmp/test_strain_lib.db"
     lib = StrainLibrary(hass)
@@ -41,9 +44,11 @@ async def test_update_strain_lineage_tree_single_parent():
     result = await lib.update_strain_lineage_tree("Mystery", parents)
     assert result == "OG Kush"
 
+
 @pytest.mark.asyncio
 async def test_update_strain_lineage_tree_empty_parents():
     from custom_components.growspace_manager.strain_library import StrainLibrary
+
     hass = MagicMock()
     hass.config.path.return_value = "/tmp/test_strain_lib.db"
     lib = StrainLibrary(hass)
@@ -65,22 +70,32 @@ async def test_update_strain_lineage_tree_no_db_returns_empty():
     lib = StrainLibrary(hass)
     lib._db = None
 
-    result = await lib.update_strain_lineage_tree("X", [{"name": "Y", "source": "manual"}])
+    result = await lib.update_strain_lineage_tree(
+        "X", [{"name": "Y", "source": "manual"}]
+    )
     assert result == ""
 
 
 def test_get_strain_lineage_tree_no_lineage_tree():
     from custom_components.growspace_manager.strain_library import StrainLibrary
+
     hass = MagicMock()
     hass.config.path.return_value = "/tmp/test.db"
     lib = StrainLibrary(hass)
     lib.strains = {"OG Kush": {"meta": {}, "phenotypes": {}}}
 
     result = lib.get_strain_lineage_tree("OG Kush")
-    assert result == {"name": "OG Kush", "source": "library", "parents": [], "generation": ""}
+    assert result == {
+        "name": "OG Kush",
+        "source": "library",
+        "parents": [],
+        "generation": "",
+    }
+
 
 def test_get_strain_lineage_tree_resolves_library_parents():
     from custom_components.growspace_manager.strain_library import StrainLibrary
+
     hass = MagicMock()
     hass.config.path.return_value = "/tmp/test.db"
     lib = StrainLibrary(hass)
@@ -104,25 +119,37 @@ def test_get_strain_lineage_tree_resolves_library_parents():
     assert result["parents"][0]["name"] == "Sunset Sherbet"
     assert result["parents"][0]["parents"] == []
 
+
 def test_get_strain_lineage_tree_cycle_protection():
     from custom_components.growspace_manager.strain_library import StrainLibrary
+
     hass = MagicMock()
     hass.config.path.return_value = "/tmp/test.db"
     lib = StrainLibrary(hass)
     # A references B, B references A
     lib.strains = {
-        "A": {"meta": {"lineage_tree": [{"name": "B", "source": "library"}]}, "phenotypes": {}},
-        "B": {"meta": {"lineage_tree": [{"name": "A", "source": "library"}]}, "phenotypes": {}},
+        "A": {
+            "meta": {"lineage_tree": [{"name": "B", "source": "library"}]},
+            "phenotypes": {},
+        },
+        "B": {
+            "meta": {"lineage_tree": [{"name": "A", "source": "library"}]},
+            "phenotypes": {},
+        },
     }
     result = lib.get_strain_lineage_tree("A")
     # Should terminate without infinite recursion
     assert result["name"] == "A"
     assert result["parents"][0]["name"] == "B"
     # A appears as a leaf inside B (cycle caught by _seen at depth guard)
-    assert result["parents"][0]["parents"] == [{"name": "A", "source": "library", "parents": [], "generation": ""}]
+    assert result["parents"][0]["parents"] == [
+        {"name": "A", "source": "library", "parents": [], "generation": ""}
+    ]
+
 
 def test_get_strain_lineage_tree_manual_parent_is_leaf():
     from custom_components.growspace_manager.strain_library import StrainLibrary
+
     hass = MagicMock()
     hass.config.path.return_value = "/tmp/test.db"
     lib = StrainLibrary(hass)
@@ -137,10 +164,16 @@ def test_get_strain_lineage_tree_manual_parent_is_leaf():
         },
     }
     result = lib.get_strain_lineage_tree("Hybrid X")
-    assert result["parents"][0] == {"name": "OG Kush", "source": "manual", "parents": []}
+    assert result["parents"][0] == {
+        "name": "OG Kush",
+        "source": "manual",
+        "parents": [],
+    }
+
 
 def test_get_strain_names_returns_sorted_list():
     from custom_components.growspace_manager.strain_library import StrainLibrary
+
     hass = MagicMock()
     hass.config.path.return_value = "/tmp/test.db"
     lib = StrainLibrary(hass)
@@ -275,4 +308,6 @@ async def test_async_import_seedfinder_lineage_tree_noop_when_db_none():
     lib.strains = {}
 
     # Must not raise
-    await lib.async_import_seedfinder_lineage_tree("X", {"name": "X", "parents": [{"name": "Y", "parents": []}]})
+    await lib.async_import_seedfinder_lineage_tree(
+        "X", {"name": "X", "parents": [{"name": "Y", "parents": []}]}
+    )

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -293,35 +293,80 @@ def test_interpolate_value() -> None:
 
 def test_classify_stages() -> None:
     """Test classify_stages for all branches."""
+
     def sc(days: StageDays) -> tuple[BayesianStage, BayesianStage, float]:
         r = classify_stages(days)
         return r.stage_a, r.stage_b, r.factor
 
     # Flower — early (before transition window)
-    assert sc(StageDays(flower=10)) == (BayesianStage.FLOWER_EARLY, BayesianStage.FLOWER_EARLY, 0.0)
+    assert sc(StageDays(flower=10)) == (
+        BayesianStage.FLOWER_EARLY,
+        BayesianStage.FLOWER_EARLY,
+        0.0,
+    )
     # Flower — early→mid transition (window is 3, boundary is 21)
-    assert sc(StageDays(flower=20)) == (BayesianStage.FLOWER_EARLY, BayesianStage.FLOWER_MID, 0.67)
+    assert sc(StageDays(flower=20)) == (
+        BayesianStage.FLOWER_EARLY,
+        BayesianStage.FLOWER_MID,
+        0.67,
+    )
     # Flower — mid
-    assert sc(StageDays(flower=25)) == (BayesianStage.FLOWER_MID, BayesianStage.FLOWER_MID, 0.0)
+    assert sc(StageDays(flower=25)) == (
+        BayesianStage.FLOWER_MID,
+        BayesianStage.FLOWER_MID,
+        0.0,
+    )
     # Flower — mid→late transition (boundary is 42)
-    assert sc(StageDays(flower=41)) == (BayesianStage.FLOWER_MID, BayesianStage.FLOWER_LATE, 0.67)
+    assert sc(StageDays(flower=41)) == (
+        BayesianStage.FLOWER_MID,
+        BayesianStage.FLOWER_LATE,
+        0.67,
+    )
     # Flower — late
-    assert sc(StageDays(flower=50)) == (BayesianStage.FLOWER_LATE, BayesianStage.FLOWER_LATE, 0.0)
+    assert sc(StageDays(flower=50)) == (
+        BayesianStage.FLOWER_LATE,
+        BayesianStage.FLOWER_LATE,
+        0.0,
+    )
 
     # Veg — transition from seedling_standard (window is 3)
-    assert sc(StageDays(veg=1)) == (BayesianStage.SEEDLING_STANDARD, BayesianStage.VEG, 0.33)
+    assert sc(StageDays(veg=1)) == (
+        BayesianStage.SEEDLING_STANDARD,
+        BayesianStage.VEG,
+        0.33,
+    )
     # Veg — stable
     assert sc(StageDays(veg=5)) == (BayesianStage.VEG, BayesianStage.VEG, 0.0)
 
     # Seedling — acclimation (start=3, end=7)
-    assert sc(StageDays(seedling=2)) == (BayesianStage.SEEDLING, BayesianStage.SEEDLING, 0.0)
-    assert sc(StageDays(seedling=5)) == (BayesianStage.SEEDLING, BayesianStage.SEEDLING_STANDARD, 0.5)
-    assert sc(StageDays(seedling=8)) == (BayesianStage.SEEDLING_STANDARD, BayesianStage.SEEDLING_STANDARD, 0.0)
+    assert sc(StageDays(seedling=2)) == (
+        BayesianStage.SEEDLING,
+        BayesianStage.SEEDLING,
+        0.0,
+    )
+    assert sc(StageDays(seedling=5)) == (
+        BayesianStage.SEEDLING,
+        BayesianStage.SEEDLING_STANDARD,
+        0.5,
+    )
+    assert sc(StageDays(seedling=8)) == (
+        BayesianStage.SEEDLING_STANDARD,
+        BayesianStage.SEEDLING_STANDARD,
+        0.0,
+    )
 
     # Clone — acclimation
     assert sc(StageDays(clone=2)) == (BayesianStage.CLONE, BayesianStage.CLONE, 0.0)
-    assert sc(StageDays(clone=5)) == (BayesianStage.CLONE, BayesianStage.CLONE_STANDARD, 0.5)
-    assert sc(StageDays(clone=8)) == (BayesianStage.CLONE_STANDARD, BayesianStage.CLONE_STANDARD, 0.0)
+    assert sc(StageDays(clone=5)) == (
+        BayesianStage.CLONE,
+        BayesianStage.CLONE_STANDARD,
+        0.5,
+    )
+    assert sc(StageDays(clone=8)) == (
+        BayesianStage.CLONE_STANDARD,
+        BayesianStage.CLONE_STANDARD,
+        0.0,
+    )
 
     # Empty — no plants at all (was previously VEG fallback)
     assert sc(StageDays()) == (BayesianStage.EMPTY, BayesianStage.EMPTY, 0.0)
@@ -335,17 +380,25 @@ def test_classify_stages() -> None:
 def test_classify_stages_display_stage() -> None:
     """Test display_stage collapses sub-stages and applies factor threshold."""
     # Sub-stage collapsing
-    assert classify_stages(StageDays(seedling=8)).display_stage == BayesianStage.SEEDLING
+    assert (
+        classify_stages(StageDays(seedling=8)).display_stage == BayesianStage.SEEDLING
+    )
     assert classify_stages(StageDays(clone=8)).display_stage == BayesianStage.CLONE
     assert classify_stages(StageDays(veg=5)).display_stage == BayesianStage.VEG
 
     # Factor < 0.5 → display stage_a (collapsed)
-    r = classify_stages(StageDays(seedling=5))  # factor=0.5, stage_a=SEEDLING, stage_b=SEEDLING_STANDARD
+    r = classify_stages(
+        StageDays(seedling=5)
+    )  # factor=0.5, stage_a=SEEDLING, stage_b=SEEDLING_STANDARD
     assert r.factor == 0.5
-    assert r.display_stage == BayesianStage.SEEDLING  # 0.5 >= 0.5 → stage_b, collapsed to SEEDLING
+    assert (
+        r.display_stage == BayesianStage.SEEDLING
+    )  # 0.5 >= 0.5 → stage_b, collapsed to SEEDLING
 
     # Factor >= 0.5 → stage_b
-    r = classify_stages(StageDays(flower=20))  # factor=0.67, stage_a=FLOWER_EARLY, stage_b=FLOWER_MID
+    r = classify_stages(
+        StageDays(flower=20)
+    )  # factor=0.67, stage_a=FLOWER_EARLY, stage_b=FLOWER_MID
     assert r.display_stage == BayesianStage.FLOWER_MID
 
     # Factor < 0.5 → stage_a


### PR DESCRIPTION
Mechanical reformat only — no behaviour change.

Pre-commit's `ruff-format` hook runs on changed files only, so files untouched for a while drifted out of format. This brings the whole tree back in line in one pass.

## Scope

140 files, all line-wrapping of long calls and signatures. `ruff format --check custom_components/ tests/` now reports 614 files already formatted.

## Safety

Every changed file's AST was compared against its previous version:

```
python files changed : 140
AST identical        : 140
AST DIFFERENT        : 0
parse errors         : 0
```

Byte-identical syntax trees — proof of zero semantic change, covering untested code too. Full suite re-run after the reformat: **5091 passed**.

## Ordering

Does not conflict with #(rm-scratch-file) — that branch touches only `scratch_mock_test.py` at the repo root, which is not among these 140 files. `git merge-tree` reports 0 conflicts. Merge this one first, as the larger diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)