### PR TITLE
fix(environment): drive AC-only VPD actuators

### DIFF
--- a/custom_components/growspace_manager/vpd_on_off_controller.py
+++ b/custom_components/growspace_manager/vpd_on_off_controller.py
@@ -166,7 +166,8 @@ class VpdOnOffController:
     async def async_check_and_control(self) -> None:
         """Evaluate VPD against stage thresholds and drive the device."""
         entities = self._get_all_controlled_entities()
-        if not self.vpd_sensor or not entities:
+        has_actuators = bool(entities or self._get_ac_infinity_devices())
+        if not self.vpd_sensor or not has_actuators:
             return
 
         current_vpd = self._get_current_vpd()

--- a/tests/integration/test_humidifier_coordinator.py
+++ b/tests/integration/test_humidifier_coordinator.py
@@ -508,6 +508,35 @@ async def test_ac_infinity_humidifier_turn_on(
     )
 
 
+async def test_ac_infinity_only_humidifier_reacts_to_vpd(
+    mock_hass, mock_main_coordinator, mock_track_state_change_event
+) -> None:
+    """An AC-only bundle must pass the event-handler actuator guard."""
+    coord = _ac_infinity_humidifier(
+        mock_hass, mock_main_coordinator, mock_track_state_change_event
+    )
+    coord._get_current_vpd = MagicMock(return_value=2.0)
+    coord._get_growth_stage = MagicMock(return_value=PlantStage.VEG)
+    coord._day_night.determine = MagicMock(return_value=True)
+    coord._is_device_on = MagicMock(return_value=False)
+    coord._is_locked_by_timer = MagicMock(return_value=False)
+
+    await coord.async_check_and_control()
+
+    mock_hass.services.async_call.assert_any_await(
+        "select",
+        "select_option",
+        {ATTR_ENTITY_ID: "select.hum_mode", "option": "On"},
+        blocking=False,
+    )
+    mock_hass.services.async_call.assert_any_await(
+        "number",
+        "set_value",
+        {ATTR_ENTITY_ID: "number.hum_speed", "value": 8},
+        blocking=False,
+    )
+
+
 async def test_ac_infinity_humidifier_turn_off(
     mock_hass, mock_main_coordinator, mock_track_state_change_event
 ) -> None:


### PR DESCRIPTION
## Summary
- treat AC Infinity bundles as actuators in VPD event handling even when no plain entities are configured
- add a regression test proving an AC-only humidifier receives both mode and speed writes
- supports Venosta-web/growspace_manager_workspace#20

## Validation
- backend pre-commit suite passed, including pytest and mypy
- 5,175 backend tests passed
- changed files pass ruff lint and format checks