### PR TITLE
ci: enforce repository spelling baseline

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,6 +29,13 @@ jobs:
         name: Setup Python
         with:
           python-version: "3.14"
+      - name: Install pre-commit
+        run: python -m pip install "pre-commit==4.6.2"
+      # Invoke the checked-in hook rather than duplicating its codespell options
+      # here, so commits and CI enforce exactly the same spelling configuration.
+      # Keeping this in the required Ruff job also makes spelling a merge gate.
+      - name: Check spelling
+        run: pre-commit run codespell --all-files
       - name: Install ruff
         run: python -m pip install --upgrade "ruff==0.15.12"
       - name: ruff check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,20 @@ repos:
     hooks:
       - id: codespell
         args:
-          - --ignore-words-list=aiport,astroid,checkin,currenty,hass,iif,incomfort,lookin,nam,NotIn,tage,trough
-          - --skip="./.*,*.csv,*.json,*.ambr"
+          - --ignore-words-list=hass,tage,trough
           - --quiet-level=2
-        exclude_types: [csv, json, html]
-        exclude: ^tests/fixtures/
+        # These are tracked for tests or debugging, but are not first-party
+        # prose:
+        # captured SeedFinder HTML, generated Ruff output, copied card bundles,
+        # and generated Syrupy snapshots. Keep authored dotfiles and data files
+        # in scope so `--all-files` remains a repository-wide check.
+        exclude: >-
+          (?x)^(
+            custom_components/growspace_manager/
+            (ruff_output\.txt|search_results\.html)
+            |tests/[^/]+/configs/www/growspace-manager-card\.js
+            |tests/.+/snapshots/.+\.ambr
+          )$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/custom_components/growspace_manager/grow_light_ac_infinity.py
+++ b/custom_components/growspace_manager/grow_light_ac_infinity.py
@@ -76,7 +76,7 @@ def ac_infinity_schedule_matches(
 ) -> bool:
     """Return whether the port already holds the desired schedule.
 
-    Lets the caller skip an unnecessary re-push. A missing or unparseable
+    Lets the caller skip an unnecessary re-push. A missing or unparsable
     reading counts as a mismatch (push and converge) — ``ac_infinity`` is
     cloud-polled, so a just-written value that has not read back yet may cause a
     harmless extra push rather than a silently stale schedule.

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ syrupy>=5.0.0
 # gate, and move the Ruff pre-commit rev with any Ruff version bump.
 ruff==0.15.12
 mypy==1.20.2
-pre-commit
+pre-commit==4.6.2
 pylint
 yamllint
 codespell

--- a/tests/integration/test_history_fix.py
+++ b/tests/integration/test_history_fix.py
@@ -51,7 +51,7 @@ async def test_websocket_history_handles_dicts(hass: HomeAssistant):
 
         result = await websocket_get_history_stats(hass, MagicMock(), msg)
 
-        # If it fails with AttributeError, send_result wont be called (validation)
+        # If it fails with AttributeError, send_result won't be called (validation)
         # or it will raise uncaught exception depending on test harness.
         # But our code catches Exception and sends error usually?
         # Wait, the logs showed "Error handling websocket_get_history_stats" AND Traceback.

--- a/tests/integration/test_websocket_coverage.py
+++ b/tests/integration/test_websocket_coverage.py
@@ -60,7 +60,7 @@ async def test_websocket_get_event_log_recorder_error(
     ):
         result = await websocket_get_event_log(hass, MagicMock(), mock_msg)
 
-        # Sould return empty result, not error
+        # Should return empty result, not error
         assert result == {"gs1": []}
 
 


### PR DESCRIPTION
## Summary

- correct the three genuine spelling mistakes in authored Python source and tests
- narrow codespell exclusions to captured SeedFinder HTML, generated Ruff output, copied Lovelace bundles, and Syrupy snapshots
- include authored dotfiles and data files in the all-files spelling baseline
- run the checked-in codespell pre-commit hook inside the required Ruff CI job
- pin the pre-commit runner used locally and in CI

## Validation

- `pre-commit run codespell --all-files` passes
- a temporary typo in `.github/workflows/lint.yaml` was rejected by the hook, then removed
- `./scripts/check backend full`: 5,212 passed; 44 snapshots passed; 99% aggregate coverage
- commit hooks: Ruff, formatting, codespell, yamllint, Prettier, pytest, and mypy passed

Closes #698