### PR TITLE
fix(plants): resolve Current Stage through the Plant Lifecycle module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -81,6 +81,10 @@ The immutable event draft produced by Lifecycle Correction, recording the prior/
 **Compatibility Data**
 The lifecycle-owned projection for legacy Plant consumers: the shadow `stage`, latest per-stage `*_start` values, and Stage History. It is rebuilt from trusted intervals after every Applied transition or Lifecycle Correction so legacy fields cannot disagree with the domain result.
 
+**Current Stage Resolution**
+The read path's single rule for reporting [[Current Stage]], implemented in `domain/current_stage.py` and shared by the plant view model the card renders, the plant sensor's state and `stage` attribute, and nutrient-preset stage matching: stored [[Stage History]] wins whenever it parses, and the legacy `calculate_plant_stage` date heuristic applies only to Plants with no stored history or history that needs repair. It deliberately does not hand the `plant.stage` shadow to the lifecycle as an expected current stage — that comparison fails history closed to [[Unknown Stage]] and belongs to the mutation path, which repairs the disagreement. Consequences: after a Reveg the stale `flower_start` no longer outranks the newer veg interval, and a promoted clone still sitting in the clone growspace reads as veg rather than taking the special-growspace shortcut.
+_Avoid_: displayed stage, computed stage
+
 **Photoperiod Flip**
 The calendar day on which a Plant transitions from vegetative to flower stage — specifically, the day `flower_start == today`. The grower must change the light schedule to 12 hours on this day. When `IrrigationStrategy.auto_light_tracking` is enabled on the growspace, the integration will auto-adapt the light schedule from sensor data; otherwise the grower must update it manually. A notification is sent once per day per growspace when any plant's Photoperiod Flip day arrives.
 

