### PR TITLE
Fix vision snapshots outside flower light window

### DIFF
--- a/custom_components/growspace_manager/domain/light_schedule.py
+++ b/custom_components/growspace_manager/domain/light_schedule.py
@@ -32,7 +32,7 @@ def resolve_photoperiod_hours(
         if not plant.flower_start:
             continue
         try:
-            if date.fromisoformat(plant.flower_start) <= today:
+            if datetime.fromisoformat(plant.flower_start).date() <= today:
                 return flower_hours
         except ValueError:
             continue

--- a/tests/domain/test_light_schedule.py
+++ b/tests/domain/test_light_schedule.py
@@ -47,6 +47,7 @@ def test_window_wrapping_past_midnight() -> None:
         ([], 18),  # no plants -> veg
         ([_plant(None), _plant(None)], 18),  # all vegetative -> veg
         ([_plant(None), _plant("2026-07-01")], 12),  # one entered flower -> flower
+        ([_plant("2026-07-01T00:00:00+02:00")], 12),  # persisted lifecycle timestamp
         ([_plant("2026-07-03")], 12),  # entered flower today -> flower
         ([_plant("2026-07-10")], 18),  # flower start in the future -> still veg
     ],

--- a/tests/test_vision_checkup_scheduler.py
+++ b/tests/test_vision_checkup_scheduler.py
@@ -396,6 +396,34 @@ def test_schedule_growspace_creates_three_timers(mock_hass, mock_coordinator):
     assert len(scheduler._unsub_timers["tent1"]) == 3
 
 
+def test_schedule_growspace_uses_flower_window_for_persisted_datetime(
+    mock_hass, mock_coordinator
+):
+    """Real persisted flower timestamps keep every checkup inside lights-on."""
+
+    gs = _make_mock_growspace(lights_on_time="11:00:00")
+    plant = MagicMock()
+    plant.flower_start = "2026-08-01T00:00:00+02:00"
+    mock_coordinator.growspaces = {"tent1": gs}
+    mock_coordinator.services.growspaces.get_growspace_plants.return_value = [plant]
+    scheduler = VisionCheckupScheduler(mock_hass, mock_coordinator)
+
+    with (
+        patch(
+            "custom_components.growspace_manager.vision_checkup_scheduler.async_track_point_in_utc_time",
+        ) as mock_track,
+        patch(
+            "custom_components.growspace_manager.vision_checkup_scheduler.ha_now",
+            return_value=datetime(2026, 8, 25, 10, 0, 0, tzinfo=UTC),
+        ),
+    ):
+        mock_track.return_value = MagicMock()
+        scheduler.schedule_growspace("tent1")
+
+    scheduled_times = [call.args[2].time() for call in mock_track.call_args_list]
+    assert scheduled_times == [time(12, 0), time(17, 0), time(22, 0)]
+
+
 def test_schedule_growspace_skips_disabled_vision(mock_hass, mock_coordinator):
     """Test that scheduling skips growspaces with vision disabled."""
 


### PR DESCRIPTION
## Summary
- parse persisted flower lifecycle timestamps as ISO datetimes when resolving the photoperiod
- keep automated camera snapshots inside the active 12/12 flower light window
- add domain and scheduler regressions for lights on at 11:00

## Root cause
Persisted flower_start values include a time and timezone. The date-only parser rejected them and silently selected the 18-hour vegetative photoperiod, placing the late snapshot in darkness.

## Validation
- ./scripts/codex-worktree check backend fast
- 5093 tests passed
- 46 snapshots passed