### PR TITLE
fix(irrigation): expose resolved photoperiod

### DIFF
--- a/custom_components/growspace_manager/integration_types.py
+++ b/custom_components/growspace_manager/integration_types.py
@@ -155,6 +155,7 @@ class IrrigationConfigData(TypedDict, total=False):
     irrigation_times: list[IrrigationScheduleItemData]
     drain_times: list[IrrigationScheduleItemData]
     veg_day_hours: int
+    resolved_day_hours: int
 
 
 class IrrigationStrategyData(TypedDict, total=False):

--- a/custom_components/growspace_manager/models/growspace.py
+++ b/custom_components/growspace_manager/models/growspace.py
@@ -718,7 +718,7 @@ class Growspace(BaseModel):
                         float(irr_config["veg_day_hours"])
                     )
                 except ValueError, TypeError:
-                    irr_config["veg_day_hours"] = 12
+                    irr_config["veg_day_hours"] = 18
 
             # Migrate irrigation_times and drain_times
             for list_key in ["irrigation_times", "drain_times"]:

--- a/custom_components/growspace_manager/models/growspace.py
+++ b/custom_components/growspace_manager/models/growspace.py
@@ -763,7 +763,7 @@ class Growspace(BaseModel):
         if "irrigation_strategy" in data and isinstance(
             data["irrigation_strategy"], dict
         ):
-            strat = data["irrigation_strategy"].copy()
+            strategy_data = data["irrigation_strategy"].copy()
             int_fields = [
                 "p0_duration_minutes",
                 "p2_stop_before_lights_off_minutes",
@@ -776,13 +776,13 @@ class Growspace(BaseModel):
                 "p2_shot_interval_minutes",
             ]
             for f in int_fields:
-                if f in strat:
+                if f in strategy_data:
                     try:
-                        strat[f] = int(float(strat[f]))
+                        strategy_data[f] = int(float(strategy_data[f]))
                     except ValueError, TypeError:
                         # Remove invalid value to let dataclass default take over
-                        if f in strat:
-                            del strat[f]
-            data["irrigation_strategy"] = strat
+                        if f in strategy_data:
+                            del strategy_data[f]
+            data["irrigation_strategy"] = strategy_data
 
         return data

--- a/custom_components/growspace_manager/models/irrigation.py
+++ b/custom_components/growspace_manager/models/irrigation.py
@@ -304,7 +304,10 @@ class IrrigationConfig(BaseModel):
     drain_duration: int | None = None
     irrigation_times: list[IrrigationScheduleItem] = field(default_factory=list)
     drain_times: list[IrrigationScheduleItem] = field(default_factory=list)
-    veg_day_hours: int = 12
+    # Legacy irrigation copy of the vegetative photoperiod. Boundary math uses
+    # EnvironmentConfig via resolve_day_hours(), but keeping this default aligned
+    # avoids two backend models assigning different meanings to an omitted value.
+    veg_day_hours: int = 18
     pump_flow_rate_ml_per_sec: float = 0.0
     soil_trigger_percent: float | None = None
     daily_volume_cap_liters: float | None = None

--- a/custom_components/growspace_manager/presentation/growspace_view_model.py
+++ b/custom_components/growspace_manager/presentation/growspace_view_model.py
@@ -32,6 +32,7 @@ from custom_components.growspace_manager.domain.moisture_band import (
     effective_moisture_band,
     is_percentage_unit,
 )
+from custom_components.growspace_manager.domain.steering_phase import resolve_day_hours
 from custom_components.growspace_manager.tank_water_tracker import (
     consumption_buckets_24h,
 )
@@ -159,6 +160,12 @@ class GrowspaceViewModelBuilder:
         # hand-copied block this replaces was missing pump_flow_rate_ml_per_sec
         # and phase_changed_at)
         irrigation_options = growspace.irrigation_config.to_dict()
