### PR TITLE
fix(environment): accept moisture band in config service

### DIFF
--- a/custom_components/growspace_manager/schemas.py
+++ b/custom_components/growspace_manager/schemas.py
@@ -571,6 +571,16 @@ CONFIGURE_ENVIRONMENT_SCHEMA = vol.Schema(
         vol.Optional(CONF_POWER_SENSORS): cv.ensure_list,
         vol.Optional(CONF_ENERGY_SENSORS): cv.ensure_list,
         vol.Optional(CONF_ELECTRICITY_COST): vol.Coerce(float),
+        # Acceptable Moisture Band. Both edges are nullable so the pair can be
+        # cleared back to the inherited default; the atomic pair and the
+        # 0 ≤ min < max ≤ 100 relation are enforced by the Environment Patch
+        # builder, which sees both values at once.
+        vol.Optional("soil_moisture_min"): vol.Any(
+            None, vol.All(vol.Coerce(float), vol.Range(min=0.0, max=100.0))
+        ),
+        vol.Optional("soil_moisture_max"): vol.Any(
+            None, vol.All(vol.Coerce(float), vol.Range(min=0.0, max=100.0))
+        ),
         vol.Optional("circulation_fan_config"): dict,
         vol.Optional("vpd_optimal_overrides"): dict,
         # AC Infinity actuator bundles, parallel to the plain *_entities lists.
@@ -700,16 +710,6 @@ SET_IRRIGATION_STRATEGY_SCHEMA = vol.Schema(
             None, vol.All(vol.Coerce(float), vol.Range(min=0.0))
         ),
         vol.Optional("ec_modulation_enabled"): bool,
-        # Acceptable Moisture Band. Both edges are nullable so the pair can be
-        # cleared back to the inherited default; the atomic pair and the
-        # 0 ≤ min < max ≤ 100 relation are enforced by the Environment Patch
-        # builder, which sees both values at once.
-        vol.Optional("soil_moisture_min"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=0.0, max=100.0))
-        ),
-        vol.Optional("soil_moisture_max"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=0.0, max=100.0))
-        ),
     }
 )
 

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -63,6 +63,20 @@ def test_configure_environment_schema_accepts_snapshot_interval() -> None:
     assert validated["snapshot_interval_hours"] == 6
 
 
+def test_configure_environment_schema_accepts_soil_moisture_band() -> None:
+    """The config dialog can persist both bounds of the moisture band."""
+    validated = CONFIGURE_ENVIRONMENT_SCHEMA(
+        {
+            "growspace_id": "gs1",
+            "soil_moisture_min": 32.5,
+            "soil_moisture_max": 54.0,
+        }
+    )
+
+    assert validated["soil_moisture_min"] == 32.5
+    assert validated["soil_moisture_max"] == 54.0
+
+
 @pytest.mark.parametrize("value", [0, 169])
 def test_configure_environment_schema_rejects_invalid_snapshot_interval(
     value: int,


### PR DESCRIPTION
## Summary

- move `soil_moisture_min` and `soil_moisture_max` from the irrigation-strategy schema to `configure_environment`
- add a schema regression test for the exact config-dialog payload

## Root cause

The Environment Patch implementation accepted the moisture pair, but Home Assistant rejected it before the handler ran because the two fields were registered on `set_irrigation_strategy` instead of `configure_environment`.

## Validation

- original schema repro changes from `extra keys not allowed` to accepted
- focused schema tests: 11 passed
- full repository commit hooks: Ruff, format, codespell, pytest, and mypy passed
- full pytest suite: 5,208 passed