### PR TITLE
feat(irrigation): accept pump flow rate settings

### DIFF
--- a/custom_components/growspace_manager/schemas.py
+++ b/custom_components/growspace_manager/schemas.py
@@ -719,6 +719,9 @@ SET_IRRIGATION_SETTINGS_SCHEMA = vol.All(
         {
             vol.Required("growspace_id"): vol.All(str, valid_growspace_id),
             vol.Optional("irrigation_pump_entity"): str,
+            vol.Optional("pump_flow_rate_ml_per_sec"): vol.All(
+                vol.Coerce(float), vol.Range(min=0.0)
+            ),
             vol.Optional("drain_pump_entity"): str,
             vol.Optional("irrigation_duration"): vol.All(
                 vol.Coerce(int), vol.Range(min=1)

--- a/custom_components/growspace_manager/services.yaml
+++ b/custom_components/growspace_manager/services.yaml
@@ -1303,6 +1303,14 @@ set_irrigation_settings:
       selector:
         entity:
           domain: switch
+    pump_flow_rate_ml_per_sec:
+      description: Measured irrigation pump flow rate used by Volume Mode.
+      required: false
+      selector:
+        number:
+          min: 0
+          step: 0.1
+          unit_of_measurement: "mL/s"
     drain_pump_entity:
       description: The switch entity for the drain pump.
       required: false

--- a/custom_components/growspace_manager/services/irrigation.py
+++ b/custom_components/growspace_manager/services/irrigation.py
@@ -191,8 +191,8 @@ def _validate_volume_mode_selection(
     # Effective values: an incoming update wins over the stored state for both
     # the per-pot volume and the pump flow rate, so a single call (e.g. the
     # config-flow form) may set the profile, the flow rate, and the mode at once.
-    # The service schema never carries ``pump_flow_rate_ml_per_sec`` (a config
-    # field), so for the service path this falls back to the stored value.
+    # The settings service stores the pump flow rate separately from the
+    # strategy, so strategy updates fall back to the persisted config value.
     stored_profile = growspace.irrigation_strategy.substrate_profile
     profile_update = strategy.get("substrate_profile", {})
     liters_per_pot = profile_update.get("liters_per_pot", stored_profile.liters_per_pot)

--- a/tests/core/test_services_irrigation.py
+++ b/tests/core/test_services_irrigation.py
@@ -148,6 +148,7 @@ class TestHandleSetIrrigationSettings:
         call.data = {
             "growspace_id": "gs1",
             "irrigation_pump_entity": "switch.pump",
+            "pump_flow_rate_ml_per_sec": 12.5,
             "drain_pump_entity": "switch.drain",
             "irrigation_duration": 600,
             "drain_duration": 300,
@@ -159,6 +160,7 @@ class TestHandleSetIrrigationSettings:
         # Verify against the main coordinator services facade
         expected_settings = {
             "irrigation_pump_entity": "switch.pump",
+            "pump_flow_rate_ml_per_sec": 12.5,
             "drain_pump_entity": "switch.drain",
             "irrigation_duration": 600,
             "drain_duration": 300,

--- a/tests/test_schemas_validation.py
+++ b/tests/test_schemas_validation.py
@@ -16,12 +16,21 @@ def test_set_irrigation_settings_schema_valid() -> None:
     valid_data = {
         "growspace_id": "gs1",
         "irrigation_pump_entity": "switch.pump_1",
+        "pump_flow_rate_ml_per_sec": 12.5,
         "drain_pump_entity": "switch.pump_2",
         "irrigation_duration": 30,
         "drain_duration": 60,
     }
-    # Should not raise
-    SET_IRRIGATION_SETTINGS_SCHEMA(valid_data)
+    result = SET_IRRIGATION_SETTINGS_SCHEMA(valid_data)
+    assert result["pump_flow_rate_ml_per_sec"] == pytest.approx(12.5)
+
+
+def test_set_irrigation_settings_schema_rejects_negative_pump_flow_rate() -> None:
+    """Pump flow rate cannot be negative."""
+    with pytest.raises(vol.Invalid):
+        SET_IRRIGATION_SETTINGS_SCHEMA(
+            {"growspace_id": "gs1", "pump_flow_rate_ml_per_sec": -0.1}
+        )
 
 
 def test_set_irrigation_settings_schema_partial_valid() -> None:


### PR DESCRIPTION
## Summary

- allow set_irrigation_settings to accept pump_flow_rate_ml_per_sec
- validate the flow rate as a non-negative number
- document the service field and cover schema-to-handler forwarding

## Validation

- 5,203 backend tests passed
- mypy and Ruff lint passed
- all modified Python files pass Ruff formatting
- the repository-wide fast check still reports the existing Ruff-format baseline in 127 untouched files; the commit hook also skipped the existing services.yaml yamllint baseline after all other hooks passed

Backend half of Venosta-web/growspace_manager_workspace#40.