+        # Crop-steering boundary math resolves the flower photoperiod first,
+        # regardless of the growspace's current stage. Serialize that resolved
+        # value so frontend phase layouts cannot drift by reimplementing the rule.
+        irrigation_options["resolved_day_hours"] = resolve_day_hours(
+            growspace.environment_config
+        )
 
         irrigation_strategy_dict = (
             growspace.irrigation_strategy.to_dict()

--- a/tests/contract/test_growspace_payload_contract.py
+++ b/tests/contract/test_growspace_payload_contract.py
@@ -267,6 +267,10 @@ def _maximal_environment_config(prefix: str) -> EnvironmentConfig:
 
 def _maximal_growspace() -> Growspace:
     """Return a growspace with every optional nested configuration populated."""
+    environment_config = _maximal_environment_config("contract")
+    # Non-default so the fixture proves the server-resolved crop-steering
+    # photoperiod, rather than merely recording the default.
+    environment_config.flower_day_hours = 11
     return Growspace(
         id=GROWSPACE_ID,
         name="Contract Growspace",
@@ -276,7 +280,7 @@ def _maximal_growspace() -> Growspace:
         notification_target="notify.mobile_app_grower",
         created_at="2026-01-01T00:00:00+00:00",
         device_id="contract-growspace-device",
-        environment_config=_maximal_environment_config("contract"),
+        environment_config=environment_config,
         irrigation_config=IrrigationConfig(
             irrigation_pump_entity="switch.contract_irrigation_pump",
             drain_pump_entity="switch.contract_drain_pump",

--- a/tests/core/snapshots/test_models_snapshots.ambr
+++ b/tests/core/snapshots/test_models_snapshots.ambr
@@ -374,7 +374,7 @@
       'pump_flow_rate_ml_per_sec': 0.0,
       'skip_during_dark': False,
       'soil_trigger_percent': None,
-      'veg_day_hours': 12,
+      'veg_day_hours': 18,
     }),
     'irrigation_strategy': dict({
       'auto_light_tracking': False,

--- a/tests/core/snapshots/test_presentation_snapshots.ambr
+++ b/tests/core/snapshots/test_presentation_snapshots.ambr
@@ -259,9 +259,10 @@
         'pause_on_low_tank': True,
         'phase_changed_at': None,
         'pump_flow_rate_ml_per_sec': 0.0,
+        'resolved_day_hours': 12,
         'skip_during_dark': False,
         'soil_trigger_percent': None,
-        'veg_day_hours': 12,
+        'veg_day_hours': 18,
       }),
       'irrigation_strategy': dict({
         'auto_light_tracking': False,

--- a/tests/core/test_models_coverage_gap.py
+++ b/tests/core/test_models_coverage_gap.py
@@ -30,7 +30,7 @@ def test_growspace_invalid_veg_day_hours() -> None:
         "irrigation_config": {"veg_day_hours": "not_a_number"},
     }
     gs = Growspace.from_dict(data)
-    assert gs.irrigation_config.veg_day_hours == 12
+    assert gs.irrigation_config.veg_day_hours == 18
 
 
 def test_plant_genetics_key_property() -> None:

--- a/tests/fixtures/contract/growspace_payload.json
+++ b/tests/fixtures/contract/growspace_payload.json
@@ -374,6 +374,7 @@
       "pause_on_low_tank": true,
       "phase_changed_at": "2026-08-11T06:00:00+00:00",
       "pump_flow_rate_ml_per_sec": 25.0,
+      "resolved_day_hours": 11,
       "skip_during_dark": true,
       "soil_trigger_percent": 42.0,
       "veg_day_hours": 18

--- a/tests/integration/snapshots/test_services_growspace_coverage.ambr
+++ b/tests/integration/snapshots/test_services_growspace_coverage.ambr
@@ -192,7 +192,7 @@
       'pump_flow_rate_ml_per_sec': 0.0,
       'skip_during_dark': False,
       'soil_trigger_percent': None,
-      'veg_day_hours': 12,
+      'veg_day_hours': 18,
     }),
     'irrigation_strategy': dict({
       'auto_light_tracking': False,

--- a/tests/integration/test_growspace_view_model_coverage.py
+++ b/tests/integration/test_growspace_view_model_coverage.py
@@ -37,7 +37,10 @@ def builder(hass: HomeAssistant) -> GrowspaceViewModelBuilder:
 def test_growspace_view_model_build_basic(hass: HomeAssistant, builder):
     """Test basic build functionality."""
     env_config = EnvironmentConfig(
-        temperature_sensor="sensor.temp", humidity_sensor="sensor.hum"
+        temperature_sensor="sensor.temp",
+        humidity_sensor="sensor.hum",
+        veg_day_hours=19,
+        flower_day_hours=11,
     )
     growspace = Growspace(
         id="gs1",
@@ -76,6 +79,7 @@ def test_growspace_view_model_build_basic(hass: HomeAssistant, builder):
     assert result["metrics"]["metrics"] is True
     assert result["grid"]["grid"]["position_1_1"]["rich"] is True
     assert result["grid"]["grid"]["position_1_2"] is None
+    assert result["irrigation"]["irrigation_config"]["resolved_day_hours"] == 11
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- serialize the crop-steering photoperiod after the backend flower-first resolution rule
- reconcile the legacy irrigation veg-day default with EnvironmentConfig
- extend the golden growspace payload fixture with a non-default 11-hour value

## Validation
- 145 affected backend tests passed
- full pre-commit pytest and mypy hooks passed
- changed-file ruff check and format passed
- contract fixture consumer passed in the card repo

Part of Venosta-web/growspace_manager_workspace#42. The dependent card PR will land after this backend change.