### PR TITLE
ci: deduplicate PR validation and cancel superseded runs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,9 +1,23 @@
 name: Lint
 
 on:
+  # Feature branches are validated by pull_request. Restrict push validation to
+  # protected branches so a same-repository PR commit does not run twice.
   push:
+    branches:
+      - prerelease
+      - dev
+      - main
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  # Cancel only an older run for this workflow and this PR. Push and manual
+  # runs keep their branch/ref group and are never cancelled here.
+  group: >-
+    validation-${{ github.workflow }}-${{ github.event_name }}-${{
+    github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   ruff:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,8 +2,22 @@
 name: Tests
 
 "on":
+  # Feature branches are validated by pull_request. Restrict push validation to
+  # protected branches so a same-repository PR commit does not run twice.
   push:
+    branches:
+      - prerelease
+      - dev
+      - main
   pull_request:
+
+concurrency:
+  # Cancel only an older run for this workflow and this PR. Protected-branch
+  # push runs keep their ref group and are never cancelled here.
+  group: >-
+    validation-${{ github.workflow }}-${{ github.event_name }}-${{
+    github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,9 +1,23 @@
 name: HACS/HASS
 
 on:
+  # Feature branches are validated by pull_request. Restrict push validation to
+  # protected branches so a same-repository PR commit does not run twice.
   push:
+    branches:
+      - prerelease
+      - dev
+      - main
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  # Cancel only an older run for this workflow and this PR. Push and manual
+  # runs keep their branch/ref group and are never cancelled here.
+  group: >-
+    validation-${{ github.workflow }}-${{ github.event_name }}-${{
+    github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   validate-hassfest:

--- a/docs/adr/0020-ci-merge-gate-and-ha-core-aligned-test-rules.md
+++ b/docs/adr/0020-ci-merge-gate-and-ha-core-aligned-test-rules.md
@@ -187,3 +187,23 @@ versions are pinned identically for CI and local development in `lint.yaml` and
 `requirements.txt`; the Ruff pre-commit hook carries the matching version as
 well. Any version bump must update those pins together so local and CI verdicts
 remain equivalent.
+
+## Amendment (2026-08-27) — one validation event per change boundary
+
+The lint, test, and HACS/Hassfest workflows validate feature-branch commits on
+`pull_request`, not on their simultaneous `push` event. Their `push` triggers are
+therefore limited to the protected `prerelease`, `dev`, and `main` branches, where
+post-merge and direct-push validation must remain available. Without that branch
+filter, a commit pushed to a same-repository pull request emits both events and
+runs every validation workflow twice.
+
+Each validation workflow has its own concurrency group, keyed by pull-request
+number for PR events and by the unique workflow run ID otherwise. A newer commit
+cancels the superseded run of the same workflow for the same pull request.
+Protected-branch pushes and manual runs are never cancelled by this policy.
+
+Release concurrency remains a separate concern. Stable and prerelease publishing
+use dedicated `stable-publish` and `prerelease-publish` groups with cancellation
+disabled, so validation churn cannot cancel a publishing run. Workflow names and
+job names remain unchanged because the repository ruleset uses those status checks
+as merge gates.


### PR DESCRIPTION
## Summary

- restrict lint, test, and HACS/Hassfest push validation to protected branches while keeping pull-request validation for feature branches
- cancel superseded validation runs per workflow and pull request, with unique groups for protected-branch and manual runs
- document the trigger and concurrency boundaries, including isolation from stable and prerelease publishing

## Validation

- actionlint v1.7.12 passed for all changed workflows
- changed-file pre-commit hooks passed
- backend fast gate passed: Ruff, formatting, mypy, 5,211 tests, and 44 snapshots

Closes #696