### PR TITLE
fix(environment): preserve band identity in stage selectors

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,6 +66,12 @@ The cumulative days a Plant has spent in each canonical stage, including repeate
 **Cultivation Band**
 The stable age classification within the Current Stage: Seedling and Clone are Acclimating on days 0–6 and Established on day 7 onward; Flower is Early on days 0–20, Mid on days 21–41, and Late on day 42 onward. A separate adjacent-band interpolation hint is available in the three days before a boundary, but never changes the reported band identity early.
 
+**Band Identity**
+The [[Cultivation Band]] a Plant or growspace is currently in. It changes only at the band's actual age boundary; an adjacent-band interpolation hint blends numeric environmental targets without changing this identity early.
+
+**Transition Blend**
+A numeric ramp from one [[Current Stage]] into the next, distinct from interpolation between [[Cultivation Band]]s within one stage. Its reported stage changes to the destination at the ramp's midpoint; the seedling-to-veg ramp is the current example.
+
 **Lifecycle Transition**
 An immutable `Applied`, `NoChange`, or `Rejected` proposal. It carries before/after lifecycle values and facts, [[Compatibility Data]], and any Lifecycle Repair Event draft; applying persistence, moves, or events belongs to a separate effect shell.
 

--- a/custom_components/growspace_manager/CONTEXT.md
+++ b/custom_components/growspace_manager/CONTEXT.md
@@ -30,7 +30,7 @@ The aggregated per-stage maximum-days inputs for a growspace, derived from its p
 
 ## StageClassification
 
-The canonical output of `classify_stages(StageDays)`, defined in `domain/stage.py`. Carries `stage_a` and `stage_b` (`BayesianStage` enum values) and a `factor` (0.0–1.0) for smooth VPD threshold interpolation across stage boundaries, plus a `display_stage` property that collapses internal Bayesian sub-stages (e.g. `SEEDLING_STANDARD` → `SEEDLING`) and applies the factor-≥-0.5 flip rule for the card-visible label. `EMPTY` classification disables VPD monitoring and Bayesian evaluation — used when a growspace has no active plants.
+The canonical output of `classify_stages(StageDays)`, defined in `domain/stage.py`. Carries `stage_a` and `stage_b` (`BayesianStage` enum values), a `factor` (0.0–1.0) for smooth VPD threshold interpolation, and `is_transition_blend`, which distinguishes a lifecycle transition from an in-stage band interpolation. Its `display_stage` property preserves `stage_a` as the reported selector during band interpolation, flips to `stage_b` at a transition blend's midpoint, and collapses internal Bayesian sub-stages (e.g. `SEEDLING_STANDARD` → `SEEDLING`). `EMPTY` classification disables VPD monitoring and Bayesian evaluation — used when a growspace has no active plants.
 
 ## EnvironmentConfig
 

--- a/custom_components/growspace_manager/domain/stage.py
+++ b/custom_components/growspace_manager/domain/stage.py
@@ -84,11 +84,16 @@ class StageClassification:
     stage_a: BayesianStage
     stage_b: BayesianStage
     factor: float
+    is_transition_blend: bool = False
 
     @property
     def display_stage(self) -> BayesianStage:
-        """Card-visible stage: flips to stage_b once factor ≥ 0.5, then collapses sub-stages."""
-        raw = self.stage_b if self.factor >= 0.5 else self.stage_a
+        """Reported selector stage, preserving band identity during interpolation."""
+        raw = (
+            self.stage_b
+            if self.is_transition_blend and self.factor >= 0.5
+            else self.stage_a
+        )
         return _COLLAPSE_MAP.get(raw, raw)
 
 
@@ -146,6 +151,7 @@ def classify_stages(days: StageDays) -> StageClassification:
                 BayesianStage.SEEDLING_STANDARD,
                 BayesianStage.VEG,
                 round(float(factor), 2),
+                is_transition_blend=True,
             )
         return StageClassification(BayesianStage.VEG, BayesianStage.VEG, 0.0)
 

