### PR TITLE
feat(vision): configure snapshot cadence by service

### DIFF
--- a/custom_components/growspace_manager/schemas.py
+++ b/custom_components/growspace_manager/schemas.py
@@ -105,6 +105,7 @@ from .const import (
     CONF_PORE_EC_SENSORS,
     CONF_POWER_SENSORS,
     CONF_RUNOFF_EC_SENSORS,
+    CONF_SNAPSHOT_INTERVAL,
     CONF_SOIL_MOISTURE_SENSOR,
     CONF_STRESS_THRESHOLD,
     CONF_SUBSTRATE_TEMP_SENSORS,
@@ -556,6 +557,9 @@ CONFIGURE_ENVIRONMENT_SCHEMA = vol.Schema(
         vol.Optional(CONF_SUBSTRATE_TEMP_SENSORS): cv.ensure_list,
         vol.Optional(CONF_LUNG_ROOM_TEMP_SENSORS): cv.ensure_list,
         vol.Optional(CONF_CAMERA_ENTITIES): cv.ensure_list,
+        vol.Optional(CONF_SNAPSHOT_INTERVAL): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=168)
+        ),
         # Advanced / irrigation monitoring sensors
         vol.Optional(CONF_PH_SENSORS): cv.ensure_list,
         vol.Optional(CONF_FEED_EC_SENSORS): cv.ensure_list,

--- a/custom_components/growspace_manager/services.yaml
+++ b/custom_components/growspace_manager/services.yaml
@@ -718,6 +718,24 @@ configure_environment:
       required: false
       selector:
         object:
+    camera_entities:
+      name: Camera Entities
+      description: Cameras used for snapshots and Vision Checkups.
+      required: false
+      selector:
+        entity:
+          domain: camera
+          multiple: true
+    snapshot_interval_hours:
+      name: Snapshot Interval
+      description: Hours between scheduled camera snapshots.
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 168
+          step: 1
+          unit_of_measurement: h
 
 remove_environment:
   description: Remove environment configuration for a growspace

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -54,6 +54,26 @@ def test_configure_environment_schema_supports_multi_entities() -> None:
     assert validated[CONF_EXHAUST_FAN_ENTITIES] == ["switch.exhaust1"]
 
 
+def test_configure_environment_schema_accepts_snapshot_interval() -> None:
+    """The service path can persist the camera snapshot cadence used by E2E setup."""
+    validated = CONFIGURE_ENVIRONMENT_SCHEMA(
+        {"growspace_id": "gs1", "snapshot_interval_hours": 6}
+    )
+
+    assert validated["snapshot_interval_hours"] == 6
+
+
+@pytest.mark.parametrize("value", [0, 169])
+def test_configure_environment_schema_rejects_invalid_snapshot_interval(
+    value: int,
+) -> None:
+    """Snapshot cadence uses the same one-week bounds as the config flow."""
+    with pytest.raises(vol.Invalid):
+        CONFIGURE_ENVIRONMENT_SCHEMA(
+            {"growspace_id": "gs1", "snapshot_interval_hours": value}
+        )
+
+
 def test_configure_environment_schema_accepts_vpd_optimal_overrides() -> None:
     """Test that CONFIGURE_ENVIRONMENT_SCHEMA accepts vpd_optimal_overrides."""
     payload = {


### PR DESCRIPTION
Summary:
- allow configure_environment to persist snapshot_interval_hours with the config-flow bounds
- document camera_entities and snapshot cadence in the Home Assistant service UI
- cover accepted and rejected cadence values

Validation:
- 5,165 backend tests passed
- mypy passed
- Ruff and changed-file formatting passed
- live Home Assistant setup persisted both cameras and snapshot_interval_hours: 6

Workspace issue: Venosta-web/growspace_manager_workspace#22

Merge order: backend first, then the card and workspace fixture PRs.