### PR TITLE
Migrate analytics to lifetime stage days

### DIFF
--- a/custom_components/growspace_manager/domain/__init__.py
+++ b/custom_components/growspace_manager/domain/__init__.py
@@ -11,6 +11,7 @@ from .date_logic import (
     get_days_since_watering,
 )
 from .grid_builder import build_position_grid
+from .lifetime_stage_days import resolve_lifetime_stage_days
 from .plant_lifecycle import (
     KNOWN_STAGES,
     TRANSITION_GRAPH,
@@ -66,4 +67,5 @@ __all__ = [
     "get_days_since_ipm",
     "get_days_since_training",
     "get_days_since_watering",
+    "resolve_lifetime_stage_days",
 ]

--- a/custom_components/growspace_manager/domain/lifetime_stage_days.py
+++ b/custom_components/growspace_manager/domain/lifetime_stage_days.py
@@ -1,0 +1,39 @@
+"""Plant read adapter for [[Lifetime Stage Days]]."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date
+from typing import TYPE_CHECKING
+
+from .plant_lifecycle import KNOWN_STAGES, LifetimeStageDays, PlantLifecycle
+
+if TYPE_CHECKING:
+    from custom_components.growspace_manager.models import Plant
+
+
+def resolve_lifetime_stage_days(
+    plant: Plant, *, observed_on: date
+) -> LifetimeStageDays:
+    """Return cumulative stage days from one Plant Lifecycle facts snapshot.
+
+    A stored Stage History is authoritative. Older Plants whose history is absent
+    are reconstructed from their legacy lifecycle dates by ``PlantLifecycle``;
+    malformed present history stays fail-closed and therefore reports zeroes.
+    """
+    stored_history = getattr(plant, "stage_history", None)
+    raw_history: list[object] | None = (
+        [dict(item) if isinstance(item, Mapping) else item for item in stored_history]
+        if isinstance(stored_history, list) and stored_history
+        else None
+    )
+    legacy_dates = {
+        f"{stage.value}_start": getattr(plant, f"{stage.value}_start", None)
+        for stage in KNOWN_STAGES
+    }
+    lifecycle = PlantLifecycle.from_data(
+        raw_history,
+        observed_on=observed_on,
+        legacy_dates=legacy_dates,
+    )
+    return lifecycle.facts(on=observed_on).lifetime_stage_days

--- a/custom_components/growspace_manager/managers/plant.py
+++ b/custom_components/growspace_manager/managers/plant.py
@@ -18,6 +18,9 @@ from custom_components.growspace_manager.const import (
     PlantStage,
 )
 from custom_components.growspace_manager.domain.date_logic import plant_updated_date
+from custom_components.growspace_manager.domain.lifetime_stage_days import (
+    resolve_lifetime_stage_days,
+)
 from custom_components.growspace_manager.domain.plant_lifecycle import (
     TRANSITION_GRAPH,
     Applied,
@@ -28,9 +31,6 @@ from custom_components.growspace_manager.domain.plant_lifecycle import (
     Rejected,
 )
 from custom_components.growspace_manager.domain.stage import STAGE_REGISTRY
-from custom_components.growspace_manager.domain.stage_calculator import (
-    calculate_days_in_stage,
-)
 from custom_components.growspace_manager.events import (
     EVENT_PLANT_ADDED,
     EVENT_PLANT_HARVESTED,
@@ -1756,8 +1756,10 @@ class PlantManager(BaseService):
 
     async def _record_analytics(self, plant: Plant) -> None:
         """Record harvest analytics for a plant."""
-        veg_days = calculate_days_in_stage(plant, PlantStage.VEG)
-        flower_days = calculate_days_in_stage(plant, PlantStage.FLOWER)
+        observed_on = dt_util.now().date()
+        lifetime_days = resolve_lifetime_stage_days(plant, observed_on=observed_on)
+        veg_days = lifetime_days.veg
+        flower_days = lifetime_days.flower
         if self.strain_library and (veg_days > 0 or flower_days > 0):
             try:
                 metrics = getattr(plant, "harvest_metrics", None)

--- a/custom_components/growspace_manager/services/ai_assistant.py
+++ b/custom_components/growspace_manager/services/ai_assistant.py
@@ -13,9 +13,8 @@ from custom_components.growspace_manager.const import (
     CONF_AI_ENABLED,
     CONF_ASSISTANT_ID,
     GrowspaceService,
-    PlantStage,
 )
-from custom_components.growspace_manager.domain import calculate_days_in_stage
+from custom_components.growspace_manager.domain import resolve_lifetime_stage_days
 from custom_components.growspace_manager.domain.moisture_band import (
     interpret_moisture_reading,
 )
@@ -27,6 +26,7 @@ from custom_components.growspace_manager.schemas import (
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import Context, HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.util import dt as dt_util
 
 from ._definition import ServiceDefinition
 from .strain_library import StrainLibrary
@@ -210,37 +210,23 @@ class GrowAssistant:
 
         stages: dict[str, int] = {}
         strains = set()
+        observed_on = dt_util.now().date()
+        lifetime_days = [
+            resolve_lifetime_stage_days(plant, observed_on=observed_on)
+            for plant in plants
+        ]
 
         for plant in plants:
             stage = getattr(plant, "stage", "unknown")
             stages[stage] = stages.get(stage, 0) + 1
             strains.add(plant.strain)
 
-            # Calculate stage durations
-            # Calculate stage durations (unused but potentially useful for future)
-            # veg_days = self.coordinator.calculate_days_in_stage(plant, "veg")
-            # flower_days = self.coordinator.calculate_days_in_stage(plant, "flower")
-
         return {
             "count": len(plants),
             "stages": stages,
             "strains": list(strains),
-            "max_veg_days": max(
-                (
-                    calculate_days_in_stage(p, PlantStage.VEG)
-                    for p in plants
-                    if p.veg_start
-                ),
-                default=0,
-            ),
-            "max_flower_days": max(
-                (
-                    calculate_days_in_stage(p, PlantStage.FLOWER)
-                    for p in plants
-                    if p.flower_start
-                ),
-                default=0,
-            ),
+            "max_veg_days": max((days.veg for days in lifetime_days), default=0),
+            "max_flower_days": max((days.flower for days in lifetime_days), default=0),
         }
 
     def _get_strain_analytics(self, plants: list[Any]) -> dict[str, Any]:

--- a/tests/integration/test_lifetime_stage_days_consumers.py
+++ b/tests/integration/test_lifetime_stage_days_consumers.py
@@ -1,0 +1,46 @@
+"""Regression coverage for Lifetime Stage Days consumers."""
+
+from unittest.mock import MagicMock
+
+from custom_components.growspace_manager.models import Growspace, Plant, PlantGenetics
+from custom_components.growspace_manager.services.ai_assistant import GrowAssistant
+from homeassistant.core import HomeAssistant
+
+
+def test_ai_grow_context_uses_lifetime_days_after_reveg() -> None:
+    """AI grow context sums every historical veg and flower interval."""
+    plant = Plant(
+        plant_id="reveg-summary",
+        growspace_id="tent",
+        genetics=PlantGenetics(strain_name="Strain A"),
+        stage="dry",
+        # The legacy calculation sees only these latest starts: 20d veg, 10d flower.
+        veg_start="2025-07-21",
+        flower_start="2025-08-10",
+        dry_start="2025-08-20",
+        stage_history=[
+            {"stage": "veg", "start": "2025-07-01", "end": "2025-07-11"},
+            {"stage": "flower", "start": "2025-07-11", "end": "2025-07-21"},
+            {"stage": "veg", "start": "2025-07-21", "end": "2025-08-10"},
+            {"stage": "flower", "start": "2025-08-10", "end": "2025-08-20"},
+            {"stage": "dry", "start": "2025-08-20", "end": None},
+        ],
+    )
+    growspace = Growspace(id="tent", name="Tent")
+    coordinator = MagicMock()
+    coordinator._data_repository.get_growspace.return_value = growspace
+    coordinator._data_repository.get_growspace_plants.return_value = [plant]
+    hass = MagicMock(spec=HomeAssistant)
+    hass.states = MagicMock()
+    hass.states.get.return_value = None
+    strain_library = MagicMock()
+    strain_library.get_all.return_value = {}
+
+    data = GrowAssistant(hass, coordinator, strain_library).gather_growspace_data(
+        "tent"
+    )
+
+    assert (
+        data["plants"]["max_veg_days"],
+        data["plants"]["max_flower_days"],
+    ) == (30, 20)

--- a/tests/integration/test_plant_lifecycle_coverage.py
+++ b/tests/integration/test_plant_lifecycle_coverage.py
@@ -1,7 +1,7 @@
 """Additional tests for plant_lifecycle_manager coverage."""
 
 from datetime import date
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -150,22 +150,24 @@ async def test_record_analytics_exception_handling(
         plant_id="test_plant",
         growspace_id="test_growspace",
         strain="Test Strain",
+        stage="dry",
         veg_start="2024-01-01",
-        flower_start="2024-02-01",
+        flower_start="2024-01-31",
+        dry_start="2024-03-31",
+        stage_history=[
+            {"stage": "veg", "start": "2024-01-01", "end": "2024-01-31"},
+            {"stage": "flower", "start": "2024-01-31", "end": "2024-03-31"},
+            {"stage": "dry", "start": "2024-03-31", "end": None},
+        ],
     )
 
-    # Patch calculate_days_in_stage to return positive days
-    with patch(
-        "custom_components.growspace_manager.managers.plant.calculate_days_in_stage",
-        side_effect=[30, 60],
-    ):
-        # Mock strain_library.record_harvest to raise exception
-        strain_library_mock.record_harvest = AsyncMock(
-            side_effect=Exception("Database error")
-        )
+    # Mock strain_library.record_harvest to raise exception
+    strain_library_mock.record_harvest = AsyncMock(
+        side_effect=Exception("Database error")
+    )
 
-        # Should not raise, exception is caught and logged
-        await manager._record_analytics(plant)
+    # Should not raise, exception is caught and logged
+    await manager._record_analytics(plant)
 
     # Verify record_harvest was called with scores (all None since plant has no scores set)
     strain_library_mock.record_harvest.assert_awaited_once_with(

--- a/tests/managers/test_plant_lifecycle_atomic.py
+++ b/tests/managers/test_plant_lifecycle_atomic.py
@@ -187,6 +187,37 @@ async def test_all_mutation_paths_append_stage_history(
 
 
 @pytest.mark.asyncio
+async def test_harvest_analytics_record_lifetime_days_after_reveg(
+    manager_factory, repository: GrowspaceRepository
+) -> None:
+    """Harvest analytics sum every veg and flower interval after a Reveg."""
+    manager = manager_factory()
+    plant = Plant(
+        plant_id="reveg-harvest",
+        growspace_id="main",
+        genetics=PlantGenetics(strain_name="Test", phenotype_name="Keeper"),
+        stage=PlantStage.FLOWER,
+        # The legacy calculation sees only these latest starts: 20d veg, 10d flower.
+        veg_start="2025-07-21",
+        flower_start="2025-08-10",
+        stage_history=[
+            {"stage": "veg", "start": "2025-07-01", "end": "2025-07-11"},
+            {"stage": "flower", "start": "2025-07-11", "end": "2025-07-21"},
+            {"stage": "veg", "start": "2025-07-21", "end": "2025-08-10"},
+            {"stage": "flower", "start": "2025-08-10", "end": None},
+        ],
+    )
+    repository.add_plant(plant)
+
+    await manager.transition_plant_stage(
+        plant.plant_id, PlantStage.DRY, date(2025, 8, 20)
+    )
+
+    recorded = manager.strain_library.record_harvest.await_args.args
+    assert recorded[2:4] == (30, 20)
+
+
+@pytest.mark.asyncio
 async def test_reveg_clears_stale_later_stage_fields(
     manager_factory, repository: GrowspaceRepository
 ) -> None:


### PR DESCRIPTION
## Summary

- add a shared Plant Lifecycle adapter for Lifetime Stage Days
- record harvest analytics and build AI grow-context summaries from the same lifetime figures
- add reveg regressions showing the correct 30d veg / 20d flower totals instead of the legacy 20d / 10d latest-interval figures

## Testing

- pre-commit hooks: Ruff check/format, codespell, pytest, and mypy
- full backend suite: 5,223 tests passed; 46 snapshots passed

Closes #636