### PR TITLE
fix(environment): restore air exchange recommendations

### DIFF
--- a/custom_components/growspace_manager/environment_analyzer.py
+++ b/custom_components/growspace_manager/environment_analyzer.py
@@ -75,7 +75,9 @@ class EnvironmentAnalyzer:
         stage_b = classification.stage_b
         factor = classification.factor
 
-        display = StageEnvironmentalTargets(stage_a, stage_b, factor).vpd_display_targets()
+        display = StageEnvironmentalTargets(
+            stage_a, stage_b, factor
+        ).vpd_display_targets()
         d_danger_min = display.day_danger_min
         d_danger_max = display.day_danger_max
         d_target_min = display.day_target_min
@@ -165,7 +167,7 @@ class EnvironmentAnalyzer:
                         break
                     # If it parses but is 0, it's valid code (night)
                     has_valid_state = True
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
 
         if not has_valid_state:
@@ -188,7 +190,7 @@ class EnvironmentAnalyzer:
         if state and state.state not in ["unknown", "unavailable"]:
             try:
                 return float(state.state)
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 return None
         return None
 
@@ -207,6 +209,24 @@ class EnvironmentAnalyzer:
             return None
 
         return sum(values) / len(values)
+
+    def _get_target_vpd(self, growspace_id: str) -> float | None:
+        """Return the midpoint of the growspace's active biological VPD band."""
+        metrics = (
+            self.coordinator.data.get("serialized_growspaces", {})
+            .get(growspace_id, {})
+            .get("metrics", {})
+        )
+        target_min = metrics.get("vpd_target_min")
+        target_max = metrics.get("vpd_target_max")
+        if (
+            not isinstance(target_min, (int, float))
+            or isinstance(target_min, bool)
+            or not isinstance(target_max, (int, float))
+            or isinstance(target_max, bool)
+        ):
+            return None
+        return (float(target_min) + float(target_max)) / 2
 
     def _get_outside_conditions(
         self, global_settings: dict[str, Any]
@@ -365,11 +385,7 @@ class EnvironmentAnalyzer:
                 [env_config.vpd_sensor] if env_config.vpd_sensor else []
             )
             current_vpd = self._get_aggregated_sensor_value(vpd_sensors)
-            target_vpd = (
-                self.coordinator.data.get("bayesian_sensors_reason", {})
-                .get(growspace_id, {})
-                .get("target_vpd")
-            )
+            target_vpd = self._get_target_vpd(growspace_id)
 
             recommendations[growspace_id] = self._calculate_recommendation(
                 growspace_id,

--- a/tests/core/test_coordinator.py
+++ b/tests/core/test_coordinator.py
@@ -1339,7 +1339,11 @@ async def test_async_update_air_exchange_recommendations(hass: HomeAssistant) ->
     vpd_sensor_entity_id = "sensor.stress_gs_vpd"
 
     gs.environment_config = EnvironmentConfig(vpd_sensor=vpd_sensor_entity_id)
-    coordinator.data = {"bayesian_sensors_reason": {gs.id: {"target_vpd": 1.2}}}
+    coordinator.data = {
+        "serialized_growspaces": {
+            gs.id: {"metrics": {"vpd_target_min": 1.0, "vpd_target_max": 1.4}}
+        }
+    }
 
     # Mock the entity registry to return the correct entity ID
     entity_registry = er.async_get(hass)
@@ -2029,7 +2033,11 @@ async def test_async_update_air_exchange_recommendations_no_vpd(
     coordinator = create_test_coordinator(hass, data={})
     gs = await coordinator._growspace_manager.add_growspace("Test GS")
     gs.environment_config = EnvironmentConfig(vpd_sensor="sensor.vpd")
-    coordinator.data = {"bayesian_sensors_reason": {gs.id: {"target_vpd": None}}}
+    coordinator.data = {
+        "serialized_growspaces": {
+            gs.id: {"metrics": {"vpd_target_min": None, "vpd_target_max": None}}
+        }
+    }
 
     with patch(
         "homeassistant.helpers.entity_registry.EntityRegistry.async_get_entity_id",

--- a/tests/logic/test_environment_analyzer.py
+++ b/tests/logic/test_environment_analyzer.py
@@ -43,6 +43,7 @@ def mock_growspace():
     gs.environment_config.vpd_sensors = []
     gs.environment_config.temperature_sensors = []
     gs.environment_config.humidity_sensors = []
+    gs.environment_config.minimum_source_air_temperature = 18.0
     return gs
 
 
@@ -50,11 +51,22 @@ def test_classify_stages_display_stage_via_domain() -> None:
     """Test that classify_stages produces the correct display_stage for all branches."""
     assert classify_stages(StageDays(cure=5)).display_stage == BayesianStage.CURE
     assert classify_stages(StageDays(dry=5)).display_stage == BayesianStage.DRY
-    assert classify_stages(StageDays(flower=10)).display_stage == BayesianStage.FLOWER_EARLY
-    assert classify_stages(StageDays(flower=DEFAULT_FLOWER_EARLY_DAYS + 5)).display_stage == BayesianStage.FLOWER_MID
-    assert classify_stages(StageDays(flower=DEFAULT_FLOWER_EARLY_DAYS + 30)).display_stage == BayesianStage.FLOWER_LATE
+    assert (
+        classify_stages(StageDays(flower=10)).display_stage
+        == BayesianStage.FLOWER_EARLY
+    )
+    assert (
+        classify_stages(StageDays(flower=DEFAULT_FLOWER_EARLY_DAYS + 5)).display_stage
+        == BayesianStage.FLOWER_MID
+    )
+    assert (
+        classify_stages(StageDays(flower=DEFAULT_FLOWER_EARLY_DAYS + 30)).display_stage
+        == BayesianStage.FLOWER_LATE
+    )
     assert classify_stages(StageDays(veg=10)).display_stage == BayesianStage.VEG
-    assert classify_stages(StageDays(seedling=5)).display_stage == BayesianStage.SEEDLING
+    assert (
+        classify_stages(StageDays(seedling=5)).display_stage == BayesianStage.SEEDLING
+    )
     assert classify_stages(StageDays(clone=5)).display_stage == BayesianStage.CLONE
     assert classify_stages(StageDays()).display_stage == BayesianStage.EMPTY
 
@@ -258,8 +270,12 @@ async def test_async_update_air_exchange_full_flow(
             "weather_entity": "weather.home",
             "lung_room_temp_sensor": "sensor.lung_temp",
             "lung_room_humidity_sensor": "sensor.lung_hum",
-        },
-        "bayesian_sensors_reason": {"gs1": {"target_vpd": 1.0}},
+        }
+    }
+    mock_coordinator.data = {
+        "serialized_growspaces": {
+            "gs1": {"metrics": {"vpd_target_min": 0.9, "vpd_target_max": 1.1}}
+        }
     }
 
     # Mock sensors


### PR DESCRIPTION
## Summary

- derive air-exchange recommendations from the growspace's active biological VPD target band
- remove the dependency on an unpopulated legacy coordinator key
- cover midpoint selection and missing-target fallback behavior

## Testing

- pre-commit: ruff check, ruff format, codespell, pytest, and mypy passed
- `../../.venv/bin/pytest tests/logic/test_environment_analyzer.py tests/core/test_coordinator.py -q` — 121 passed

## Coordination

Backend-first change for [workspace issue #23](https://github.com/Venosta-web/growspace_manager_workspace/issues/23). The dependent card and workspace PRs should merge after this one.
