### PR TITLE
Route update_plant lifecycle edits through correction

### DIFF
--- a/custom_components/growspace_manager/managers/plant.py
+++ b/custom_components/growspace_manager/managers/plant.py
@@ -12,13 +12,16 @@ import uuid
 from custom_components.growspace_manager.const import (
     CATEGORY_MILESTONE,
     DATE_FIELDS,
+    EVENT_GROWSPACE_LOG_ENTRY,
     PLANT_STAGES,
     SPECIAL_GROWSPACES,
     PlantStage,
 )
 from custom_components.growspace_manager.domain.date_logic import plant_updated_date
 from custom_components.growspace_manager.domain.plant_lifecycle import (
+    TRANSITION_GRAPH,
     Applied,
+    LifecycleCorrection,
     LifecycleDecision,
     LifecycleStage,
     PlantLifecycle,
@@ -93,6 +96,8 @@ _SPECIAL_LIFECYCLE_STAGES = {
     LifecycleStage.CLONE,
     LifecycleStage.MOTHER,
 }
+_LIFECYCLE_UPDATE_FIELDS = {"stage", *DATE_FIELDS}
+_LIFECYCLE_CORRECTION_REASON = "Lifecycle corrected through update_plant"
 
 
 def _as_lifecycle_stage(stage: str | PlantStage) -> LifecycleStage:
@@ -154,7 +159,13 @@ class PlantManager(BaseService):
                 deepcopy(getattr(snapshot, model_field.name)),
             )
 
-    def _plant_lifecycle(self, plant: Plant, *, observed_on: date) -> PlantLifecycle:
+    def _plant_lifecycle(
+        self,
+        plant: Plant,
+        *,
+        observed_on: date,
+        allow_repair: bool = False,
+    ) -> PlantLifecycle:
         """Parse a Plant through the lifecycle domain, bootstrapping legacy empties."""
         raw_stage = plant.stage or calculate_plant_stage(plant)
         try:
@@ -198,12 +209,194 @@ class PlantManager(BaseService):
             legacy_dates=legacy_dates,
             current_stage=current_stage,
         )
-        if lifecycle.warnings:
+        if lifecycle.warnings and not allow_repair:
             details = ", ".join(warning.code.value for warning in lifecycle.warnings)
             raise ValidationChangeError(
                 f"Plant {plant.plant_id} lifecycle requires repair: {details}"
             )
         return lifecycle
