### PR TITLE
ci: require Ruff formatting and mypy gates

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,11 +19,8 @@ jobs:
         run: python -m pip install --upgrade "ruff==0.15.12"
       - name: ruff check
         run: ruff check custom_components/ tests/
-      # Non-blocking until the existing repo-wide format drift is normalised in a
-      # dedicated PR (would otherwise conflict with in-flight feature branches).
-      - name: ruff format --check (non-blocking)
+      - name: ruff format --check
         run: ruff format --check custom_components/ tests/
-        continue-on-error: true
 
   mypy:
     name: mypy
@@ -35,17 +32,19 @@ jobs:
         with:
           python-version: "3.14"
           cache: "pip"
-      # Two-phase constrained install, matching tests.yaml — see the comment there.
+      # Two-phase constrained install, matching tests.yaml — see the comment
+      # there.
       - name: install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install "$(grep '^homeassistant==' requirements.txt)"
-          pip install -r requirements.txt -c "$(
-            python -c 'import homeassistant, pathlib; print(pathlib.Path(homeassistant.__file__).parent / "package_constraints.txt")'
+          constraints_file="$(
+            python -c 'import homeassistant, pathlib; print(
+              pathlib.Path(homeassistant.__file__).parent
+              / "package_constraints.txt"
+            )'
           )"
+          pip install -r requirements.txt -c "$constraints_file"
           pip install "mypy==1.20.2"
-      # Non-blocking until the inherited HA-core-strict baseline (~460 errors) is
-      # burned down in a dedicated effort; see ADR 0020.
-      - name: mypy (non-blocking)
-        run: mypy custom_components/growspace_manager/
-        continue-on-error: true
+      - name: mypy
+        run: mypy --follow-imports=silent custom_components/

--- a/docs/adr/0020-ci-merge-gate-and-ha-core-aligned-test-rules.md
+++ b/docs/adr/0020-ci-merge-gate-and-ha-core-aligned-test-rules.md
@@ -170,3 +170,20 @@ baseline must preserve that minimum; a change that cannot do so requires a
 separate decision to raise it. CI continues to exercise one Home Assistant
 version for now. A minimum-and-latest matrix is a separate reliability change
 with its own paired test-helper dependency maintenance.
+
+## Amendment (2026-08-27) — formatting and typing are blocking gates
+
+The repository-wide Ruff formatting and mypy baselines are now clean. The
+temporary `continue-on-error` exceptions in `lint.yaml` are removed: formatting
+or typing regressions fail the `Ruff` or `mypy` job and therefore block merging.
+
+CI deliberately runs the same commands as the prescribed local backend gate:
+
+- `ruff format --check custom_components/ tests/`
+- `mypy --follow-imports=silent custom_components/`
+
+Both commands use the repository's `pyproject.toml` configuration. Ruff and mypy
+versions are pinned identically for CI and local development in `lint.yaml` and
+`requirements.txt`; the Ruff pre-commit hook carries the matching version as
+well. Any version bump must update those pins together so local and CI verdicts
+remain equivalent.

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,10 +51,9 @@ hassil==3.11.0
 home-assistant-intents==2026.7.30
 syrupy>=5.0.0
 
-# Local dev tooling — NOT what the gate runs. CI pins its own copies: ruff and mypy
-# in lint.yaml, and the hook versions in .pre-commit-config.yaml. ruff is pinned to
-# lint.yaml's version so a local `ruff check` agrees with the gate; lint.yaml is the
-# source of truth, so bump it there first.
+# Local dev tooling — CI installs separate copies using matching pins in
+# lint.yaml. Keep both versions synchronized so local checks agree with the
+# gate, and move the Ruff pre-commit rev with any Ruff version bump.
 ruff==0.15.12
 mypy==1.20.2
 pre-commit


### PR DESCRIPTION
## Summary

- make Ruff formatting failures block the existing Ruff CI job
- make mypy failures block CI and align its scope and import-following mode with the local backend gate
- replace stale baseline guidance with the active zero-error gate contract and synchronized tool-pin guidance

## Validation

- `./scripts/codex-worktree check backend fast`
  - Ruff check passed
  - Ruff format checked 624 files
  - mypy found no issues in 210 source files
  - 5,211 tests and 44 snapshots passed
- changed-file pre-commit hooks passed, including yamllint and Prettier

Closes #695