### PR TITLE
refactor(irrigation): deepen patches behind one write seam

### DIFF
--- a/custom_components/growspace_manager/config_handlers/irrigation_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/irrigation_config_handler.py
@@ -10,9 +10,8 @@ from typing import Any
 import voluptuous as vol
 
 from custom_components.growspace_manager.const import ShotSizingMode, SubstrateMediaType
-from custom_components.growspace_manager.services.irrigation import (
-    _build_substrate_profile_update,
-    _validate_volume_mode_selection,
+from custom_components.growspace_manager.services.irrigation_change import (
+    IrrigationChangeError,
 )
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.helpers import selector
@@ -105,33 +104,45 @@ class IrrigationConfigHandler(BaseConfigHandler[dict[str, Any]]):
             "use_vwc_steering": growspace.irrigation_strategy.enabled,
         }
 
+        errors: dict[str, str] = {}
+        error_message: str | None = None
         if user_input is not None:
-            # Fold the flat substrate fields into the nested ``substrate_profile``
-            # and reject Volume Mode without its prerequisites — reusing the exact
-            # helpers the set_irrigation_strategy service uses, so the form and the
-            # service share one write path and one validation rule (ADR-0011).
-            _build_substrate_profile_update(user_input)
-            _validate_volume_mode_selection(coordinator, growspace_id, user_input)
-            await coordinator.services.growspaces.update_irrigation_config(
-                growspace_id, user_input
-            )
-
-            if self.config_entry is None:
-                return self.flow.async_abort(reason="setup_error")
-            # This triggers async_update_listener in __init__.py, reloading the IrrigationCoordinator
-            return self.flow.async_create_entry(
-                title="",
-                data=self.config_entry.options,  # No changes to ConfigEntry options
-                description="Irrigation settings have been updated.",
-            )
+            change_values = dict(user_input)
+            for display_field in (
+                "current_irrigation_times",
+                "current_drain_times",
+                "growspace_id_read_only",
+            ):
+                change_values.pop(display_field, None)
+            try:
+                await coordinator.services.growspaces.update_irrigation_config(
+                    growspace_id, change_values
+                )
+            except IrrigationChangeError as err:
+                errors["base"] = "invalid_irrigation_change"
+                error_message = str(err)
+                irrigation_options.update(user_input)
+            else:
+                if self.config_entry is None:
+                    return self.flow.async_abort(reason="setup_error")
+                # This triggers async_update_listener in __init__.py, reloading the IrrigationCoordinator
+                return self.flow.async_create_entry(
+                    title="",
+                    data=self.config_entry.options,  # No changes to ConfigEntry options
+                    description="Irrigation settings have been updated.",
+                )
 
         # Describe schema to pass ALL data to the Lovelace component
         schema = self.get_irrigation_overview_schema(irrigation_options, growspace_id)
 
+        description_placeholders = {"growspace_name": growspace.name}
+        if error_message is not None:
+            description_placeholders["error"] = error_message
         return self.flow.async_show_form(
             step_id="irrigation_overview",
             data_schema=schema,
-            description_placeholders={"growspace_name": growspace.name},
+            errors=errors,
+            description_placeholders=description_placeholders,
         )
 
     def get_irrigation_overview_schema(

--- a/custom_components/growspace_manager/config_handlers/irrigation_config_handler.py
+++ b/custom_components/growspace_manager/config_handlers/irrigation_config_handler.py
@@ -123,12 +123,12 @@ class IrrigationConfigHandler(BaseConfigHandler[dict[str, Any]]):
                 error_message = str(err)
                 irrigation_options.update(user_input)
             else:
-                if self.config_entry is None:
-                    return self.flow.async_abort(reason="setup_error")
+                config_entry = self.config_entry
+                assert config_entry is not None
                 # This triggers async_update_listener in __init__.py, reloading the IrrigationCoordinator
                 return self.flow.async_create_entry(
                     title="",
-                    data=self.config_entry.options,  # No changes to ConfigEntry options
+                    data=config_entry.options,  # No changes to ConfigEntry options
                     description="Irrigation settings have been updated.",
                 )
 

--- a/custom_components/growspace_manager/schemas.py
+++ b/custom_components/growspace_manager/schemas.py
@@ -744,7 +744,6 @@ SET_IRRIGATION_SETTINGS_SCHEMA = vol.All(
             vol.Optional("halt_on_runoff_ec_threshold"): vol.Any(
                 None, vol.All(vol.Coerce(float), vol.Range(min=0.0))
             ),
-            vol.Optional("active_steering_phase"): vol.In(["p1", "p2", "p3"]),
         }
     ),
     _validate_pump_entities,

--- a/custom_components/growspace_manager/services.yaml
+++ b/custom_components/growspace_manager/services.yaml
@@ -1301,6 +1301,54 @@ set_irrigation_strategy:
         number:
           min: 0
           unit_of_measurement: "minutes"
+    auto_light_tracking:
+      description: Use observed light transitions instead of the configured lights-on time.
+      required: false
+      selector:
+        boolean:
+    shot_sizing_mode:
+      description: Size irrigation shots by duration or substrate-volume percentage.
+      required: false
+      selector:
+        select:
+          options:
+            - "seconds"
+            - "volume"
+    substrate_media_type:
+      description: Growing-medium type used by Volume Mode presets.
+      required: false
+      selector:
+        select:
+          options:
+            - "coco"
+            - "rockwool"
+            - "soil"
+    substrate_liters_per_pot:
+      description: Substrate volume per pot used to calculate Volume Mode shots.
+      required: false
+      selector:
+        number:
+          min: 0.0
+          step: 0.1
+          unit_of_measurement: "L"
+    p1_shot_volume_percent:
+      description: P1 shot size as a percentage of total substrate volume.
+      required: false
+      selector:
+        number:
+          min: 0.0
+          max: 100.0
+          step: 0.1
+          unit_of_measurement: "%"
+    p2_shot_volume_percent:
+      description: P2 shot size as a percentage of total substrate volume.
+      required: false
+      selector:
+        number:
+          min: 0.0
+          max: 100.0
+          step: 0.1
+          unit_of_measurement: "%"
     dynamic_shot_enabled:
       description: >-
         Master toggle for Adaptive Shot Control — adapts both shot size and
@@ -1416,6 +1464,63 @@ set_irrigation_settings:
         number:
           min: 1
           unit_of_measurement: "seconds"
+    soil_trigger_percent:
+      description: Soil-moisture percentage below which irrigation may trigger.
+      required: false
+      selector:
+        number:
+          min: 0.0
+          max: 100.0
+          step: 0.1
+          unit_of_measurement: "%"
+    daily_volume_cap_liters:
+      description: Maximum irrigation volume allowed per day; omit to disable the cap.
+      required: false
+      selector:
+        number:
+          min: 0.0
+          step: 0.1
+          unit_of_measurement: "L"
+    max_cycles_per_day:
+      description: Maximum automatic irrigation cycles allowed per day; omit for no cap.
+      required: false
+      selector:
+        number:
+          min: 0
+          step: 1
+    skip_during_dark:
+      description: Skip automatic irrigation while the growspace is dark.
+      required: false
+      selector:
+        boolean:
+    pause_on_low_tank:
+      description: Pause automatic irrigation when a configured tank is low.
+      required: false
+      selector:
+        boolean:
+    log_to_logbook:
+      description: Record irrigation activity in the Home Assistant logbook.
+      required: false
+      selector:
+        boolean:
+    auto_advance_p1_to_p2:
+      description: Automatically advance from steering phase P1 to P2.
+      required: false
+      selector:
+        boolean:
+    auto_advance_p2_to_p3:
+      description: Automatically advance from steering phase P2 to P3.
+      required: false
+      selector:
+        boolean:
+    halt_on_runoff_ec_threshold:
+      description: Halt irrigation when runoff EC reaches this threshold; omit to disable.
+      required: false
+      selector:
+        number:
+          min: 0.0
+          step: 0.1
+          unit_of_measurement: "mS/cm"
 
 apply_steering_mode:
   description: >-

