### PR TITLE
feat(climate): drive numeric fan speed entities

### DIFF
--- a/custom_components/growspace_manager/actuator_driver.py
+++ b/custom_components/growspace_manager/actuator_driver.py
@@ -33,6 +33,9 @@ _LOGGER = logging.getLogger(__name__)
 # On/off domains driven via turn_on/turn_off rather than by percentage.
 _SWITCH_DOMAINS = ("switch", "input_boolean")
 
+# Writable numeric entities use the card's documented 0-10 Fan Entity Mode.
+_SPEED_NUMBER_DOMAINS = ("input_number", "number")
+
 # Domains a binary on/off controller drives via their own turn_on/turn_off
 # service; any other domain falls back to the generic ``homeassistant`` service.
 _ON_OFF_NATIVE_DOMAINS = ("switch", "humidifier", "fan", "input_boolean")
@@ -210,6 +213,50 @@ class LightDriver:
         return state is not None and state.state == STATE_ON
 
 
+class NumberDriver:
+    """Drives a writable 0-10 numeric fan-speed entity.
+
+    Coordinators express demand as a percentage while the card's numeric Fan
+    Entity Mode deliberately exposes the device-native 0-10 speed index.  The
+    driver owns that translation so coordinators and presentation code keep
+    their existing units.
+    """
+
+    def __init__(self, hass: HomeAssistant, entity_id: str) -> None:
+        """Initialize the driver for an ``input_number`` or ``number`` entity."""
+        self._hass = hass
+        self._entity_id = entity_id
+        self._domain = entity_id.split(".", 1)[0]
+
+    async def set_speed(self, pct: int) -> None:
+        """Map a 0-100 percentage demand onto the 0-10 speed index."""
+        value = max(0, min(10, round(pct / 10)))
+        await _safe_service_call(
+            self._hass,
+            self._domain,
+            "set_value",
+            {ATTR_ENTITY_ID: self._entity_id, "value": value},
+        )
+
+    async def turn_on(self) -> None:
+        """Set the numeric speed to its maximum."""
+        await self.set_speed(100)
+
+    async def turn_off(self) -> None:
+        """Set the numeric speed to zero."""
+        await self.set_speed(0)
+
+    def is_on(self) -> bool:
+        """Return whether the current numeric speed is positive."""
+        state = self._hass.states.get(self._entity_id)
+        if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            return False
+        try:
+            return float(state.state) > 0
+        except ValueError:
+            return False
+
+
 def resolve_actuator_driver(
     hass: HomeAssistant, entity_id: str, *, switch_off_threshold: int = 0
 ) -> ActuatorDriver | None:
@@ -223,6 +270,8 @@ def resolve_actuator_driver(
         return FanDriver(hass, entity_id)
     if domain == "light":
         return LightDriver(hass, entity_id)
+    if domain in _SPEED_NUMBER_DOMAINS:
+        return NumberDriver(hass, entity_id)
     if domain in _SWITCH_DOMAINS:
         return SwitchDriver(hass, entity_id, off_threshold=switch_off_threshold)
     return None

--- a/tests/integration/test_actuator_driver.py
+++ b/tests/integration/test_actuator_driver.py
@@ -9,6 +9,7 @@ from custom_components.growspace_manager.actuator_driver import (
     FanDriver,
     GenericOnOffDriver,
     LightDriver,
+    NumberDriver,
     SwitchDriver,
     resolve_actuator_driver,
     resolve_actuator_drivers,
@@ -127,6 +128,8 @@ async def test_switch_driver_default_threshold_is_zero(mock_hass: MagicMock) -> 
     ("entity_id", "expected_type"),
     [
         ("fan.exhaust", FanDriver),
+        ("input_number.exhaust_speed", NumberDriver),
+        ("number.exhaust_speed", NumberDriver),
         ("switch.exhaust", SwitchDriver),
         ("input_boolean.damper", SwitchDriver),
     ],
@@ -162,6 +165,40 @@ async def test_safe_service_call_swallows_device_errors(
     mock_hass.services.async_call.side_effect = error
     await FanDriver(mock_hass, "fan.exhaust").set_speed(50)
     mock_hass.services.async_call.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "pct", "value"),
+    [
+        ("input_number.exhaust_speed", 0, 0),
+        ("input_number.exhaust_speed", 64, 6),
+        ("number.circulation_speed", 100, 10),
+    ],
+)
+async def test_number_driver_scales_percentage_to_speed_index(
+    mock_hass: MagicMock, entity_id: str, pct: int, value: int
+) -> None:
+    """Writable numeric fan entities receive the card's 0-10 speed index."""
+    await NumberDriver(mock_hass, entity_id).set_speed(pct)
+    domain = entity_id.split(".", 1)[0]
+    mock_hass.services.async_call.assert_awaited_once_with(
+        domain,
+        "set_value",
+        {ATTR_ENTITY_ID: entity_id, "value": value},
+        blocking=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("0", False), ("5", True), (STATE_UNKNOWN, False), ("not-a-number", False)],
+)
+async def test_number_driver_is_on_reads_positive_speed(
+    mock_hass: MagicMock, value: str, expected: bool
+) -> None:
+    """Numeric fan state is on only when it is available and above zero."""
+    mock_hass.states.get.return_value = _state(value)
+    assert NumberDriver(mock_hass, "input_number.fan_speed").is_on() is expected
 
 
 # ---------------------------------------------------------------------------
@@ -291,10 +328,20 @@ async def test_resolve_actuator_drivers_merges_and_skips_unsupported(
     """The aggregator yields a driver per plain entity and AC Infinity bundle."""
     drivers = resolve_actuator_drivers(
         mock_hass,
-        ["fan.exhaust", "switch.damper", "climate.unsupported"],
+        [
+            "fan.exhaust",
+            "input_number.exhaust_speed",
+            "switch.damper",
+            "climate.unsupported",
+        ],
         [ACInfinityDevice(mode_entity="select.m", speed_entity="number.s")],
     )
-    assert [type(d) for d in drivers] == [FanDriver, SwitchDriver, ACInfinityDriver]
+    assert [type(d) for d in drivers] == [
+        FanDriver,
+        NumberDriver,
+        SwitchDriver,
+        ACInfinityDriver,
+    ]
 
 
 async def test_resolve_actuator_drivers_empty(mock_hass: MagicMock) -> None:


### PR DESCRIPTION
## Summary

- add a numeric actuator driver for input_number and number fan-speed entities
- translate controller demand from 0-100 percent to the card numeric fan scale of 0-10
- include numeric actuators in resolver aggregation with availability and on-state handling

## Validation

- 5,174 backend tests passed
- 63 focused actuator-driver tests passed
- changed files pass Ruff check and format
- commit hooks passed pytest, mypy, Ruff, codespell, YAML, JSON, Prettier, and branch guards

Part of Venosta-web/growspace_manager_workspace#21.