--- a/tests/domain/test_cultivation_band.py
+++ b/tests/domain/test_cultivation_band.py
@@ -20,6 +20,9 @@ from custom_components.growspace_manager.domain.cultivation_band import (
     growspace_cultivation_band,
     plant_cultivation_band,
 )
+from custom_components.growspace_manager.domain.fan_control import (
+    resolve_stage_vpd_target,
+)
 from custom_components.growspace_manager.domain.plant_lifecycle import CultivationBandId
 from custom_components.growspace_manager.domain.stage import (
     BayesianStage,
@@ -164,6 +167,36 @@ def test_day_21_and_42_are_the_days_the_band_changes() -> None:
     assert bands[21] is CultivationBandId.MID_FLOWER
     assert bands[41] is CultivationBandId.MID_FLOWER
     assert bands[42] is CultivationBandId.LATE_FLOWER
+
+
+@pytest.mark.parametrize(
+    ("flower_day", "expected_stage"),
+    [
+        (20, BayesianStage.FLOWER_EARLY),
+        (41, BayesianStage.FLOWER_MID),
+    ],
+)
+def test_current_stage_vpd_override_matches_the_reported_granular_stage(
+    flower_day: int,
+    expected_stage: BayesianStage,
+) -> None:
+    """The card's Current row names the override the fan resolver applies."""
+    overrides = {
+        "flower_early": {"day": 1.01, "night": 1.02},
+        "flower_mid": {"day": 1.21, "night": 1.22},
+        "flower_late": {"day": 1.41, "night": 1.42},
+    }
+    classification = classify_stages(StageDays(flower=flower_day))
+
+    # EnvironmentAnalyzer publishes display_stage as granular_stage; the card
+    # marks that key Current. It must name the same override used by both fans.
+    granular_stage = classification.display_stage
+    applied_target = resolve_stage_vpd_target(
+        [_flowering_plant(flower_day)], overrides, fallback_vpd_target=0.5, is_day=True
+    )
+
+    assert granular_stage is expected_stage
+    assert applied_target == overrides[granular_stage.value]["day"]
 
 
 def test_the_growspace_band_is_the_most_demanding_plant() -> None:

--- a/tests/logic/test_environment_analyzer.py
+++ b/tests/logic/test_environment_analyzer.py
@@ -71,6 +71,26 @@ def test_classify_stages_display_stage_via_domain() -> None:
     assert classify_stages(StageDays()).display_stage == BayesianStage.EMPTY
 
 
+@pytest.mark.parametrize(
+    ("days", "expected_stage"),
+    [
+        (StageDays(flower=20), BayesianStage.FLOWER_EARLY),
+        (StageDays(flower=41), BayesianStage.FLOWER_MID),
+        (StageDays(veg=2), BayesianStage.VEG),
+    ],
+)
+def test_biological_metrics_reports_the_current_stage_selector(
+    analyzer: EnvironmentAnalyzer,
+    mock_growspace,
+    days: StageDays,
+    expected_stage: BayesianStage,
+) -> None:
+    """granular_stage preserves bands but flips a true transition at midpoint."""
+    metrics = analyzer.calculate_biological_metrics(mock_growspace, days)
+
+    assert metrics["granular_stage"] is expected_stage
+
+
 def test_determine_is_day(
     hass: HomeAssistant, analyzer: EnvironmentAnalyzer, mock_growspace
 ) -> None:

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -293,35 +293,80 @@ def test_interpolate_value() -> None:
 
 def test_classify_stages() -> None:
     """Test classify_stages for all branches."""
+
     def sc(days: StageDays) -> tuple[BayesianStage, BayesianStage, float]:
         r = classify_stages(days)
         return r.stage_a, r.stage_b, r.factor
 
     # Flower — early (before transition window)
-    assert sc(StageDays(flower=10)) == (BayesianStage.FLOWER_EARLY, BayesianStage.FLOWER_EARLY, 0.0)
+    assert sc(StageDays(flower=10)) == (
+        BayesianStage.FLOWER_EARLY,
+        BayesianStage.FLOWER_EARLY,
+        0.0,
+    )
     # Flower — early→mid transition (window is 3, boundary is 21)
-    assert sc(StageDays(flower=20)) == (BayesianStage.FLOWER_EARLY, BayesianStage.FLOWER_MID, 0.67)
+    assert sc(StageDays(flower=20)) == (
+        BayesianStage.FLOWER_EARLY,
+        BayesianStage.FLOWER_MID,
+        0.67,
+    )
     # Flower — mid
-    assert sc(StageDays(flower=25)) == (BayesianStage.FLOWER_MID, BayesianStage.FLOWER_MID, 0.0)
+    assert sc(StageDays(flower=25)) == (
+        BayesianStage.FLOWER_MID,
+        BayesianStage.FLOWER_MID,
+        0.0,
+    )
     # Flower — mid→late transition (boundary is 42)
-    assert sc(StageDays(flower=41)) == (BayesianStage.FLOWER_MID, BayesianStage.FLOWER_LATE, 0.67)
+    assert sc(StageDays(flower=41)) == (
+        BayesianStage.FLOWER_MID,
+        BayesianStage.FLOWER_LATE,
+        0.67,
+    )
     # Flower — late
-    assert sc(StageDays(flower=50)) == (BayesianStage.FLOWER_LATE, BayesianStage.FLOWER_LATE, 0.0)
+    assert sc(StageDays(flower=50)) == (
+        BayesianStage.FLOWER_LATE,
+        BayesianStage.FLOWER_LATE,
+        0.0,
+    )
 
     # Veg — transition from seedling_standard (window is 3)
-    assert sc(StageDays(veg=1)) == (BayesianStage.SEEDLING_STANDARD, BayesianStage.VEG, 0.33)
+    assert sc(StageDays(veg=1)) == (
+        BayesianStage.SEEDLING_STANDARD,
+        BayesianStage.VEG,
+        0.33,
+    )
     # Veg — stable
     assert sc(StageDays(veg=5)) == (BayesianStage.VEG, BayesianStage.VEG, 0.0)
 
     # Seedling — acclimation (start=3, end=7)
-    assert sc(StageDays(seedling=2)) == (BayesianStage.SEEDLING, BayesianStage.SEEDLING, 0.0)
-    assert sc(StageDays(seedling=5)) == (BayesianStage.SEEDLING, BayesianStage.SEEDLING_STANDARD, 0.5)
-    assert sc(StageDays(seedling=8)) == (BayesianStage.SEEDLING_STANDARD, BayesianStage.SEEDLING_STANDARD, 0.0)
+    assert sc(StageDays(seedling=2)) == (
+        BayesianStage.SEEDLING,
+        BayesianStage.SEEDLING,
+        0.0,
+    )
+    assert sc(StageDays(seedling=5)) == (
+        BayesianStage.SEEDLING,
+        BayesianStage.SEEDLING_STANDARD,
+        0.5,
+    )
+    assert sc(StageDays(seedling=8)) == (
+        BayesianStage.SEEDLING_STANDARD,
+        BayesianStage.SEEDLING_STANDARD,
+        0.0,
+    )
 
     # Clone — acclimation
     assert sc(StageDays(clone=2)) == (BayesianStage.CLONE, BayesianStage.CLONE, 0.0)
-    assert sc(StageDays(clone=5)) == (BayesianStage.CLONE, BayesianStage.CLONE_STANDARD, 0.5)
-    assert sc(StageDays(clone=8)) == (BayesianStage.CLONE_STANDARD, BayesianStage.CLONE_STANDARD, 0.0)
+    assert sc(StageDays(clone=5)) == (
+        BayesianStage.CLONE,
+        BayesianStage.CLONE_STANDARD,
+        0.5,
+    )
+    assert sc(StageDays(clone=8)) == (
+        BayesianStage.CLONE_STANDARD,
+        BayesianStage.CLONE_STANDARD,
+        0.0,
+    )
 
     # Empty — no plants at all (was previously VEG fallback)
     assert sc(StageDays()) == (BayesianStage.EMPTY, BayesianStage.EMPTY, 0.0)
@@ -333,24 +378,47 @@ def test_classify_stages() -> None:
 
 
 def test_classify_stages_display_stage() -> None:
-    """Test display_stage collapses sub-stages and applies factor threshold."""
+    """Test display_stage preserves bands and flips only lifecycle transitions."""
     # Sub-stage collapsing
-    assert classify_stages(StageDays(seedling=8)).display_stage == BayesianStage.SEEDLING
+    assert (
+        classify_stages(StageDays(seedling=8)).display_stage == BayesianStage.SEEDLING
+    )
     assert classify_stages(StageDays(clone=8)).display_stage == BayesianStage.CLONE
     assert classify_stages(StageDays(veg=5)).display_stage == BayesianStage.VEG
 
     # Factor < 0.5 → display stage_a (collapsed)
-    r = classify_stages(StageDays(seedling=5))  # factor=0.5, stage_a=SEEDLING, stage_b=SEEDLING_STANDARD
+    r = classify_stages(
+        StageDays(seedling=5)
+    )  # factor=0.5, stage_a=SEEDLING, stage_b=SEEDLING_STANDARD
     assert r.factor == 0.5
-    assert r.display_stage == BayesianStage.SEEDLING  # 0.5 >= 0.5 → stage_b, collapsed to SEEDLING
+    assert (
+        r.display_stage == BayesianStage.SEEDLING
+    )  # 0.5 >= 0.5 → stage_b, collapsed to SEEDLING
 
-    # Factor >= 0.5 → stage_b
-    r = classify_stages(StageDays(flower=20))  # factor=0.67, stage_a=FLOWER_EARLY, stage_b=FLOWER_MID
-    assert r.display_stage == BayesianStage.FLOWER_MID
-
-    # Factor < 0.5 → stage_a
-    r = classify_stages(StageDays(flower=10))  # factor=0.0 → stage_a=FLOWER_EARLY
+    # A band interpolation never moves the reported identity early.
+    r = classify_stages(
+        StageDays(flower=20)
+    )  # factor=0.67, stage_a=FLOWER_EARLY, stage_b=FLOWER_MID
+    assert r.is_transition_blend is False
     assert r.display_stage == BayesianStage.FLOWER_EARLY
+    assert (
+        classify_stages(StageDays(flower=41)).display_stage == BayesianStage.FLOWER_MID
+    )
+
+    # A lifecycle transition still flips at the midpoint.
+    r = classify_stages(StageDays(veg=2))
+    assert r.is_transition_blend is True
+    assert r.display_stage == BayesianStage.VEG
+
+    # Seedling and clone acclimation sub-stages always collapse to their parent.
+    for day in range(10):
+        assert (
+            classify_stages(StageDays(seedling=day)).display_stage
+            == BayesianStage.SEEDLING
+        )
+        assert (
+            classify_stages(StageDays(clone=day)).display_stage == BayesianStage.CLONE
+        )
 
     # Empty → EMPTY
     assert classify_stages(StageDays()).display_stage == BayesianStage.EMPTY


### PR DESCRIPTION
## Summary
- distinguish cultivation-band interpolation from true lifecycle transition blends in StageClassification
- keep flower day 20 on flower_early and day 41 on flower_mid while preserving the numeric target blend
- keep the seedling-to-veg midpoint flip and seedling/clone selector collapsing unchanged
- assert that granular_stage names the same Stage VPD override applied by the fan resolver

## Testing
- focused regression matrix: 6 passed
- related stage/environment files: 88 passed
- backend suite: 5218 passed
- Ruff lint and mypy: passed
- changed Python files: Ruff format passed

The workspace-wide format check still reports unrelated legacy formatting debt outside the changed files.

Closes #659