--- a/custom_components/growspace_manager/services/growspace_facade.py
+++ b/custom_components/growspace_manager/services/growspace_facade.py
@@ -7,10 +7,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from custom_components.growspace_manager.const import (
-    ATTR_DRAIN_TIMES,
     ATTR_GROWSPACE_ID,
     ATTR_IMAGES,
-    ATTR_IRRIGATION_TIMES,
     ATTR_NAME,
     ATTR_NOTES,
     ATTR_NOTIFICATION_TARGET,
@@ -23,7 +21,6 @@ from custom_components.growspace_manager.const import (
     VERSION,
     GrowspaceService,
     SteeringMode,
-    SubstrateMediaType,
 )
 from custom_components.growspace_manager.domain.ec_state import record_drain_reading
 from custom_components.growspace_manager.domain.stage import StageDays
@@ -37,9 +34,7 @@ from custom_components.growspace_manager.exceptions import (
 from custom_components.growspace_manager.models import (
     ECTargetRange,
     Growspace,
-    IrrigationConfig,
     Subarea,
-    SubstrateProfile,
     WaterUsageData,
 )
 from custom_components.growspace_manager.schemas import (
@@ -60,6 +55,12 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import dt as dt_util, slugify
 
 from ._definition import ServiceDefinition
+from .irrigation_change import (
+    IrrigationChange,
+    IrrigationChangeOperation,
+    IrrigationChangeResult,
+    async_apply_irrigation_change,
+)
 from .utils import handle_service_errors
 
 if TYPE_CHECKING:
@@ -267,90 +268,42 @@ class GrowspaceFacade:
 
     async def update_irrigation_config(
         self, growspace_id: str, user_input: dict[str, Any]
-    ) -> None:
-        """Update irrigation configuration for a growspace."""
-        growspace = self._coordinator.growspaces.get(growspace_id)
-        if not growspace:
-            raise GrowspaceNotFoundError(f"Growspace {growspace_id} not found")
-        if user_input.get("clear"):
-            growspace.irrigation_config = IrrigationConfig()
-            growspace.irrigation_strategy.enabled = False
-            _LOGGER.info("Cleared irrigation config for %s", growspace_id)
-            await self._coordinator.async_commit()
-            return
-        if "use_vwc_steering" in user_input:
-            growspace.irrigation_strategy.enabled = bool(
-                user_input.pop("use_vwc_steering")
-            )
-        updated_settings = {
-            k: v
-            for k, v in user_input.items()
-            if k
-            not in [ATTR_IRRIGATION_TIMES, ATTR_DRAIN_TIMES, "growspace_id_read_only"]
-        }
-        for pump_key in ("irrigation_pump_entity", "drain_pump_entity"):
-            if pump_key in updated_settings and not updated_settings[pump_key]:
-                updated_settings[pump_key] = None
-        if "substrate_profile" in updated_settings:
-            updated_settings["substrate_profile"] = self._merge_substrate_profile(
-                growspace.irrigation_strategy.substrate_profile,
-                updated_settings["substrate_profile"],
-            )
-
-        # Validate the Pore EC Target Band (min < max) using the effective
-        # post-update values so setting a single edge is checked against the
-        # already-stored other edge.
-        strategy = growspace.irrigation_strategy
-        band_min = updated_settings.get(
-            "pore_ec_target_min", strategy.pore_ec_target_min
-        )
-        band_max = updated_settings.get(
-            "pore_ec_target_max", strategy.pore_ec_target_max
-        )
-        if band_min is not None and band_max is not None and band_min >= band_max:
-            raise ServiceValidationError(
-                f"Pore EC target band invalid: min ({band_min}) must be below "
-                f"max ({band_max})"
-            )
-
-        for k, v in updated_settings.items():
-            if hasattr(growspace.irrigation_config, k):
-                setattr(growspace.irrigation_config, k, v)
-            elif hasattr(growspace.irrigation_strategy, k):
-                setattr(growspace.irrigation_strategy, k, v)
-        self._coordinator.cache.invalidate(growspace_id)
-        await self._coordinator.async_commit()
-        await self._coordinator.async_request_refresh()
-        _LOGGER.info("Updated irrigation config for %s", growspace_id)
-
-    @staticmethod
-    def _merge_substrate_profile(
-        existing: SubstrateProfile, update: Any
-    ) -> SubstrateProfile:
-        """Merge a partial substrate-profile update onto the existing profile.
-
-        The service surface may send only the media type or only the per-pot
-        volume; unspecified keys keep their current value (ADR-0011 profile).
-        """
-        if isinstance(update, SubstrateProfile):
-            return update
-        data = update if isinstance(update, dict) else {}
-        return SubstrateProfile(
-            media_type=SubstrateMediaType(data.get("media_type", existing.media_type)),
-            liters_per_pot=float(data.get("liters_per_pot", existing.liters_per_pot)),
+    ) -> IrrigationChangeResult:
+        """Apply an options-flow Irrigation Change."""
+        return await async_apply_irrigation_change(
+            self._coordinator,
+            growspace_id,
+            IrrigationChange(
+                operation=IrrigationChangeOperation.OPTIONS,
+                values=user_input,
+            ),
         )
 
     async def set_irrigation_settings(
         self, growspace_id: str, settings: dict[str, Any]
-    ) -> None:
-        """Set irrigation settings for a growspace."""
-        await self.update_irrigation_config(growspace_id, settings)
+    ) -> IrrigationChangeResult:
+        """Apply a settings-action Irrigation Change."""
+        return await async_apply_irrigation_change(
+            self._coordinator,
+            growspace_id,
+            IrrigationChange(
+                operation=IrrigationChangeOperation.SETTINGS,
+                values=settings,
+            ),
+        )
 
     async def set_irrigation_strategy(
         self, growspace_id: str, strategy: dict[str, Any]
-    ) -> None:
-        """Set irrigation strategy for a growspace."""
-        await self.update_irrigation_config(growspace_id, strategy)
+    ) -> IrrigationChangeResult:
+        """Apply a strategy-action Irrigation Change."""
+        return await async_apply_irrigation_change(
+            self._coordinator,
+            growspace_id,
+            IrrigationChange(
+                operation=IrrigationChangeOperation.STRATEGY,
+                values=strategy,
+            ),
+        )
 
     async def apply_steering_mode(self, growspace_id: str, mode: SteeringMode) -> None:
         """Stamp a Steering Mode's preset values into the strategy (ADR-0012).

--- a/custom_components/growspace_manager/services/irrigation.py
+++ b/custom_components/growspace_manager/services/irrigation.py
@@ -33,6 +33,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
 
 from ._definition import ServiceDefinition
+from .irrigation_change import IrrigationChangeError
 from .utils import handle_service_errors
 
 if TYPE_CHECKING:
@@ -91,9 +92,12 @@ async def handle_set_irrigation_settings(
         key: value for key, value in call.data.items() if key != ATTR_GROWSPACE_ID
     }
 
-    await coordinator.services.growspaces.set_irrigation_settings(
-        growspace_id, settings
-    )
+    try:
+        await coordinator.services.growspaces.set_irrigation_settings(
+            growspace_id, settings
+        )
+    except IrrigationChangeError as err:
+        raise ServiceValidationError(str(err)) from err
     _LOGGER.info("Set irrigation settings for growspace '%s'", growspace_id)
 
 
@@ -111,12 +115,12 @@ async def handle_set_irrigation_strategy(
         key: value for key, value in call.data.items() if key != ATTR_GROWSPACE_ID
     }
 
-    _build_substrate_profile_update(strategy)
-    _validate_volume_mode_selection(coordinator, growspace_id, strategy)
-
-    await coordinator.services.growspaces.set_irrigation_strategy(
-        growspace_id, strategy
-    )
+    try:
+        await coordinator.services.growspaces.set_irrigation_strategy(
+            growspace_id, strategy
+        )
+    except IrrigationChangeError as err:
+        raise ServiceValidationError(str(err)) from err
     _LOGGER.info("Set irrigation strategy for growspace '%s'", growspace_id)
 
 
@@ -137,75 +141,6 @@ async def handle_apply_steering_mode(
     _LOGGER.info(
         "Applied %s steering mode for growspace '%s'", mode.value, growspace_id
     )
-
-
-def _build_substrate_profile_update(strategy: dict) -> None:
-    """Fold flat substrate-profile keys into a nested ``substrate_profile`` dict.
-
-    The service surface accepts ``substrate_media_type`` / ``substrate_liters_per_pot``
-    as flat fields; the model stores them on the nested ``SubstrateProfile``. We
-    merge them into a single dict so the generic setattr-based config updater can
-    deserialize them onto the strategy. Only the provided keys are touched so a
-    partial update preserves the other half of the profile.
-    """
-    from custom_components.growspace_manager.const import (  # noqa: PLC0415
-        SubstrateMediaType,
-    )
-
-    media_type = strategy.pop("substrate_media_type", None)
-    liters_per_pot = strategy.pop("substrate_liters_per_pot", None)
-    if media_type is None and liters_per_pot is None:
-        return
-
-    profile: dict[str, object] = {}
-    if media_type is not None:
-        profile["media_type"] = SubstrateMediaType(media_type).value
-    if liters_per_pot is not None:
-        profile["liters_per_pot"] = float(liters_per_pot)
-    strategy["substrate_profile"] = profile
-
-
-def _validate_volume_mode_selection(
-    coordinator: GrowspaceCoordinator,
-    growspace_id: str,
-    strategy: dict,
-) -> None:
-    """Reject selecting Volume Mode unless its prerequisites are met (ADR-0011).
-
-    Volume Mode is opt-in and is only selectable when a substrate profile
-    (positive liters-per-pot) and a positive pump flow rate are both configured.
-    Prerequisites are evaluated against the post-update state so a single call may
-    set the profile and the mode together.
-    """
-    from custom_components.growspace_manager.const import (  # noqa: PLC0415
-        ShotSizingMode,
-    )
-
-    if strategy.get("shot_sizing_mode") != ShotSizingMode.VOLUME.value:
-        return
-
-    growspace = coordinator.growspaces.get(growspace_id)
-    if growspace is None:
-        return
-
-    # Effective values: an incoming update wins over the stored state for both
-    # the per-pot volume and the pump flow rate, so a single call (e.g. the
-    # config-flow form) may set the profile, the flow rate, and the mode at once.
-    # The settings service stores the pump flow rate separately from the
-    # strategy, so strategy updates fall back to the persisted config value.
-    stored_profile = growspace.irrigation_strategy.substrate_profile
-    profile_update = strategy.get("substrate_profile", {})
-    liters_per_pot = profile_update.get("liters_per_pot", stored_profile.liters_per_pot)
-    flow_rate = strategy.get(
-        "pump_flow_rate_ml_per_sec",
-        growspace.irrigation_config.pump_flow_rate_ml_per_sec,
-    )
-
-    if liters_per_pot <= 0.0 or flow_rate <= 0.0:
-        raise ServiceValidationError(
-            "Volume Mode requires a substrate profile (liters per pot) and a "
-            "pump flow rate to be configured first."
-        )
 
 
 @handle_service_errors

--- a/custom_components/growspace_manager/services/irrigation_change.py
+++ b/custom_components/growspace_manager/services/irrigation_change.py
@@ -1,0 +1,282 @@
+"""Irrigation Change — the one write seam for sparse irrigation changes.
+
+The interface owns canonical field classification, normalization, validation,
+atomic replacement and the effects that follow a successful change. Home
+Assistant actions and config-flow handlers are transport adapters for it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+from custom_components.growspace_manager.const import ShotSizingMode, SubstrateMediaType
+from custom_components.growspace_manager.exceptions import GrowspaceNotFoundError
+from custom_components.growspace_manager.models import SubstrateProfile
+
+if TYPE_CHECKING:
+    from custom_components.growspace_manager.coordinator import GrowspaceCoordinator
+
+
+class IrrigationChangeError(ValueError):
+    """A payload that cannot become an Irrigation Change."""
+
+
+class IrrigationChangeOperation(StrEnum):
+    """The public operation that submitted an Irrigation Change."""
+
+    SETTINGS = "settings"
+    STRATEGY = "strategy"
+    OPTIONS = "options"
+
+
+# Fields owned by the grower-facing settings interface. Schedule collections,
+# EC target ranges, the active steering phase and its timestamp have dedicated
+# owners and are deliberately absent.
+IRRIGATION_CONFIG_CHANGE_FIELDS: frozenset[str] = frozenset(
+    {
+        "irrigation_pump_entity",
+        "drain_pump_entity",
+        "irrigation_duration",
+        "drain_duration",
+        "pump_flow_rate_ml_per_sec",
+        "soil_trigger_percent",
+        "daily_volume_cap_liters",
+        "max_cycles_per_day",
+        "skip_during_dark",
+        "pause_on_low_tank",
+        "log_to_logbook",
+        "auto_advance_p1_to_p2",
+        "auto_advance_p2_to_p3",
+        "halt_on_runoff_ec_threshold",
+    }
+)
+
+# Canonical strategy fields owned by growers. detected_lights_on_time is an
+# observed runtime value and declared_steering_mode belongs to the preset-stamp
+# operation, so neither is writable through a sparse strategy change.
+IRRIGATION_STRATEGY_CHANGE_FIELDS: frozenset[str] = frozenset(
+    {
+        "enabled",
+        "lights_on_time",
+        "p0_duration_minutes",
+        "p2_stop_before_lights_off_minutes",
+        "target_vwc_percent",
+        "maintenance_dryback_percent",
+        "p1_shot_duration_seconds",
+        "p1_shot_interval_minutes",
+        "p2_shot_duration_seconds",
+        "p2_shot_interval_minutes",
+        "auto_light_tracking",
+        "shot_sizing_mode",
+        "substrate_profile",
+        "p1_shot_volume_percent",
+        "p2_shot_volume_percent",
+        "dynamic_shot_enabled",
+        "dynamic_aggressiveness",
+        "dynamic_recovery",
+        "dynamic_shot_size_floor",
+        "dynamic_interval_ceiling",
+        "pore_ec_target_min",
+        "pore_ec_target_max",
+        "ec_modulation_enabled",
+    }
+)
+
+# Compatibility spellings accepted by existing action/config-flow payloads.
+_STRATEGY_ALIASES = frozenset(
+    {
+        "shot_duration_seconds",
+        "shot_interval_minutes",
+        "substrate_media_type",
+        "substrate_liters_per_pot",
+    }
+)
+_OPTIONS_ALIASES = frozenset({"use_vwc_steering"})
+
+
+@dataclass(frozen=True, slots=True)
+class IrrigationChange:
+    """One sparse irrigation edit from a public operation."""
+
+    operation: IrrigationChangeOperation
+    values: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        """Take an immutable snapshot of the transport payload."""
+        object.__setattr__(self, "values", MappingProxyType(dict(self.values)))
+
+
+@dataclass(frozen=True, slots=True)
+class IrrigationChangeResult:
+    """Immutable description of an applied Irrigation Change."""
+
+    operation: IrrigationChangeOperation
+    changed_config_fields: frozenset[str]
+    changed_strategy_fields: frozenset[str]
+
+
+def _accepted_fields(operation: IrrigationChangeOperation) -> frozenset[str]:
+    """Return the compatibility surface for one public operation."""
+    if operation is IrrigationChangeOperation.SETTINGS:
+        return IRRIGATION_CONFIG_CHANGE_FIELDS
+    if operation is IrrigationChangeOperation.STRATEGY:
+        return IRRIGATION_STRATEGY_CHANGE_FIELDS | _STRATEGY_ALIASES
+    return (
+        IRRIGATION_CONFIG_CHANGE_FIELDS
+        | IRRIGATION_STRATEGY_CHANGE_FIELDS
+        | _STRATEGY_ALIASES
+        | _OPTIONS_ALIASES
+    )
+
+
+def _normalize_values(
+    change: IrrigationChange, existing_profile: SubstrateProfile
+) -> dict[str, Any]:
+    """Translate compatibility spellings into canonical typed model values."""
+    values = dict(change.values)
+
+    if "use_vwc_steering" in values:
+        values.setdefault("enabled", bool(values.pop("use_vwc_steering")))
+
+    for alias, phase_fields in {
+        "shot_duration_seconds": (
+            "p1_shot_duration_seconds",
+            "p2_shot_duration_seconds",
+        ),
+        "shot_interval_minutes": (
+            "p1_shot_interval_minutes",
+            "p2_shot_interval_minutes",
+        ),
+    }.items():
+        if alias in values:
+            alias_value = values.pop(alias)
+            for phase_field in phase_fields:
+                values.setdefault(phase_field, alias_value)
+
+    profile_update = values.pop("substrate_profile", None)
+    media_type = values.pop("substrate_media_type", None)
+    liters_per_pot = values.pop("substrate_liters_per_pot", None)
+    if (
+        profile_update is not None
+        or media_type is not None
+        or liters_per_pot is not None
+    ):
+        if isinstance(profile_update, SubstrateProfile):
+            profile_data: dict[str, Any] = {
+                "media_type": profile_update.media_type,
+                "liters_per_pot": profile_update.liters_per_pot,
+            }
+        elif isinstance(profile_update, Mapping):
+            profile_data = dict(profile_update)
+        elif profile_update is None:
+            profile_data = {}
+        else:
+            raise IrrigationChangeError("substrate_profile must be a mapping")
+        if media_type is not None:
+            profile_data["media_type"] = media_type
+        if liters_per_pot is not None:
+            profile_data["liters_per_pot"] = liters_per_pot
+        values["substrate_profile"] = SubstrateProfile(
+            media_type=SubstrateMediaType(
+                profile_data.get("media_type", existing_profile.media_type)
+            ),
+            liters_per_pot=float(
+                profile_data.get("liters_per_pot", existing_profile.liters_per_pot)
+            ),
+        )
+
+    for pump_field in ("irrigation_pump_entity", "drain_pump_entity"):
+        if pump_field in values and not values[pump_field]:
+            values[pump_field] = None
+
+    if "shot_sizing_mode" in values:
+        values["shot_sizing_mode"] = ShotSizingMode(values["shot_sizing_mode"])
+
+    return values
+
+
+def _validate_candidate(config: Any, strategy: Any) -> None:
+    """Validate invariants against the complete post-change state."""
+    if strategy.shot_sizing_mode is ShotSizingMode.VOLUME and (
+        strategy.substrate_profile.liters_per_pot <= 0.0
+        or config.pump_flow_rate_ml_per_sec <= 0.0
+    ):
+        raise IrrigationChangeError(
+            "Volume Mode requires a substrate profile (liters per pot) and a "
+            "pump flow rate to be configured first."
+        )
+
+    band_min = strategy.pore_ec_target_min
+    band_max = strategy.pore_ec_target_max
+    if band_min is not None and band_max is not None and band_min >= band_max:
+        raise IrrigationChangeError(
+            f"Pore EC target band invalid: min ({band_min}) must be below "
+            f"max ({band_max})"
+        )
+
+
+async def async_apply_irrigation_change(
+    coordinator: GrowspaceCoordinator,
+    growspace_id: str,
+    change: IrrigationChange,
+) -> IrrigationChangeResult:
+    """Apply one strict, atomic Irrigation Change."""
+    accepted = _accepted_fields(change.operation)
+    for field in change.values:
+        if field not in accepted:
+            raise IrrigationChangeError(
+                f"Field '{field}' is not writable by the "
+                f"{change.operation.value} irrigation operation"
+            )
+
+    growspace = coordinator.growspaces.get(growspace_id)
+    if growspace is None:
+        raise GrowspaceNotFoundError(f"Growspace {growspace_id} not found")
+
+    values = _normalize_values(change, growspace.irrigation_strategy.substrate_profile)
+    config_updates = {
+        field: value
+        for field, value in values.items()
+        if field in IRRIGATION_CONFIG_CHANGE_FIELDS
+    }
+    strategy_updates = {
+        field: value
+        for field, value in values.items()
+        if field in IRRIGATION_STRATEGY_CHANGE_FIELDS
+    }
+    prior_config = growspace.irrigation_config
+    prior_strategy = growspace.irrigation_strategy
+    candidate_config = replace(prior_config, **config_updates)
+    candidate_strategy = replace(prior_strategy, **strategy_updates)
+    _validate_candidate(candidate_config, candidate_strategy)
+    changed_config_fields = frozenset(
+        field
+        for field in config_updates
+        if getattr(prior_config, field) != getattr(candidate_config, field)
+    )
+    changed_strategy_fields = frozenset(
+        field
+        for field in strategy_updates
+        if getattr(prior_strategy, field) != getattr(candidate_strategy, field)
+    )
+
+    growspace.irrigation_config = candidate_config
+    growspace.irrigation_strategy = candidate_strategy
+    coordinator.cache.invalidate(growspace_id)
+    try:
+        await coordinator.async_commit()
+    except Exception:
+        growspace.irrigation_config = prior_config
+        growspace.irrigation_strategy = prior_strategy
+        raise
+    await coordinator.async_request_refresh()
+
+    return IrrigationChangeResult(
+        operation=change.operation,
+        changed_config_fields=changed_config_fields,
+        changed_strategy_fields=changed_strategy_fields,
+    )

--- a/custom_components/growspace_manager/strings.json
+++ b/custom_components/growspace_manager/strings.json
@@ -479,6 +479,7 @@
       "setup_error": "The integration is not set up yet. Try again once it has finished loading.",
       "file_not_found": "No file was found at that path. Check the path and try again.",
       "invalid_zip": "That file is not a valid strain library archive.",
+      "invalid_irrigation_change": "The irrigation settings are invalid: {error}",
       "import_failed": "The strain library could not be imported. Check the logs for details.",
       "add_failed": "The item could not be added because of an unexpected error. Check the logs for details.",
       "update_failed": "The item could not be updated because of an unexpected error. Check the logs for details.",

--- a/custom_components/growspace_manager/translations/en.json
+++ b/custom_components/growspace_manager/translations/en.json
@@ -479,6 +479,7 @@
       "setup_error": "The integration is not set up yet. Try again once it has finished loading.",
       "file_not_found": "No file was found at that path. Check the path and try again.",
       "invalid_zip": "That file is not a valid strain library archive.",
+      "invalid_irrigation_change": "The irrigation settings are invalid: {error}",
       "import_failed": "The strain library could not be imported. Check the logs for details.",
       "add_failed": "The item could not be added because of an unexpected error. Check the logs for details.",
       "update_failed": "The item could not be updated because of an unexpected error. Check the logs for details.",

--- a/tests/config/test_config_flow.py
+++ b/tests/config/test_config_flow.py
@@ -2388,6 +2388,44 @@ async def test_options_flow_configure_irrigation_submit(
     )
 
 
+@pytest.mark.asyncio
+async def test_options_flow_presents_irrigation_change_validation_failure(
+    hass: HomeAssistant, mock_coordinator: MagicMock
+) -> None:
+    """The options adapter keeps an invalid candidate on the form."""
+    from custom_components.growspace_manager.services.irrigation_change import (
+        IrrigationChangeError,
+    )
+
+    config_entry = MockConfigEntry(domain=DOMAIN, data={"name": "Test"}, options={})
+    config_entry.add_to_hass(hass)
+    config_entry.runtime_data = mock_coordinator
+    mock_coordinator.growspaces = {
+        "gs1": Mock(
+            name="Growspace 1",
+            irrigation_config=IrrigationConfig(),
+            irrigation_strategy=IrrigationStrategy(),
+        )
+    }
+    mock_coordinator.services.growspaces.update_irrigation_config = AsyncMock(
+        side_effect=IrrigationChangeError("Pore EC target band invalid")
+    )
+    flow = OptionsFlowHandler(config_entry)
+    flow.hass = hass
+    flow.selected_growspace_id = "gs1"
+
+    result = await flow.async_step_irrigation_overview(
+        user_input={"pore_ec_target_min": 5.0, "pore_ec_target_max": 4.0}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "irrigation_overview"
+    assert result["errors"] == {"base": "invalid_irrigation_change"}
+    assert result["description_placeholders"]["error"] == (
+        "Pore EC target band invalid"
+    )
+
+
 # ============================================================================
 # Test OptionsFlowHandler - Manage Strain Library
 # ============================================================================

--- a/tests/contract/test_irrigation_action_metadata.py
+++ b/tests/contract/test_irrigation_action_metadata.py
@@ -1,0 +1,47 @@
+"""Structural guard for the public Irrigation Change action metadata."""
+
+from pathlib import Path
+
+import voluptuous as vol
+import yaml
+
+from custom_components.growspace_manager.schemas import (
+    SET_IRRIGATION_SETTINGS_SCHEMA,
+    SET_IRRIGATION_STRATEGY_SCHEMA,
+)
+from custom_components.growspace_manager.services.irrigation_change import (
+    IRRIGATION_CONFIG_CHANGE_FIELDS,
+    IRRIGATION_STRATEGY_CHANGE_FIELDS,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+SERVICES_YAML = ROOT / "custom_components" / "growspace_manager" / "services.yaml"
+
+_STRATEGY_WIRE_FIELDS = {
+    "shot_duration_seconds",
+    "shot_interval_minutes",
+    "substrate_media_type",
+    "substrate_liters_per_pot",
+}
+
+
+def _fields(schema: vol.Schema) -> set[str]:
+    """Return marker names from one voluptuous mapping schema."""
+    return {marker.schema for marker in schema.schema if isinstance(marker, vol.Marker)}
+
+
+def test_irrigation_action_metadata_matches_change_interface() -> None:
+    """Both action schemas and metadata expose exactly their owned fields."""
+    metadata = yaml.safe_load(SERVICES_YAML.read_text(encoding="utf-8"))
+    settings_schema = SET_IRRIGATION_SETTINGS_SCHEMA.validators[0]
+    expected_settings = {"growspace_id"} | set(IRRIGATION_CONFIG_CHANGE_FIELDS)
+    expected_strategy = (
+        {"growspace_id"}
+        | (set(IRRIGATION_STRATEGY_CHANGE_FIELDS) - {"substrate_profile"})
+        | _STRATEGY_WIRE_FIELDS
+    )
+
+    assert _fields(settings_schema) == expected_settings
+    assert _fields(SET_IRRIGATION_STRATEGY_SCHEMA) == expected_strategy
+    assert set(metadata["set_irrigation_settings"]["fields"]) == expected_settings
+    assert set(metadata["set_irrigation_strategy"]["fields"]) == expected_strategy

--- a/tests/core/test_coordinator.py
+++ b/tests/core/test_coordinator.py
@@ -2059,21 +2059,16 @@ async def test_async_update_irrigation_config(
     gs_id = gs.id
     gs.irrigation_config.irrigation_pump_entity = "switch.pump1"
 
-    # 1. Update with read-only fields (should be ignored) and valid fields
-    user_input = {
-        "irrigation_pump_entity": "switch.pump2",
-        "current_irrigation_times": "ignored",
-        "growspace_id_read_only": "ignored",
-    }
-
-    await coordinator.services.growspaces.update_irrigation_config(gs_id, user_input)
+    await coordinator.services.growspaces.update_irrigation_config(
+        gs_id, {"irrigation_pump_entity": "switch.pump2"}
+    )
 
     assert (
         coordinator.growspaces[gs_id].irrigation_config.irrigation_pump_entity
         == "switch.pump2"
     )
 
-    # 2. Calling with non-existent GS raises GrowspaceNotFoundError
+    # Calling with non-existent GS raises GrowspaceNotFoundError.
     with pytest.raises(GrowspaceNotFoundError):
         await coordinator.services.growspaces.update_irrigation_config("missing", {})
 

--- a/tests/core/test_services_irrigation.py
+++ b/tests/core/test_services_irrigation.py
@@ -4,6 +4,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from custom_components.growspace_manager.models import Growspace
+from custom_components.growspace_manager.services.growspace_facade import (
+    GrowspaceFacade,
+)
 from custom_components.growspace_manager.services.irrigation import (
     _get_irrigation_coordinator,
     handle_add_drain_time,
@@ -67,6 +71,22 @@ def mock_coordinator():
 def mock_strain_library():
     """Create a mock strain library."""
     return MagicMock()
+
+
+def _install_real_irrigation_action_stack(
+    coordinator: MagicMock, irrigation_coordinator: MagicMock
+) -> Growspace:
+    """Connect an action handler to the real facade and Irrigation Change seam."""
+    growspace = Growspace(id="gs1", name="Growspace 1")
+    coordinator.growspaces = {growspace.id: growspace}
+    coordinator._subsystem_manager.irrigation_coordinators = {
+        growspace.id: irrigation_coordinator
+    }
+    coordinator.cache = MagicMock()
+    coordinator.async_commit = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.services.growspaces = GrowspaceFacade(coordinator)
+    return growspace
 
 
 class TestGetIrrigationCoordinator:
@@ -137,11 +157,10 @@ class TestHandleSetIrrigationSettings:
         mock_irrigation_coordinator,
         mock_coordinator,
     ):
-        """Test setting irrigation settings."""
-        # Setup
-        mock_coordinator._subsystem_manager.irrigation_coordinators = {
-            "gs1": mock_irrigation_coordinator
-        }
+        """The settings action applies canonical state through the write seam."""
+        growspace = _install_real_irrigation_action_stack(
+            mock_coordinator, mock_irrigation_coordinator
+        )
 
         call = MagicMock(spec=ServiceCall)
         call.data = {
@@ -153,20 +172,13 @@ class TestHandleSetIrrigationSettings:
             "drain_duration": 300,
         }
 
-        # Execute
         await handle_set_irrigation_settings(mock_hass, mock_coordinator, call)
 
-        # Verify against the main coordinator services facade
-        expected_settings = {
-            "irrigation_pump_entity": "switch.pump",
-            "pump_flow_rate_ml_per_sec": 12.5,
-            "drain_pump_entity": "switch.drain",
-            "irrigation_duration": 600,
-            "drain_duration": 300,
-        }
-        mock_coordinator.services.growspaces.set_irrigation_settings.assert_awaited_once_with(
-            "gs1", expected_settings
-        )
+        assert growspace.irrigation_config.irrigation_pump_entity == "switch.pump"
+        assert growspace.irrigation_config.pump_flow_rate_ml_per_sec == 12.5
+        assert growspace.irrigation_config.drain_pump_entity == "switch.drain"
+        assert growspace.irrigation_config.irrigation_duration == 600
+        assert growspace.irrigation_config.drain_duration == 300
 
     @pytest.mark.asyncio
     async def test_set_irrigation_settings_accepts_input_boolean_entities(
@@ -213,6 +225,28 @@ class TestHandleSetIrrigationSettings:
         # Should raise ServiceValidationError because GS not found even in fallback
         with pytest.raises(ServiceValidationError, match="not found"):
             await handle_set_irrigation_settings(mock_hass, mock_coordinator, call)
+
+    @pytest.mark.asyncio
+    async def test_set_irrigation_settings_presents_change_validation_error(
+        self,
+        mock_hass: MagicMock,
+        mock_irrigation_coordinator: MagicMock,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """The settings adapter presents a rejected field without rewriting it."""
+        _install_real_irrigation_action_stack(
+            mock_coordinator, mock_irrigation_coordinator
+        )
+        call = MagicMock(spec=ServiceCall)
+        call.data = {"growspace_id": "gs1", "active_steering_phase": "p2"}
+
+        with pytest.raises(ServiceValidationError) as exc_info:
+            await handle_set_irrigation_settings(mock_hass, mock_coordinator, call)
+
+        assert str(exc_info.value) == (
+            "Field 'active_steering_phase' is not writable by the settings "
+            "irrigation operation"
+        )
 
 
 class TestHandleAddIrrigationTime:
@@ -391,11 +425,10 @@ class TestHandleSetIrrigationStrategy:
         mock_irrigation_coordinator: MagicMock,
         mock_coordinator: MagicMock,
     ) -> None:
-        """Test setting irrigation strategy."""
-        # Setup
-        mock_coordinator._subsystem_manager.irrigation_coordinators = {
-            "gs1": mock_irrigation_coordinator
-        }
+        """The strategy action applies canonical state through the write seam."""
+        growspace = _install_real_irrigation_action_stack(
+            mock_coordinator, mock_irrigation_coordinator
+        )
 
         call = MagicMock(spec=ServiceCall)
         call.data = {
@@ -410,23 +443,18 @@ class TestHandleSetIrrigationStrategy:
             "shot_interval_minutes": 15,
         }
 
-        # Execute
         await handle_set_irrigation_strategy(mock_hass, mock_coordinator, call)
 
-        # Verify against the main coordinator services facade
-        expected_strategy = {
-            "enabled": True,
-            "lights_on_time": "06:00:00",
-            "p0_duration_minutes": 60,
-            "p2_stop_before_lights_off_minutes": 120,
-            "target_vwc_percent": 55.0,
-            "maintenance_dryback_percent": 2.0,
-            "shot_duration_seconds": 10,
-            "shot_interval_minutes": 15,
-        }
-        mock_coordinator.services.growspaces.set_irrigation_strategy.assert_awaited_once_with(
-            "gs1", expected_strategy
-        )
+        assert growspace.irrigation_strategy.enabled is True
+        assert growspace.irrigation_strategy.lights_on_time == "06:00:00"
+        assert growspace.irrigation_strategy.p0_duration_minutes == 60
+        assert growspace.irrigation_strategy.p2_stop_before_lights_off_minutes == 120
+        assert growspace.irrigation_strategy.target_vwc_percent == 55.0
+        assert growspace.irrigation_strategy.maintenance_dryback_percent == 2.0
+        assert growspace.irrigation_strategy.p1_shot_duration_seconds == 10
+        assert growspace.irrigation_strategy.p2_shot_duration_seconds == 10
+        assert growspace.irrigation_strategy.p1_shot_interval_minutes == 15
+        assert growspace.irrigation_strategy.p2_shot_interval_minutes == 15
 
     @pytest.mark.asyncio
     async def test_set_irrigation_strategy_growspace_not_found(

--- a/tests/core/test_services_irrigation.py
+++ b/tests/core/test_services_irrigation.py
@@ -6,7 +6,6 @@ import pytest
 
 from custom_components.growspace_manager.services.irrigation import (
     _get_irrigation_coordinator,
-    _validate_volume_mode_selection,
     handle_add_drain_time,
     handle_add_irrigation_time,
     handle_remove_drain_time,
@@ -446,6 +445,32 @@ class TestHandleSetIrrigationStrategy:
         with pytest.raises(ServiceValidationError, match="not found"):
             await handle_set_irrigation_strategy(mock_hass, mock_coordinator, call)
 
+    @pytest.mark.asyncio
+    async def test_set_irrigation_strategy_presents_change_validation_error(
+        self,
+        mock_hass: MagicMock,
+        mock_irrigation_coordinator: MagicMock,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """The action adapter presents a domain validation failure unchanged."""
+        from custom_components.growspace_manager.services.irrigation_change import (
+            IrrigationChangeError,
+        )
+
+        mock_coordinator._subsystem_manager.irrigation_coordinators = {
+            "gs1": mock_irrigation_coordinator
+        }
+        mock_coordinator.services.growspaces.set_irrigation_strategy.side_effect = (
+            IrrigationChangeError("Field 'detected_lights_on_time' is read-only")
+        )
+        call = MagicMock(spec=ServiceCall)
+        call.data = {"growspace_id": "gs1", "detected_lights_on_time": "07:00:00"}
+
+        with pytest.raises(ServiceValidationError) as exc_info:
+            await handle_set_irrigation_strategy(mock_hass, mock_coordinator, call)
+
+        assert str(exc_info.value) == ("Field 'detected_lights_on_time' is read-only")
+
 
 class TestHandleApplySteeringMode:
     """Tests for handle_apply_steering_mode service handler (ADR-0012)."""
@@ -535,118 +560,3 @@ class TestHandleRunIrrigationCycle:
 
         with pytest.raises(ServiceValidationError, match="not found"):
             await handle_run_irrigation_cycle(mock_hass, mock_coordinator, call)
-
-
-class TestVolumeModeStrategyValidation:
-    """Volume Mode gating + substrate-profile folding (ADR-0011)."""
-
-    def _make_growspace(self, liters_per_pot: float, flow_rate: float):
-        from custom_components.growspace_manager.models import (
-            Growspace,
-            IrrigationConfig,
-            IrrigationStrategy,
-            SubstrateProfile,
-        )
-
-        gs = Growspace(
-            id="gs1",
-            name="GS",
-            irrigation_config=IrrigationConfig(pump_flow_rate_ml_per_sec=flow_rate),
-        )
-        gs.irrigation_strategy = IrrigationStrategy(
-            substrate_profile=SubstrateProfile(liters_per_pot=liters_per_pot)
-        )
-        return gs
-
-    @pytest.mark.asyncio
-    async def test_volume_mode_rejected_without_profile(
-        self, mock_hass: MagicMock, mock_coordinator: MagicMock
-    ) -> None:
-        """Selecting Volume Mode without a substrate profile is rejected."""
-        mock_coordinator.growspaces = {"gs1": self._make_growspace(0.0, 20.0)}
-
-        call = MagicMock(spec=ServiceCall)
-        call.data = {"growspace_id": "gs1", "shot_sizing_mode": "volume"}
-
-        with pytest.raises(ServiceValidationError, match="Volume Mode requires"):
-            await handle_set_irrigation_strategy(mock_hass, mock_coordinator, call)
-        mock_coordinator.services.growspaces.set_irrigation_strategy.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_volume_mode_rejected_without_flow_rate(
-        self, mock_hass: MagicMock, mock_coordinator: MagicMock
-    ) -> None:
-        """Selecting Volume Mode without a pump flow rate is rejected."""
-        mock_coordinator.growspaces = {"gs1": self._make_growspace(6.0, 0.0)}
-
-        call = MagicMock(spec=ServiceCall)
-        call.data = {"growspace_id": "gs1", "shot_sizing_mode": "volume"}
-
-        with pytest.raises(ServiceValidationError, match="Volume Mode requires"):
-            await handle_set_irrigation_strategy(mock_hass, mock_coordinator, call)
-
-    @pytest.mark.asyncio
-    async def test_volume_mode_accepted_when_profile_set_in_same_call(
-        self, mock_hass: MagicMock, mock_coordinator: MagicMock
-    ) -> None:
-        """A single call may set the profile and switch to Volume Mode together."""
-        mock_coordinator.growspaces = {"gs1": self._make_growspace(0.0, 20.0)}
-
-        call = MagicMock(spec=ServiceCall)
-        call.data = {
-            "growspace_id": "gs1",
-            "shot_sizing_mode": "volume",
-            "substrate_media_type": "rockwool",
-            "substrate_liters_per_pot": 6.0,
-        }
-
-        await handle_set_irrigation_strategy(mock_hass, mock_coordinator, call)
-
-        _gid, strategy = (
-            mock_coordinator.services.growspaces.set_irrigation_strategy.await_args[0]
-        )
-        # Flat substrate keys are folded into a nested profile dict.
-        assert "substrate_media_type" not in strategy
-        assert strategy["substrate_profile"] == {
-            "media_type": "rockwool",
-            "liters_per_pot": 6.0,
-        }
-        assert strategy["shot_sizing_mode"] == "volume"
-
-    @pytest.mark.asyncio
-    async def test_seconds_mode_skips_volume_validation(
-        self, mock_hass: MagicMock, mock_coordinator: MagicMock
-    ) -> None:
-        """Seconds Mode is accepted with no profile or flow rate."""
-        mock_coordinator.growspaces = {"gs1": self._make_growspace(0.0, 0.0)}
-
-        call = MagicMock(spec=ServiceCall)
-        call.data = {"growspace_id": "gs1", "shot_sizing_mode": "seconds"}
-
-        await handle_set_irrigation_strategy(mock_hass, mock_coordinator, call)
-
-        mock_coordinator.services.growspaces.set_irrigation_strategy.assert_awaited_once()
-
-    def test_incoming_flow_rate_satisfies_gate(
-        self, mock_coordinator: MagicMock
-    ) -> None:
-        """An incoming pump flow rate wins over the stored one (config-flow path).
-
-        The config-flow form sets the flow rate and the mode in one submission, so
-        the gate must evaluate the incoming value, not the (still-zero) stored one.
-        """
-        mock_coordinator.growspaces = {"gs1": self._make_growspace(6.0, 0.0)}
-
-        # No raise: incoming flow rate is positive even though stored is 0.0.
-        _validate_volume_mode_selection(
-            mock_coordinator,
-            "gs1",
-            {"shot_sizing_mode": "volume", "pump_flow_rate_ml_per_sec": 12.0},
-        )
-
-        with pytest.raises(ServiceValidationError, match="Volume Mode requires"):
-            _validate_volume_mode_selection(
-                mock_coordinator,
-                "gs1",
-                {"shot_sizing_mode": "volume", "pump_flow_rate_ml_per_sec": 0.0},
-            )

--- a/tests/integration/test_facade_comprehensive.py
+++ b/tests/integration/test_facade_comprehensive.py
@@ -11,7 +11,6 @@ from custom_components.growspace_manager.data_access.notification_state import (
 from custom_components.growspace_manager.models import (
     Growspace,
     HarvestMetrics,
-    IrrigationConfig,
     IrrigationTank,
     PhenotypeScore,
 )
@@ -442,133 +441,6 @@ async def test_add_mother_plant(mock_coordinator) -> None:
 
 
 # ---------------------------------------------------------------------------
-# update_irrigation_config
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_update_irrigation_config_not_found(mock_coordinator) -> None:
-    """update_irrigation_config raises error if growspace not found."""
-    from custom_components.growspace_manager.exceptions import GrowspaceNotFoundError
-
-    facade = ServiceFacade(mock_coordinator)
-    mock_coordinator.growspaces = {}
-    with pytest.raises(GrowspaceNotFoundError):
-        await facade.growspaces.update_irrigation_config("missing", {})
-
-
-@pytest.mark.asyncio
-async def test_update_irrigation_config_clear(mock_coordinator) -> None:
-    """Clear flag resets irrigation config."""
-    facade = ServiceFacade(mock_coordinator)
-    gs = MagicMock()
-    gs.irrigation_config = MagicMock()
-    gs.irrigation_strategy = MagicMock()
-    mock_coordinator.growspaces = {"gs1": gs}
-    mock_coordinator.async_commit = AsyncMock()
-
-    await facade.growspaces.update_irrigation_config("gs1", {"clear": True})
-
-    assert isinstance(gs.irrigation_config, IrrigationConfig)
-    assert gs.irrigation_strategy.enabled is False
-    mock_coordinator.async_commit.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_update_irrigation_config_vwc_steering(mock_coordinator) -> None:
-    """use_vwc_steering sets strategy.enabled."""
-    facade = ServiceFacade(mock_coordinator)
-    gs = Growspace(id="gs1", name="GS1")
-    mock_coordinator.growspaces = {"gs1": gs}
-    mock_coordinator.async_commit = AsyncMock()
-    mock_coordinator.async_request_refresh = AsyncMock()
-    mock_coordinator.cache = MagicMock()
-
-    await facade.growspaces.update_irrigation_config("gs1", {"use_vwc_steering": True})
-    assert gs.irrigation_strategy.enabled is True
-
-
-@pytest.mark.asyncio
-async def test_update_irrigation_config_sets_fields(mock_coordinator) -> None:
-    """update_irrigation_config updates IrrigationConfig fields."""
-    facade = ServiceFacade(mock_coordinator)
-    gs = Growspace(id="gs1", name="GS1")
-    mock_coordinator.growspaces = {"gs1": gs}
-    mock_coordinator.async_commit = AsyncMock()
-    mock_coordinator.async_request_refresh = AsyncMock()
-    mock_coordinator.cache = MagicMock()
-
-    await facade.growspaces.update_irrigation_config(
-        "gs1",
-        {
-            "target_vwc": 0.35,
-            "irrigation_pump_entity": "",  # falsy -> None
-            "drain_pump_entity": "",  # falsy -> None
-        },
-    )
-    assert gs.irrigation_config.irrigation_pump_entity is None
-
-
-@pytest.mark.asyncio
-async def test_update_irrigation_config_sets_pore_ec_band(mock_coordinator) -> None:
-    """A valid pore-EC band and opt-in flag land on the strategy."""
-    facade = ServiceFacade(mock_coordinator)
-    gs = Growspace(id="gs1", name="GS1")
-    mock_coordinator.growspaces = {"gs1": gs}
-    mock_coordinator.async_commit = AsyncMock()
-    mock_coordinator.async_request_refresh = AsyncMock()
-    mock_coordinator.cache = MagicMock()
-
-    await facade.growspaces.update_irrigation_config(
-        "gs1",
-        {
-            "pore_ec_target_min": 2.0,
-            "pore_ec_target_max": 3.5,
-            "ec_modulation_enabled": True,
-        },
-    )
-    assert gs.irrigation_strategy.pore_ec_target_min == 2.0
-    assert gs.irrigation_strategy.pore_ec_target_max == 3.5
-    assert gs.irrigation_strategy.ec_modulation_enabled is True
-
-
-@pytest.mark.asyncio
-async def test_update_irrigation_config_rejects_inverted_band(mock_coordinator) -> None:
-    """A pore-EC band with min >= max is rejected with a validation error."""
-    facade = ServiceFacade(mock_coordinator)
-    gs = Growspace(id="gs1", name="GS1")
-    mock_coordinator.growspaces = {"gs1": gs}
-    mock_coordinator.async_commit = AsyncMock()
-    mock_coordinator.async_request_refresh = AsyncMock()
-    mock_coordinator.cache = MagicMock()
-
-    with pytest.raises(ServiceValidationError, match="Pore EC target band"):
-        await facade.growspaces.update_irrigation_config(
-            "gs1",
-            {"pore_ec_target_min": 3.0, "pore_ec_target_max": 2.0},
-        )
-
-
-@pytest.mark.asyncio
-async def test_update_irrigation_config_band_single_edge_vs_stored(
-    mock_coordinator,
-) -> None:
-    """Setting one edge is validated against the already-stored other edge."""
-    facade = ServiceFacade(mock_coordinator)
-    gs = Growspace(id="gs1", name="GS1")
-    gs.irrigation_strategy.pore_ec_target_max = 3.0
-    mock_coordinator.growspaces = {"gs1": gs}
-    mock_coordinator.async_commit = AsyncMock()
-    mock_coordinator.async_request_refresh = AsyncMock()
-    mock_coordinator.cache = MagicMock()
-
-    with pytest.raises(ServiceValidationError, match="Pore EC target band"):
-        await facade.growspaces.update_irrigation_config(
-            "gs1", {"pore_ec_target_min": 4.0}
-        )
-
-
-# ---------------------------------------------------------------------------
 # take_clones / promote_clone
 # ---------------------------------------------------------------------------
 
@@ -603,19 +475,6 @@ async def test_promote_clone(mock_coordinator) -> None:
 # ---------------------------------------------------------------------------
 # Irrigation schedule methods
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_set_irrigation_settings(mock_coordinator) -> None:
-    """set_irrigation_settings delegates to update_irrigation_config."""
-    facade = ServiceFacade(mock_coordinator)
-    gs = Growspace(id="gs1", name="GS1")
-    mock_coordinator.growspaces = {"gs1": gs}
-    mock_coordinator.async_commit = AsyncMock()
-    mock_coordinator.async_request_refresh = AsyncMock()
-    mock_coordinator.cache = MagicMock()
-
-    await facade.growspaces.set_irrigation_settings("gs1", {"target_vwc": 0.4})
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_irrigation_config_volume_mode_flow.py
+++ b/tests/integration/test_irrigation_config_volume_mode_flow.py
@@ -21,7 +21,6 @@ from custom_components.growspace_manager.models import (
     SubstrateProfile,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 
 
 def _suggested_value(schema: vol.Schema, key: str):
@@ -152,16 +151,17 @@ async def test_volume_mode_round_trips_through_real_facade(
 async def test_volume_mode_rejected_without_prerequisites_in_flow(
     handler: IrrigationConfigHandler,
 ) -> None:
-    """Selecting Volume Mode with no profile/flow rate raises the shared error."""
+    """Selecting Volume Mode without prerequisites stays on the form."""
     coordinator = handler.config_entry.runtime_data
     gs = _add_growspace(coordinator)
 
-    with pytest.raises(ServiceValidationError, match="Volume Mode requires"):
-        await handler.async_step_irrigation_overview(
-            {"shot_sizing_mode": ShotSizingMode.VOLUME.value}
-        )
+    result = await handler.async_step_irrigation_overview(
+        {"shot_sizing_mode": ShotSizingMode.VOLUME.value}
+    )
 
-    # The rejected submission leaves the strategy untouched.
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "invalid_irrigation_change"}
+    assert "Volume Mode requires" in result["description_placeholders"]["error"]
     assert gs.irrigation_strategy.shot_sizing_mode == ShotSizingMode.SECONDS
 
 

--- a/tests/services/test_irrigation_change.py
+++ b/tests/services/test_irrigation_change.py
@@ -136,6 +136,72 @@ async def test_change_normalizes_compatibility_fields_to_canonical_state() -> No
 
 
 @pytest.mark.asyncio
+async def test_change_accepts_a_typed_substrate_profile() -> None:
+    """Callers may supply the canonical model value without re-encoding it."""
+    growspace = Growspace(id="tent", name="Tent")
+    coordinator = _coordinator(growspace)
+    profile = SubstrateProfile(
+        media_type=SubstrateMediaType.COCO,
+        liters_per_pot=8.0,
+    )
+
+    await async_apply_irrigation_change(
+        coordinator,
+        "tent",
+        IrrigationChange(
+            operation=IrrigationChangeOperation.OPTIONS,
+            values={"substrate_profile": profile},
+        ),
+    )
+
+    assert growspace.irrigation_strategy.substrate_profile == profile
+
+
+@pytest.mark.asyncio
+async def test_change_merges_a_partial_substrate_profile_mapping() -> None:
+    """A nested partial profile retains the stored value for its missing half."""
+    growspace = Growspace(id="tent", name="Tent")
+    growspace.irrigation_strategy.substrate_profile = SubstrateProfile(
+        media_type=SubstrateMediaType.ROCKWOOL,
+        liters_per_pot=4.0,
+    )
+    coordinator = _coordinator(growspace)
+
+    await async_apply_irrigation_change(
+        coordinator,
+        "tent",
+        IrrigationChange(
+            operation=IrrigationChangeOperation.OPTIONS,
+            values={"substrate_profile": {"liters_per_pot": 6.0}},
+        ),
+    )
+
+    assert growspace.irrigation_strategy.substrate_profile == SubstrateProfile(
+        media_type=SubstrateMediaType.ROCKWOOL,
+        liters_per_pot=6.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_change_rejects_a_non_mapping_substrate_profile() -> None:
+    """Malformed profile input fails before state or persistence is touched."""
+    growspace = Growspace(id="tent", name="Tent")
+    coordinator = _coordinator(growspace)
+
+    with pytest.raises(IrrigationChangeError, match="must be a mapping"):
+        await async_apply_irrigation_change(
+            coordinator,
+            "tent",
+            IrrigationChange(
+                operation=IrrigationChangeOperation.OPTIONS,
+                values={"substrate_profile": "rockwool"},
+            ),
+        )
+
+    coordinator.async_commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_change_validates_volume_mode_against_effective_state() -> None:
     """A settings-only change cannot remove a prerequisite from active Volume Mode."""
     growspace = Growspace(id="tent", name="Tent")

--- a/tests/services/test_irrigation_change.py
+++ b/tests/services/test_irrigation_change.py
@@ -1,0 +1,244 @@
+"""Tests for the Irrigation Change write seam."""
+
+from dataclasses import FrozenInstanceError
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.growspace_manager.const import ShotSizingMode, SubstrateMediaType
+from custom_components.growspace_manager.models import Growspace, SubstrateProfile
+from custom_components.growspace_manager.services.irrigation_change import (
+    IrrigationChange,
+    IrrigationChangeError,
+    IrrigationChangeOperation,
+    async_apply_irrigation_change,
+)
+
+
+def _coordinator(growspace: Growspace) -> SimpleNamespace:
+    """Return the effect shell needed by the public Irrigation Change seam."""
+    coordinator = SimpleNamespace(
+        growspaces={growspace.id: growspace},
+        cache=MagicMock(),
+        async_commit=AsyncMock(),
+        async_request_refresh=AsyncMock(),
+    )
+    return coordinator
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "unknown_field",
+        "active_steering_phase",
+        "phase_changed_at",
+        "detected_lights_on_time",
+        "declared_steering_mode",
+    ],
+)
+@pytest.mark.asyncio
+async def test_change_rejects_fields_the_grower_does_not_own(field: str) -> None:
+    """Unknown, derived, and runtime-owned fields fail instead of disappearing."""
+    growspace = Growspace(id="tent", name="Tent")
+    coordinator = _coordinator(growspace)
+
+    with pytest.raises(IrrigationChangeError, match=field):
+        await async_apply_irrigation_change(
+            coordinator,
+            "tent",
+            IrrigationChange(
+                operation=IrrigationChangeOperation.OPTIONS,
+                values={field: "replacement"},
+            ),
+        )
+
+    coordinator.async_commit.assert_not_awaited()
+    coordinator.async_request_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_change_atomically_replaces_candidate_state_and_describes_it() -> None:
+    """One mixed options change returns canonical immutable changed-field sets."""
+    growspace = Growspace(id="tent", name="Tent")
+    prior_config = growspace.irrigation_config
+    prior_strategy = growspace.irrigation_strategy
+    coordinator = _coordinator(growspace)
+
+    result = await async_apply_irrigation_change(
+        coordinator,
+        "tent",
+        IrrigationChange(
+            operation=IrrigationChangeOperation.OPTIONS,
+            values={
+                "irrigation_duration": 45,
+                "target_vwc_percent": 58.0,
+            },
+        ),
+    )
+
+    assert growspace.irrigation_config is not prior_config
+    assert growspace.irrigation_strategy is not prior_strategy
+    assert growspace.irrigation_config.irrigation_duration == 45
+    assert growspace.irrigation_strategy.target_vwc_percent == 58.0
+    assert result.operation is IrrigationChangeOperation.OPTIONS
+    assert result.changed_config_fields == frozenset({"irrigation_duration"})
+    assert result.changed_strategy_fields == frozenset({"target_vwc_percent"})
+    with pytest.raises(FrozenInstanceError):
+        result.operation = IrrigationChangeOperation.SETTINGS  # type: ignore[misc]
+    coordinator.cache.invalidate.assert_called_once_with("tent")
+    coordinator.async_commit.assert_awaited_once()
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_change_normalizes_compatibility_fields_to_canonical_state() -> None:
+    """Pump clears, form aliases, and partial profiles keep public behavior."""
+    growspace = Growspace(id="tent", name="Tent")
+    growspace.irrigation_config.irrigation_pump_entity = "switch.pump"
+    growspace.irrigation_strategy.substrate_profile = SubstrateProfile(
+        media_type=SubstrateMediaType.ROCKWOOL,
+        liters_per_pot=4.0,
+    )
+    coordinator = _coordinator(growspace)
+
+    result = await async_apply_irrigation_change(
+        coordinator,
+        "tent",
+        IrrigationChange(
+            operation=IrrigationChangeOperation.OPTIONS,
+            values={
+                "irrigation_pump_entity": "",
+                "use_vwc_steering": True,
+                "shot_duration_seconds": 12,
+                "substrate_liters_per_pot": 6.0,
+            },
+        ),
+    )
+
+    assert growspace.irrigation_config.irrigation_pump_entity is None
+    assert growspace.irrigation_strategy.enabled is True
+    assert growspace.irrigation_strategy.p1_shot_duration_seconds == 12
+    assert growspace.irrigation_strategy.p2_shot_duration_seconds == 12
+    assert growspace.irrigation_strategy.substrate_profile == SubstrateProfile(
+        media_type=SubstrateMediaType.ROCKWOOL,
+        liters_per_pot=6.0,
+    )
+    assert result.changed_config_fields == frozenset({"irrigation_pump_entity"})
+    assert result.changed_strategy_fields == frozenset(
+        {
+            "enabled",
+            "p1_shot_duration_seconds",
+            "p2_shot_duration_seconds",
+            "substrate_profile",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_change_validates_volume_mode_against_effective_state() -> None:
+    """A settings-only change cannot remove a prerequisite from active Volume Mode."""
+    growspace = Growspace(id="tent", name="Tent")
+    growspace.irrigation_config.pump_flow_rate_ml_per_sec = 20.0
+    growspace.irrigation_strategy.shot_sizing_mode = ShotSizingMode.VOLUME
+    growspace.irrigation_strategy.substrate_profile = SubstrateProfile(
+        liters_per_pot=4.0
+    )
+    prior_config = growspace.irrigation_config
+    prior_strategy = growspace.irrigation_strategy
+    coordinator = _coordinator(growspace)
+
+    with pytest.raises(IrrigationChangeError, match="Volume Mode requires"):
+        await async_apply_irrigation_change(
+            coordinator,
+            "tent",
+            IrrigationChange(
+                operation=IrrigationChangeOperation.SETTINGS,
+                values={"pump_flow_rate_ml_per_sec": 0.0},
+            ),
+        )
+
+    assert growspace.irrigation_config is prior_config
+    assert growspace.irrigation_strategy is prior_strategy
+    coordinator.async_commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_change_accepts_volume_mode_prerequisites_in_the_same_change() -> None:
+    """The effective-state candidate includes config and strategy values together."""
+    growspace = Growspace(id="tent", name="Tent")
+    coordinator = _coordinator(growspace)
+
+    await async_apply_irrigation_change(
+        coordinator,
+        "tent",
+        IrrigationChange(
+            operation=IrrigationChangeOperation.OPTIONS,
+            values={
+                "shot_sizing_mode": "volume",
+                "pump_flow_rate_ml_per_sec": 12.0,
+                "substrate_media_type": "rockwool",
+                "substrate_liters_per_pot": 6.0,
+            },
+        ),
+    )
+
+    assert growspace.irrigation_strategy.shot_sizing_mode is ShotSizingMode.VOLUME
+    assert growspace.irrigation_config.pump_flow_rate_ml_per_sec == 12.0
+    assert growspace.irrigation_strategy.substrate_profile == SubstrateProfile(
+        media_type=SubstrateMediaType.ROCKWOOL,
+        liters_per_pot=6.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_change_validates_partial_pore_ec_band_against_effective_state() -> None:
+    """One supplied band edge is ordered against the retained opposite edge."""
+    growspace = Growspace(id="tent", name="Tent")
+    growspace.irrigation_strategy.pore_ec_target_min = 2.0
+    growspace.irrigation_strategy.pore_ec_target_max = 4.0
+    prior_strategy = growspace.irrigation_strategy
+    coordinator = _coordinator(growspace)
+
+    with pytest.raises(IrrigationChangeError, match=r"min \(5.0\).*max \(4.0\)"):
+        await async_apply_irrigation_change(
+            coordinator,
+            "tent",
+            IrrigationChange(
+                operation=IrrigationChangeOperation.STRATEGY,
+                values={"pore_ec_target_min": 5.0},
+            ),
+        )
+
+    assert growspace.irrigation_strategy is prior_strategy
+    coordinator.async_commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_change_restores_prior_state_when_persistence_fails() -> None:
+    """The candidate is never left live when the persistence effect rejects it."""
+    growspace = Growspace(id="tent", name="Tent")
+    prior_config = growspace.irrigation_config
+    prior_strategy = growspace.irrigation_strategy
+    coordinator = _coordinator(growspace)
+    coordinator.async_commit.side_effect = OSError("disk full")
+
+    with pytest.raises(OSError, match="disk full"):
+        await async_apply_irrigation_change(
+            coordinator,
+            "tent",
+            IrrigationChange(
+                operation=IrrigationChangeOperation.OPTIONS,
+                values={
+                    "irrigation_duration": 90,
+                    "target_vwc_percent": 61.0,
+                },
+            ),
+        )
+
+    assert growspace.irrigation_config is prior_config
+    assert growspace.irrigation_strategy is prior_strategy
+    assert growspace.irrigation_config.irrigation_duration is None
+    assert growspace.irrigation_strategy.target_vwc_percent == 55.0
+    coordinator.async_commit.assert_awaited_once()
+    coordinator.async_request_refresh.assert_not_awaited()


### PR DESCRIPTION
## Summary

- route irrigation settings actions, strategy actions, and the options flow through one strict atomic change seam
- define canonical config and strategy ownership, normalize compatible sparse inputs, and validate effective Volume Mode and Pore EC state before mutation
- persist, invalidate, and refresh exactly once while restoring prior in-memory state on persistence failure
- return immutable applied-change results and complete Home Assistant action metadata
- replace redundant facade forwarding coverage with deep seam tests while retaining thin transport-adapter tests

## Validation

- `./scripts/codex-worktree check backend fast` — 5,218 tests and 44 snapshots passed
- `./scripts/codex-worktree check backend full` — 5,218 tests, 44 snapshots, 99% total coverage
- commit hooks: Ruff, formatting, codespell, JSON, yamllint, Prettier, pytest, and mypy passed

Closes #710