+
+    @staticmethod
+    def _same_lifecycle_day(left: object, right: object) -> bool:
+        """Compare stored lifecycle values at the domain's calendar-day precision."""
+        return str(left)[:10] == str(right)[:10]
+
+    def _correction_history(
+        self,
+        plant: Plant,
+        correction: LifecycleCorrection,
+        corrected_timestamp: str,
+    ) -> list[dict[str, str | None]]:
+        """Project a correction while retaining trusted timestamp precision."""
+        projected = correction.compatibility_data.as_dict()["stage_history"]
+        history = [dict(item) for item in projected]
+        raw_history = plant.stage_history
+
+        for index, item in enumerate(history[:-1]):
+            if index >= len(raw_history):
+                break
+            raw = raw_history[index]
+            if (
+                raw["stage"] == item["stage"]
+                and self._same_lifecycle_day(raw["start"], item["start"])
+                and self._same_lifecycle_day(raw["end"], item["end"])
+            ):
+                history[index] = dict(raw)
+
+        history[-1]["start"] = corrected_timestamp
+        if len(history) > 1 and self._same_lifecycle_day(
+            history[-2]["end"], corrected_timestamp
+        ):
+            history[-2]["end"] = corrected_timestamp
+        return history
+
+    def _lifecycle_compatibility_updates(
+        self,
+        plant: Plant,
+        decision: LifecycleDecision | LifecycleCorrection,
+        lifecycle: PlantLifecycle,
+        target_stage: LifecycleStage,
+        target_timestamp: str,
+    ) -> dict[str, Any]:
+        """Build one timestamp-preserving update for every lifecycle-owned field."""
+        projected = decision.compatibility_data.as_dict()
+        if isinstance(decision, LifecycleCorrection):
+            projected["stage_history"] = self._correction_history(
+                plant, decision, target_timestamp
+            )
+        else:
+            projected["stage_history"] = self._transition_history(
+                plant, lifecycle, decision, target_timestamp
+            )
+
+        target_field = f"{target_stage.value}_start"
+        for field_name in DATE_FIELDS:
+            projected_value = projected[field_name]
+            if projected_value is None:
+                continue
+            if field_name == target_field:
+                projected[field_name] = target_timestamp
+                continue
+            stored_value = getattr(plant, field_name)
+            if stored_value is not None and self._same_lifecycle_day(
+                stored_value, projected_value
+            ):
+                projected[field_name] = stored_value
+        return projected
+
+    @staticmethod
+    def _lifecycle_edit_request(
+        requested_updates: dict[str, Any],
+    ) -> tuple[LifecycleStage, Any, bool]:
+        """Resolve the editor's one authoritative stage and optional start value."""
+        lifecycle_dates = {
+            field_name: requested_updates[field_name]
+            for field_name in DATE_FIELDS
+            if field_name in requested_updates
+        }
+        non_empty_date_fields = [
+            field_name
+            for field_name, value in lifecycle_dates.items()
+            if value is not None
+        ]
+        if (requested_stage := requested_updates.get("stage")) is None:
+            if len(non_empty_date_fields) != 1:
+                raise ValidationChangeError(
+                    "A lifecycle date edit must identify exactly one current stage"
+                )
+            target = _as_lifecycle_stage(
+                non_empty_date_fields[0].removesuffix("_start")
+            )
+        else:
+            target = _as_lifecycle_stage(requested_stage)
+
+        target_field = f"{target.value}_start"
+        if any(field_name != target_field for field_name in non_empty_date_fields):
+            raise ValidationChangeError(
+                "Lifecycle edits may only set the selected stage's start date"
+            )
+        target_start_supplied = target_field in lifecycle_dates
+        target_date = lifecycle_dates.get(target_field)
+        if target_start_supplied and target_date is None:
+            raise ValidationChangeError("The current lifecycle start cannot be cleared")
+        return target, target_date, target_start_supplied
+
+    @staticmethod
+    def _repair_lifecycle(
+        lifecycle: PlantLifecycle,
+        target: LifecycleStage,
+        target_timestamp: str,
+        observed_on: date,
+    ) -> LifecycleCorrection:
+        """Translate correction input errors into the manager validation vocabulary."""
+        try:
+            return lifecycle.repair_current(
+                target,
+                target_timestamp,
+                observed_on,
+                _LIFECYCLE_CORRECTION_REASON,
+            )
+        except ValueError as err:
+            raise ValidationChangeError(str(err)) from err
+
+    def _lifecycle_editor_decision(
+        self,
+        lifecycle: PlantLifecycle,
+        target: LifecycleStage,
+        target_timestamp: str,
+        observed_on: date,
+        target_start_supplied: bool,
+    ) -> tuple[LifecycleDecision | LifecycleCorrection, LifecycleCorrection | None]:
+        """Choose transition for forward movement and correction for rewritten history."""
+        transition = lifecycle.transition(target, target_timestamp, observed_on)
+        needs_repair = lifecycle.warnings or (
+            target is lifecycle.current_stage and target_start_supplied
+        )
+        if isinstance(transition, Rejected) and target not in TRANSITION_GRAPH.get(
+            lifecycle.current_stage, frozenset()
+        ):
+            needs_repair = True
+
+        if needs_repair:
+            correction = self._repair_lifecycle(
+                lifecycle, target, target_timestamp, observed_on
+            )
+            return correction, correction
+        if isinstance(transition, Rejected):
+            raise ValidationChangeError(
+                transition.reason or "Lifecycle update rejected"
+            )
+        return transition, None
+
+    def _emit_lifecycle_repair_event(
+        self, plant: Plant, correction: LifecycleCorrection
+    ) -> None:
+        """Publish the domain repair draft to the plant-filterable timeline."""
+        repair = correction.repair_event
+        stage_label = repair.corrected_stage.value.replace("_", " ").title()
+        self.hass.bus.async_fire(
+            EVENT_GROWSPACE_LOG_ENTRY,
+            {
+                "plant_id": plant.plant_id,
+                "growspace_id": plant.growspace_id,
+                "sensor_type": "lifecycle_repair",
+                "category": CATEGORY_MILESTONE,
+                "timestamp": dt_util.now().isoformat(),
+                "notes": repair.reason,
+                "reasons": [
+                    f"Corrected {stage_label} start to "
+                    f"{repair.corrected_stage_started_on.isoformat()}"
+                ],
+                "previous_stage": repair.previous_stage.value,
+                "corrected_stage": repair.corrected_stage.value,
+                "corrected_stage_started_on": (
+                    repair.corrected_stage_started_on.isoformat()
+                ),
+                "corrected_on": repair.corrected_on.isoformat(),
+                "discarded_interval_count": repair.discarded_interval_count,
+                "warning_codes": [warning.value for warning in repair.warning_codes],
+            },
+        )
 
     @staticmethod
     def _transition_history(
@@ -397,6 +590,105 @@ class PlantManager(BaseService):
         async_fire_plant_event(self.hass, EVENT_PLANT_UPDATED, plant, updates)
         return plant
 
+    async def _commit_lifecycle_update(
+        self, plant_id: str, requested_updates: dict[str, Any]
+    ) -> Plant:
+        """Commit an editor lifecycle correction/transition and other fields once."""
+        canonical_target, target_date, target_start_supplied = (
+            self._lifecycle_edit_request(requested_updates)
+        )
+
+        async with self._lock:
+            observed_on = dt_util.now().date()
+            plant = self.repository.get_plant(plant_id)
+            if not plant:
+                raise PlantNotFoundError(f"Plant {plant_id} does not exist")
+
+            lifecycle = self._plant_lifecycle(
+                plant, observed_on=observed_on, allow_repair=True
+            )
+            if target_date is None:
+                target_date = dt_util.now()
+            try:
+                target_timestamp = to_lifecycle_timestamp(target_date)
+            except (TypeError, ValueError) as err:
+                raise ValidationChangeError(str(err)) from err
+
+            decision, correction = self._lifecycle_editor_decision(
+                lifecycle,
+                canonical_target,
+                target_timestamp,
+                observed_on,
+                target_start_supplied,
+            )
+
+            lifecycle_updates: dict[str, Any] = {}
+            if isinstance(decision, (Applied, LifecycleCorrection)):
+                lifecycle_updates = self._lifecycle_compatibility_updates(
+                    plant,
+                    decision,
+                    lifecycle,
+                    canonical_target,
+                    target_timestamp,
+                )
+
+            regular_updates = {
+                key: value
+                for key, value in requested_updates.items()
+                if key not in _LIFECYCLE_UPDATE_FIELDS
+            }
+            old_growspace_id = plant.growspace_id
+            new_growspace_id = regular_updates.get("growspace_id", old_growspace_id)
+            growspace_changed = new_growspace_id != old_growspace_id
+            if growspace_changed and not self.repository.has_growspace(
+                new_growspace_id
+            ):
+                raise GrowspaceNotFoundError(f"Growspace {new_growspace_id} not found")
+            position_changed = any(
+                key in regular_updates and regular_updates[key] != getattr(plant, key)
+                for key in ("row", "col")
+            )
+
+            plant_snapshot = deepcopy(plant)
+            growspace_snapshots = {
+                growspace_id: deepcopy(self.repository.get_growspace(growspace_id))
+                for growspace_id in {old_growspace_id, new_growspace_id}
+            }
+            event_updates = {**regular_updates, **lifecycle_updates}
+            try:
+                if "strain" in regular_updates:
+                    plant.genetics.strain_name = regular_updates.pop("strain")
+                if "phenotype" in regular_updates:
+                    plant.genetics.phenotype_name = regular_updates.pop("phenotype")
+
+                for key, value in {**regular_updates, **lifecycle_updates}.items():
+                    if hasattr(plant, key):
+                        setattr(plant, key, value)
+
+                plant.updated_at = plant_updated_date()
+                if growspace_changed:
+                    self._advance_layout_revision(old_growspace_id)
+                    self._advance_layout_revision(new_growspace_id)
+                elif position_changed:
+                    self._advance_layout_revision(old_growspace_id)
+                await self._save()
+            except BaseException:
+                self._restore_plant(plant, plant_snapshot)
+                self.repository.add_plant(plant)
+                for growspace_id, snapshot in growspace_snapshots.items():
+                    if snapshot is not None:
+                        self.repository.add_growspace(snapshot)
+                    self._invalidate(growspace_id)
+                raise
+
+        self._fire_event(
+            "plant_updated", {"plant": self.plant_view_builder.build(plant)}
+        )
+        async_fire_plant_event(self.hass, EVENT_PLANT_UPDATED, plant, event_updates)
+        if correction is not None:
+            self._emit_lifecycle_repair_event(plant, correction)
+        return plant
+
     # =========================================================================
     # PLANT CRUD OPERATIONS
     # =========================================================================
@@ -564,6 +856,9 @@ class PlantManager(BaseService):
 
     async def update_plant(self, plant_id: str, **updates: Any) -> Plant:
         """Update attributes of an existing plant."""
+        if _LIFECYCLE_UPDATE_FIELDS.intersection(updates):
+            return await self._commit_lifecycle_update(plant_id, dict(updates))
+
         async with self._lock:
             plant = self.repository.get_plant(plant_id)
             if not plant:

--- a/tests/logic/test_plant_lifecycle_manager.py
+++ b/tests/logic/test_plant_lifecycle_manager.py
@@ -265,9 +265,9 @@ async def test_update_plant_preserves_lifecycle_datetime_time(
     )
     repository_mock.get_plant.return_value = plant
 
-    await manager.update_plant("p1", flower_start="2026-03-01T14:30:00+00:00")
+    await manager.update_plant("p1", flower_start="2026-01-10T14:30:00+00:00")
 
-    # Stored as a full datetime string, not truncated to "2026-03-01".
+    # Stored as a full datetime string, not truncated to "2026-01-10".
     assert "T14:30" in plant.flower_start
 
 

--- a/tests/managers/test_plant_lifecycle_atomic.py
+++ b/tests/managers/test_plant_lifecycle_atomic.py
@@ -8,7 +8,10 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from custom_components.growspace_manager.const import PlantStage
+from custom_components.growspace_manager.const import (
+    EVENT_GROWSPACE_LOG_ENTRY,
+    PlantStage,
+)
 from custom_components.growspace_manager.data_access.growspace_repository import (
     GrowspaceRepository,
 )
@@ -299,3 +302,211 @@ async def test_invalid_graph_transition_is_rejected_without_mutation(
 
     assert plant.stage == PlantStage.SEEDLING
     assert len(plant.stage_history) == 1
+
+
+@pytest.mark.asyncio
+async def test_update_plant_forward_stage_edit_uses_lifecycle_transition(
+    manager_factory, repository: GrowspaceRepository
+) -> None:
+    """A graph-valid stage edit appends history instead of overwriting the shadow."""
+    manager = manager_factory()
+    plant = _plant("forward-edit", PlantStage.VEG, "2026-08-01")
+    repository.add_plant(plant)
+
+    await manager.update_plant(
+        "forward-edit",
+        stage=PlantStage.FLOWER,
+        flower_start=date(2026, 8, 10),
+        sex="female",
+    )
+
+    assert plant.stage == PlantStage.FLOWER
+    assert plant.flower_start == "2026-08-10T00:00:00+00:00"
+    assert plant.sex == "female"
+    assert plant.stage_history == [
+        {
+            "stage": "veg",
+            "start": "2026-08-01",
+            "end": "2026-08-10T00:00:00+00:00",
+        },
+        {
+            "stage": "flower",
+            "start": "2026-08-10T00:00:00+00:00",
+            "end": None,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_plant_backdated_current_start_emits_repair_event(
+    manager_factory, repository: GrowspaceRepository
+) -> None:
+    """Editing the open interval's start is an explicit, timeline-visible repair."""
+    manager = manager_factory()
+    plant = _plant("backdated-edit", PlantStage.VEG, "2026-08-10")
+    repository.add_plant(plant)
+
+    await manager.update_plant("backdated-edit", veg_start=date(2026, 8, 5))
+
+    assert plant.stage == PlantStage.VEG
+    assert plant.veg_start == "2026-08-05T00:00:00+00:00"
+    assert plant.stage_history == [
+        {
+            "stage": "veg",
+            "start": "2026-08-05T00:00:00+00:00",
+            "end": None,
+        }
+    ]
+    repair_events = [
+        call.args[1]
+        for call in manager.hass.bus.async_fire.call_args_list
+        if call.args[0] == EVENT_GROWSPACE_LOG_ENTRY
+    ]
+    assert repair_events == [
+        {
+            "plant_id": "backdated-edit",
+            "growspace_id": "main",
+            "sensor_type": "lifecycle_repair",
+            "category": "milestone",
+            "timestamp": repair_events[0]["timestamp"],
+            "notes": "Lifecycle corrected through update_plant",
+            "reasons": ["Corrected Veg start to 2026-08-05"],
+            "previous_stage": "veg",
+            "corrected_stage": "veg",
+            "corrected_stage_started_on": "2026-08-05",
+            "corrected_on": repair_events[0]["corrected_on"],
+            "discarded_interval_count": 1,
+            "warning_codes": [],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_plant_ambiguous_correction_discards_later_intervals(
+    manager_factory, repository: GrowspaceRepository
+) -> None:
+    """A non-transition correction retains only a graph-compatible trusted prefix."""
+    manager = manager_factory()
+    plant = Plant(
+        plant_id="ambiguous-edit",
+        growspace_id="main",
+        genetics=PlantGenetics(strain_name="Test"),
+        stage=PlantStage.FLOWER,
+        seedling_start="2026-08-01",
+        veg_start="2026-08-05",
+        flower_start="2026-08-10",
+        stage_history=[
+            {"stage": "seedling", "start": "2026-08-01", "end": "2026-08-05"},
+            {"stage": "veg", "start": "2026-08-05", "end": "2026-08-10"},
+            {"stage": "flower", "start": "2026-08-10", "end": None},
+        ],
+    )
+    repository.add_plant(plant)
+
+    await manager.update_plant(
+        "ambiguous-edit",
+        stage=PlantStage.MOTHER,
+        mother_start=date(2026, 8, 7),
+    )
+
+    assert plant.stage == PlantStage.MOTHER
+    assert plant.mother_start == "2026-08-07T00:00:00+00:00"
+    assert plant.seedling_start is None
+    assert plant.veg_start is None
+    assert plant.flower_start is None
+    assert plant.stage_history == [
+        {
+            "stage": "mother",
+            "start": "2026-08-07T00:00:00+00:00",
+            "end": None,
+        }
+    ]
+    repair_event = next(
+        call.args[1]
+        for call in manager.hass.bus.async_fire.call_args_list
+        if call.args[0] == EVENT_GROWSPACE_LOG_ENTRY
+    )
+    assert repair_event["discarded_interval_count"] == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    [
+        ({"stage": "unknown-stage"}, "Invalid lifecycle stage"),
+        (
+            {"stage": PlantStage.FLOWER, "flower_start": date(2026, 7, 31)},
+            "predate the open interval",
+        ),
+        ({"veg_start": date(2099, 1, 1)}, "after corrected_on"),
+    ],
+)
+async def test_update_plant_rejects_invalid_lifecycle_edit_without_mutation(
+    manager_factory,
+    repository: GrowspaceRepository,
+    updates: dict[str, object],
+    message: str,
+) -> None:
+    """Unknown, too-early, and future lifecycle edits leave the Plant untouched."""
+    manager = manager_factory()
+    plant = _plant("rejected-edit", PlantStage.VEG, "2026-08-01")
+    repository.add_plant(plant)
+
+    with pytest.raises(ValidationChangeError, match=message):
+        await manager.update_plant("rejected-edit", **updates)
+
+    assert plant.stage == PlantStage.VEG
+    assert plant.veg_start == "2026-08-01"
+    assert plant.flower_start is None
+    assert plant.stage_history == [{"stage": "veg", "start": "2026-08-01", "end": None}]
+
+
+@pytest.mark.asyncio
+async def test_update_plant_plain_edit_skips_lifecycle_parse(
+    manager_factory, repository: GrowspaceRepository
+) -> None:
+    """Notes and position edits retain the ordinary update cost."""
+    manager = manager_factory()
+    plant = _plant("plain-edit", PlantStage.VEG, "2026-08-01")
+    repository.add_plant(plant)
+    manager._plant_lifecycle = Mock(wraps=manager._plant_lifecycle)
+
+    await manager.update_plant("plain-edit", sex="female", row=2)
+
+    assert plant.sex == "female"
+    assert plant.row == 2
+    manager._plant_lifecycle.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_failed_lifecycle_update_restores_mixed_fields_and_placement(
+    manager_factory, repository: GrowspaceRepository
+) -> None:
+    """Lifecycle, ordinary fields, layout, and placement roll back as one write."""
+    repository.add_growspace(Growspace(id="target", name="Target"))
+    manager = manager_factory(AsyncMock(side_effect=RuntimeError("disk failed")))
+    plant = _plant("mixed-rollback", PlantStage.VEG, "2026-08-01")
+    repository.add_plant(plant)
+    revisions = {
+        growspace_id: repository.require_growspace(growspace_id).layout_revision
+        for growspace_id in ("main", "target")
+    }
+
+    with pytest.raises(RuntimeError, match="disk failed"):
+        await manager.update_plant(
+            "mixed-rollback",
+            stage=PlantStage.FLOWER,
+            flower_start=date(2026, 8, 10),
+            growspace_id="target",
+            sex="female",
+        )
+
+    assert plant.stage == PlantStage.VEG
+    assert plant.growspace_id == "main"
+    assert plant.sex is None
+    assert plant.flower_start is None
+    assert plant.stage_history == [{"stage": "veg", "start": "2026-08-01", "end": None}]
+    assert {
+        growspace_id: repository.require_growspace(growspace_id).layout_revision
+        for growspace_id in ("main", "target")
+    } == revisions

--- a/tests/services/test_plant_services.py
+++ b/tests/services/test_plant_services.py
@@ -611,7 +611,7 @@ async def test_move_clone_invalid_date(
     mock_coordinator.services.plants.promote_clone.assert_called_once()
     # Logic in service: transitions invalid date string to today
     kwargs = mock_coordinator.services.plants.promote_clone.call_args_list[0].kwargs
-    # Unparseable date falls back to now as a full datetime (ADR-0013).
+    # Unparsable date falls back to now as a full datetime (ADR-0013).
     assert kwargs["transition_date"].date() == datetime.now(UTC).date()
 
 
@@ -739,6 +739,30 @@ async def test_update_plant_not_found(
         )
 
     mock_coordinator._plant_manager.update_plant.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_plant_lifecycle_rejection_is_service_validation_error(
+    hass: HomeAssistant, mock_coordinator, mock_strain_library, mock_plant
+) -> None:
+    """Domain lifecycle rejections surface as user-correctable service errors."""
+    mock_coordinator.plants = {"plant_1": mock_plant}
+    mock_coordinator._plant_manager.update_plant.side_effect = ValidationChangeError(
+        "Future-dated transitions are not allowed"
+    )
+    call = ServiceCall(
+        hass,
+        domain=DOMAIN,
+        service="update_plant",
+        data={"plant_id": "plant_1", "stage": "flower"},
+    )
+
+    with pytest.raises(
+        ServiceValidationError, match="Future-dated transitions are not allowed"
+    ):
+        await mock_coordinator.services.plants.update_plant_from_call(
+            hass, mock_strain_library, call
+        )
 
 
 @pytest.mark.asyncio
@@ -1243,7 +1267,9 @@ async def test_move_plant_exception(
     """Test exception handling in move_plant."""
     mock_coordinator.plants = {"plant_1": mock_plant}
     mock_coordinator.growspaces = {"gs1": mock_growspace}
-    mock_coordinator._plant_manager.move_plant.side_effect = GrowspaceError("Test error")
+    mock_coordinator._plant_manager.move_plant.side_effect = GrowspaceError(
+        "Test error"
+    )
     mock_coordinator.get_growspace_plants = Mock(return_value=[mock_plant])
 
     call = ServiceCall(


### PR DESCRIPTION
## Summary

- route update_plant stage edits through Plant Lifecycle transitions when graph-valid
- route history-rewriting date and stage edits through repair_current and emit a plant-filterable lifecycle repair timeline event
- commit lifecycle, ordinary plant fields, growspace placement, layout revisions, and Stage History atomically with rollback on persistence failure
- preserve the plain-field fast path without lifecycle parsing

## Tests

- pre-commit hooks passed: ruff, targeted formatting, codespell, pytest, and mypy
- canonical backend fast suite: 5216 passed and 46 snapshots passed
- canonical repository-wide format check still reports the known pre-existing 132-file drift; none of the files changed by this PR are in that list

Fixes #651