### PR TITLE
fix(environment): count a singular sensor shadow once when aggregating

### DIFF
--- a/custom_components/growspace_manager/domain/environment_state_assembler.py
+++ b/custom_components/growspace_manager/domain/environment_state_assembler.py
@@ -50,6 +50,18 @@ class AssembledEnvironment:
     observations: dict[str, Any]
 
 
+def _sensor_ids(shadow: str | None, canonical: list[str]) -> list[str]:
+    """Merge a legacy singular field with its plural, counting each sensor once.
+
+    The Environment Patch re-derives the singular shadow from the head of the
+    plural list (ADR-0026), so the two overlap by construction: averaging both
+    would weight the first sensor double and pull every multi-sensor reading
+    toward it. Mirrors ``utils.read_environment_vpd``.
+    """
+
+    return list(dict.fromkeys(s for s in (shadow, *canonical) if s is not None))
+
+
 class EnvironmentStateAssembler:
     """Builds an :class:`EnvironmentState` for one growspace from HA states."""
 
@@ -78,22 +90,12 @@ class EnvironmentStateAssembler:
         config = self.env_config
 
         temp = self._aggregated_value(
-            [
-                s
-                for s in (config.temperature_sensor, *config.temperature_sensors)
-                if s is not None
-            ]
+            _sensor_ids(config.temperature_sensor, config.temperature_sensors)
         )
         humidity = self._aggregated_value(
-            [
-                s
-                for s in (config.humidity_sensor, *config.humidity_sensors)
-                if s is not None
-            ]
+            _sensor_ids(config.humidity_sensor, config.humidity_sensors)
         )
-        vpd = self._aggregated_value(
-            [s for s in (config.vpd_sensor, *config.vpd_sensors) if s is not None]
-        )
+        vpd = self._aggregated_value(_sensor_ids(config.vpd_sensor, config.vpd_sensors))
 
         # DRY/CURE spaces ignore the leaf-surface offset; there is no canopy.
         active_lst_offset = config.lst_offset

--- a/tests/domain/test_environment_state_assembler.py
+++ b/tests/domain/test_environment_state_assembler.py
@@ -93,6 +93,24 @@ def test_aggregated_value_averages_valid_readings() -> None:
     assert result.observations["temperature"] == pytest.approx(25.0)
 
 
+def test_singular_shadow_of_a_plural_list_is_counted_once() -> None:
+    """The shadow repeats the head of its list; averaging both would skew it.
+
+    This is the shape the Environment Patch actually writes: configuring
+    ``temperature_sensors`` re-derives ``temperature_sensor`` from its head.
+    """
+    config = EnvironmentConfig(
+        temperature_sensor="sensor.t1",
+        temperature_sensors=["sensor.t1", "sensor.t2"],
+    )
+    states = {"sensor.t1": FakeState("20"), "sensor.t2": FakeState("30")}
+
+    result = build_assembler(config, states).assemble()
+
+    assert result.state.temp == pytest.approx(25.0)
+    assert result.observations["temperature"] == pytest.approx(25.0)
+
+
 def test_unavailable_and_unknown_readings_are_skipped() -> None:
     """Unavailable/unknown/non-numeric sensors do not count toward the average."""
     config = EnvironmentConfig(


### PR DESCRIPTION
## What

`EnvironmentStateAssembler.assemble()` averaged the legacy singular sensor field together with its plural list. The Environment Patch re-derives `temperature_sensor` / `humidity_sensor` / `vpd_sensor` from the head of their plural list (ADR-0026), so for any growspace configured through the plural fields the same entity appears in both — and the first sensor got double weight.

Two temperature sensors reading 20 °C and 30 °C reported **23.33 °C** instead of 25 °C. Everything downstream of `observations` inherited the skew: Bayesian stress/mold/optimal evaluation, the notifications they raise, and the card's hero values.

The fix deduplicates the merged list — which `utils.read_environment_vpd` already does for the very same field pairs, so this restores an invariant the codebase already held elsewhere.

## How it was found

The multi-sensor E2E telemetry profile in [growspace_manager_workspace#18](https://github.com/Venosta-web/growspace_manager_workspace/issues/18) is the first fixture that configures a category with more than one sensor. Measured against the live dev runtime before the fix:

```
sensor.e2e_telemetry_multi_temperature_1 = 20.0
sensor.e2e_telemetry_multi_temperature_2 = 30.0
observations.temperature                 = 23.333333333333332   # (20 + 20 + 30) / 3
```

and after:

```
observations.temperature                 = 25.0
```

## Test

`test_singular_shadow_of_a_plural_list_is_counted_once` builds the config shape the patch seam actually writes (shadow == head of the list) and asserts 25.0. It fails on `prerelease` with exactly the 23.33 the runtime showed, and passes with the fix.

The pre-existing `test_aggregated_value_averages_valid_readings` passed only because it hand-builds a config where the shadow is *not* in the list — a state the write seam cannot produce.

`./scripts/check backend fast`: 5162 passed. (The repo's ruff/format failures on `prerelease` are pre-existing and untouched; the two files here are clean.)

## Landing order

Cross-repo, GSM-first: this releases before [lovelace-growspace-manager-card#TBD](https://github.com/Venosta-web/lovelace-growspace-manager-card), whose new E2E spec asserts the corrected aggregate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)