--- a/custom_components/growspace_manager/domain/current_stage.py
+++ b/custom_components/growspace_manager/domain/current_stage.py
@@ -1,0 +1,75 @@
+"""The read path's single answer to "what stage is this Plant in?".
+
+[[Plant Lifecycle]] owns [[Current Stage]], but three readers used to derive it
+independently — the plant view model the card renders, the plant sensor's
+`stage` attribute, and nutrient-preset stage matching. All of them read the
+legacy `calculate_plant_stage` date heuristic (or the `plant.stage` shadow),
+which scans the legacy `*_start` fields in reverse stage order and so reports a
+*stale later* stage after a Reveg: `flower_start` is still set while the
+Plant is back in veg, and flower is checked first. This module routes those
+readers through the lifecycle instead, so they cannot disagree with it or with
+each other (#634).
+
+Resolution rule: stored [[Stage History]] wins whenever it parses. The legacy
+heuristic survives only as the fallback for Plants that store no history at all
+or whose history needs repair — so a Plant whose history was already consistent
+displays exactly the stage it displayed before.
+
+The stored `plant.stage` shadow is deliberately *not* handed to the lifecycle
+here as the expected current stage. That comparison raises
+`CURRENT_STAGE_MISMATCH` and fails history closed to [[Unknown Stage]], which
+would silently drop the read path back onto the heuristic for precisely the
+Plants this seam exists to fix. Validating that agreement belongs to the
+mutation path, which repairs it; the read path reports what the lifecycle knows.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+from custom_components.growspace_manager.utils import calculate_plant_stage
+from homeassistant.util import dt as dt_util
+
+from .plant_lifecycle import LifecycleStage, PlantLifecycle
+
+if TYPE_CHECKING:
+    from datetime import date
+
+    from custom_components.growspace_manager.models import Plant
+
+
+def stored_lifecycle(plant: Plant, *, observed_on: date) -> PlantLifecycle | None:
+    """Return the lifecycle parsed from stored Stage History, None when absent.
+
+    Absent history is not reconstructed from legacy dates here: reconstruction
+    is the mutation path's one-time migration, and on the read path an absent
+    history simply means the legacy heuristic still owns the answer.
+    """
+    stored_history = getattr(plant, "stage_history", None)
+    if not isinstance(stored_history, list) or not stored_history:
+        return None
+
+    raw_history = [
+        dict(item) if isinstance(item, Mapping) else item for item in stored_history
+    ]
+    return PlantLifecycle.from_history(raw_history, observed_on=observed_on)
+
+
+def resolve_current_stage(plant: Plant, *, observed_on: date | None = None) -> str:
+    """Return the Plant's Current Stage as the lifecycle module reports it.
+
+    Args:
+        plant: The Plant to resolve.
+        observed_on: The [[Observed Date]] the history is evaluated on; defaults
+            to today in the Home Assistant timezone.
+
+    Returns:
+        The canonical stage string, falling back to the legacy date heuristic
+        when no trustworthy Stage History is stored.
+    """
+    on_date = observed_on if observed_on is not None else dt_util.now().date()
+    lifecycle = stored_lifecycle(plant, observed_on=on_date)
+    if lifecycle is not None and lifecycle.current_stage is not LifecycleStage.UNKNOWN:
+        return lifecycle.current_stage.value
+    return calculate_plant_stage(plant)

--- a/custom_components/growspace_manager/managers/nutrient.py
+++ b/custom_components/growspace_manager/managers/nutrient.py
@@ -8,6 +8,9 @@ import logging
 from typing import TYPE_CHECKING, Any
 import uuid
 
+from custom_components.growspace_manager.domain.current_stage import (
+    resolve_current_stage,
+)
 from custom_components.growspace_manager.models import (
     ECRampCurve,
     ECRampPoint,
@@ -80,7 +83,9 @@ class NutrientManager:
             preset = self.nutrient_presets[preset_id]
             preset.name = name
             preset.items = [
-                NutrientPresetItem(nutrient_id=n["nutrient_id"], dose_ml_l=n["dose_ml_l"])
+                NutrientPresetItem(
+                    nutrient_id=n["nutrient_id"], dose_ml_l=n["dose_ml_l"]
+                )
                 for n in nutrients
             ]
             preset.stage = stage
@@ -95,7 +100,9 @@ class NutrientManager:
                 id=pid,
                 name=name,
                 items=[
-                    NutrientPresetItem(nutrient_id=n["nutrient_id"], dose_ml_l=n["dose_ml_l"])
+                    NutrientPresetItem(
+                        nutrient_id=n["nutrient_id"], dose_ml_l=n["dose_ml_l"]
+                    )
                     for n in nutrients
                 ],
                 stage=stage,
@@ -253,17 +260,19 @@ class NutrientManager:
             raise ValueError(f"Plant {plant_id} not found")
 
         applicable: list[NutrientPreset] = []
+        # The Plant Lifecycle module owns Current Stage; matching on the legacy
+        # `plant.stage` shadow fed presets a stale stage after a Reveg (#634).
+        current_stage = resolve_current_stage(plant).lower()
 
         for preset in self.nutrient_presets.values():
             # If preset has no stage filter, it applies to all stages
             if preset.stage is not None:
                 # Check if plant's current stage matches preset stage
-                if str(plant.stage).lower() != str(preset.stage).lower():
+                if current_stage != str(preset.stage).lower():
                     continue
 
             # If preset has min_days_in_stage, check if plant meets it
             if preset.min_days_in_stage is not None:
-                current_stage = str(plant.stage).lower()
                 days_in_stage = plant.get_days_in_stage(current_stage)
                 if days_in_stage < preset.min_days_in_stage:
                     continue

--- a/custom_components/growspace_manager/presentation/plant_view_model.py
+++ b/custom_components/growspace_manager/presentation/plant_view_model.py
@@ -29,6 +29,9 @@ from custom_components.growspace_manager.domain import (
     calculate_days_in_stage,
     get_days_since_watering,
 )
+from custom_components.growspace_manager.domain.current_stage import (
+    resolve_current_stage,
+)
 from custom_components.growspace_manager.domain.plant_metrics import (
     format_plant_position,
     get_formatted_dates,
@@ -38,7 +41,6 @@ from custom_components.growspace_manager.drying_calculator import (
     compute_weight_lost_pct,
     is_cure_ready,
 )
-from custom_components.growspace_manager.utils import calculate_plant_stage
 from homeassistant.util import dt as dt_util
 
 from .entity_queries import EntityQueries
@@ -141,7 +143,7 @@ class PlantViewModelBuilder:
             "row": int(plant.row),
             "col": int(plant.col),
             "position": format_plant_position(plant),
-            "stage": calculate_plant_stage(plant),
+            "stage": resolve_current_stage(plant),
             # Watering & Training
             "last_training_technique": plant.last_training_technique,
             "last_ipm_type": plant.last_ipm_type,
@@ -164,7 +166,7 @@ class PlantViewModelBuilder:
         :meth:`build`.
         """
         attributes: dict[str, Any] = {
-            "stage": calculate_plant_stage(plant),
+            "stage": resolve_current_stage(plant),
             "growspace_id": plant.growspace_id,
             "plant_id": plant.plant_id,
             "updated_at": plant.updated_at,

--- a/custom_components/growspace_manager/sensor/plant.py
+++ b/custom_components/growspace_manager/sensor/plant.py
@@ -6,11 +6,13 @@ from typing import Any, override
 
 from custom_components.growspace_manager.const import DOMAIN
 from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
+from custom_components.growspace_manager.domain.current_stage import (
+    resolve_current_stage,
+)
 from custom_components.growspace_manager.models import Plant
 from custom_components.growspace_manager.presentation.plant_view_model import (
     PlantViewModelBuilder,
 )
-from custom_components.growspace_manager.utils import calculate_plant_stage
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -53,7 +55,7 @@ class PlantEntity(CoordinatorEntity[GrowspaceCoordinator], SensorEntity):
         if not plant:
             return "unknown"
 
-        stage = calculate_plant_stage(plant)
+        stage = resolve_current_stage(plant)
 
         self.coordinator.growspaces.get(plant.growspace_id)
 

--- a/tests/domain/test_current_stage.py
+++ b/tests/domain/test_current_stage.py
@@ -1,0 +1,167 @@
+"""Tests for the read path's Current Stage resolution (#634).
+
+The plant view model, the plant sensor, and nutrient-preset matching all read
+Current Stage through ``resolve_current_stage``, so they agree with the Plant
+Lifecycle module and with each other. The legacy date heuristic survives only
+where no trustworthy Stage History is stored.
+"""
+
+from datetime import date
+from unittest.mock import MagicMock
+
+from custom_components.growspace_manager.domain.current_stage import (
+    resolve_current_stage,
+)
+from custom_components.growspace_manager.managers.nutrient import NutrientManager
+from custom_components.growspace_manager.models import NutrientPreset, Plant
+from custom_components.growspace_manager.presentation.plant_view_model import (
+    PlantViewModelBuilder,
+)
+from custom_components.growspace_manager.sensor.plant import PlantEntity
+from custom_components.growspace_manager.utils import calculate_plant_stage
+
+OBSERVED_ON = date(2025, 8, 20)
+
+
+def _revegged_plant() -> Plant:
+    """A Plant taken back to veg out of flower, legacy flower date still set.
+
+    This is the shape the old heuristic got wrong: it scans the legacy
+    ``*_start`` fields from the latest stage backwards, so a stale
+    ``flower_start`` beat the newer ``veg_start`` and the card kept showing
+    "flower" after the Reveg.
+    """
+    return Plant(
+        plant_id="reveg",
+        growspace_id="main",
+        stage="flower",
+        veg_start="2025-08-10",
+        flower_start="2025-08-01",
+        stage_history=[
+            {"stage": "veg", "start": "2025-07-01", "end": "2025-08-01"},
+            {"stage": "flower", "start": "2025-08-01", "end": "2025-08-10"},
+            {"stage": "veg", "start": "2025-08-10", "end": None},
+        ],
+    )
+
+
+def test_reveg_history_beats_the_stale_legacy_date_heuristic() -> None:
+    """The Reveg regression: history says veg, the old heuristic said flower."""
+    plant = _revegged_plant()
+
+    assert calculate_plant_stage(plant) == "flower"
+    assert resolve_current_stage(plant, observed_on=OBSERVED_ON) == "veg"
+
+
+def test_clone_promotion_beats_the_special_growspace_shortcut() -> None:
+    """A promoted clone still sitting in the clone growspace reads as veg."""
+    plant = Plant(
+        plant_id="promoted",
+        growspace_id="clone",
+        stage="clone",
+        clone_start="2025-07-01",
+        veg_start="2025-08-10",
+        stage_history=[
+            {"stage": "clone", "start": "2025-07-01", "end": "2025-08-10"},
+            {"stage": "veg", "start": "2025-08-10", "end": None},
+        ],
+    )
+
+    assert calculate_plant_stage(plant) == "clone"
+    assert resolve_current_stage(plant, observed_on=OBSERVED_ON) == "veg"
+
+
+def test_consistent_history_displays_the_same_stage_as_before() -> None:
+    """A Plant whose history already agreed keeps its displayed stage."""
+    plant = Plant(
+        plant_id="ordinary",
+        growspace_id="main",
+        stage="flower",
+        veg_start="2025-07-01",
+        flower_start="2025-08-01",
+        stage_history=[
+            {"stage": "veg", "start": "2025-07-01", "end": "2025-08-01"},
+            {"stage": "flower", "start": "2025-08-01", "end": None},
+        ],
+    )
+
+    assert resolve_current_stage(plant, observed_on=OBSERVED_ON) == "flower"
+    assert resolve_current_stage(
+        plant, observed_on=OBSERVED_ON
+    ) == calculate_plant_stage(plant)
+
+
+def test_absent_history_keeps_the_legacy_heuristic() -> None:
+    """Plants that store no Stage History are still read from legacy dates."""
+    plant = Plant(
+        plant_id="legacy",
+        growspace_id="main",
+        stage="",
+        veg_start="2025-07-01",
+        flower_start="2025-08-01",
+        stage_history=[],
+    )
+
+    assert resolve_current_stage(plant, observed_on=OBSERVED_ON) == "flower"
+
+
+def test_untrustworthy_history_falls_back_to_the_legacy_heuristic() -> None:
+    """History that needs repair never silently reports Unknown to the card."""
+    plant = Plant(
+        plant_id="broken",
+        growspace_id="main",
+        stage="flower",
+        flower_start="2025-08-01",
+        stage_history=[
+            {"stage": "veg", "start": "not-a-date", "end": None},
+        ],
+    )
+
+    assert resolve_current_stage(plant, observed_on=OBSERVED_ON) == "flower"
+
+
+def test_sensor_state_and_attributes_agree_with_the_module() -> None:
+    """The sensor state, its ``stage`` attribute, and the module are one answer."""
+    plant = _revegged_plant()
+    coordinator = MagicMock()
+    coordinator.plants = {plant.plant_id: plant}
+    coordinator.growspaces = {}
+
+    entity = PlantEntity(coordinator, plant)
+
+    assert entity.native_value == "veg"
+    assert entity.extra_state_attributes["stage"] == "veg"
+
+
+def test_view_model_payload_agrees_with_the_module(hass) -> None:
+    """The card's plant payload carries the module's Current Stage."""
+    plant = _revegged_plant()
+    builder = PlantViewModelBuilder(hass)
+    builder.entity_queries = MagicMock()
+    builder.entity_queries.lookup_plant_entity_id.return_value = "sensor.reveg"
+
+    assert builder.build(plant)["stage"] == "veg"
+
+
+def test_nutrient_presets_match_the_modules_current_stage() -> None:
+    """Preset stage matching follows the Reveg, not the stale legacy shadow."""
+    plant = _revegged_plant()
+    repository = MagicMock()
+    repository.get_plant.return_value = plant
+    manager = NutrientManager(repository=repository, save_callback=MagicMock())
+    manager.nutrient_presets = {
+        "veg": NutrientPreset(
+            id="veg", name="Veg", items=[], stage="veg", created_at="2025-01-01"
+        ),
+        "flower": NutrientPreset(
+            id="flower",
+            name="Flower",
+            items=[],
+            stage="flower",
+            created_at="2025-01-01",
+        ),
+    }
+
+    applicable = {preset.id for preset in manager.get_applicable_presets("reveg")}
+
+    assert applicable == {"veg"}

--- a/tests/presentation/test_plant_view_model.py
+++ b/tests/presentation/test_plant_view_model.py
@@ -59,14 +59,14 @@ def test_builder_initialization(hass: HomeAssistant):
     "custom_components.growspace_manager.presentation.plant_view_model.format_plant_position"
 )
 @patch(
-    "custom_components.growspace_manager.presentation.plant_view_model.calculate_plant_stage"
+    "custom_components.growspace_manager.presentation.plant_view_model.resolve_current_stage"
 )
 @patch(
     "custom_components.growspace_manager.presentation.plant_view_model.get_days_since_watering"
 )
 def test_build_full_payload(
     mock_get_days_since_watering,
-    mock_calculate_plant_stage,
+    mock_resolve_current_stage,
     mock_format_plant_position,
     mock_calculate_days_in_stage,
     mock_get_formatted_dates,
@@ -78,7 +78,7 @@ def test_build_full_payload(
     mock_get_formatted_dates.return_value = {"started_at": "2024-01-01"}
     mock_calculate_days_in_stage.return_value = 5
     mock_format_plant_position.return_value = "R1:C1"
-    mock_calculate_plant_stage.return_value = "veg"
+    mock_resolve_current_stage.return_value = "veg"
     mock_get_days_since_watering.return_value = 2
 
     # Mock EntityQueries
@@ -118,14 +118,14 @@ def test_build_full_payload(
     "custom_components.growspace_manager.presentation.plant_view_model.format_plant_position"
 )
 @patch(
-    "custom_components.growspace_manager.presentation.plant_view_model.calculate_plant_stage"
+    "custom_components.growspace_manager.presentation.plant_view_model.resolve_current_stage"
 )
 @patch(
     "custom_components.growspace_manager.presentation.plant_view_model.get_days_since_watering"
 )
 def test_build_provided_entity_id(
     mock_get_days_since_watering,
-    mock_calculate_plant_stage,
+    mock_resolve_current_stage,
     mock_format_plant_position,
     mock_calculate_days_in_stage,
     mock_get_formatted_dates,


### PR DESCRIPTION
Closes #634.

## What changed

The card's plant display, the plant sensor's `stage`, and nutrient-preset stage matching each derived Current Stage independently — from the legacy `calculate_plant_stage` date heuristic or the raw `plant.stage` shadow. The heuristic scans the legacy `*_start` fields in reverse stage order, so after a Reveg a stale `flower_start` outranked the newer veg interval and the plant kept reading as `flower` while the lifecycle module knew it was back in veg.

`domain/current_stage.py` is the one read-side seam all three now share:

- stored [[Stage History]] wins whenever it parses;
- the legacy heuristic survives only for plants with **no** stored history, or history that needs repair — so a plant whose history was already consistent displays exactly the stage it displayed before (AC4).

The stored `plant.stage` shadow is deliberately **not** handed to the lifecycle as an expected current stage. That comparison raises `CURRENT_STAGE_MISMATCH` and fails the history closed to Unknown, which would drop the read path back onto the heuristic for precisely the plants this fixes. Validating that agreement stays on the mutation path, which repairs it.

## Acceptance criteria

- [x] Card display and the sensor `stage` attribute agree with each other and with the module (`test_sensor_state_and_attributes_agree_with_the_module`, `test_view_model_payload_agrees_with_the_module`)
- [x] Nutrient preset stage matching uses the module's Current Stage (`test_nutrient_presets_match_the_modules_current_stage`)
- [x] Regression test for the Reveg scenario the old heuristic got wrong (`test_reveg_history_beats_the_stale_legacy_date_heuristic`)
- [x] No change for plants whose Stage History was already consistent (`test_consistent_history_displays_the_same_stage_as_before`, plus the absent/untrustworthy-history fallbacks)

## Behaviour change worth a second look

A **promoted clone that is still sitting in the clone growspace** now reads as `veg`. The old heuristic short-circuited on the special growspace (`_get_stage_from_growspace`) before looking at anything else; the module reports what the history says. That is the clone→veg promotion case the issue names, and it is covered by `test_clone_promotion_beats_the_special_growspace_shortcut` — but it is the one case where a plant's displayed stage changes without its history having been wrong.

## Validation

- `../../.venv/bin/pytest tests/ -q` → 5183 passed
- `ruff check` / `ruff format` / `mypy custom_components` → clean
- No card change: the card renders the backend-supplied `stage`, so there is no contract or schema change.