### PR TITLE
design(vision): rewrite the LLM stage as an evidence explainer

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -668,7 +668,24 @@ A user-configured reminder that fires on a specific day of a plant's lifecycle s
 A point-in-time image captured from a growspace camera. Can be triggered manually by the grower via the camera snapshots dialog or automatically as part of a scheduled [[Vision Checkup]]. Saved to the public directory `www/growspace_manager/snapshots/{growspace_id}/` as a JPEG file named with a local timestamp prefix for display in the frontend.
 
 **Vision Checkup**
-An AI-powered diagnostic task performed on one or more [[Camera Snapshot]]s from a growspace, scheduled at three key times in the light cycle (early, mid, late) or triggered manually. The snapshots are processed with a 4x4 grid overlay and canopy green-pixel coverage analysis before being sent to the AI model. The analysis results (severity, detected issues, recommendations) are stored as a `VisionCheckupResult` in the growspace's vision history.
+An observation of one or more [[Camera Snapshot]]s from a growspace, scheduled at three key times in the light cycle (early, mid, late) or triggered manually. The snapshots are processed with a 4x4 grid overlay before analysis. A checkup produces a Visual Comparison Result and an [[Evidence Fusion Outcome]]; where an AI task is configured it also produces a [[Vision Explainer Report]], which narrates that evidence and never decides it. The legacy `VisionCheckupResult` history is frozen in place (ADR 0041) and its `severity` and `issues_detected` fields are not produced by the new pipeline.
+_Avoid_: Vision diagnosis, AI verdict, plant health check
+
+**Vision Explainer**
+The optional cloud LLM stage of a [[Vision Checkup]]. It receives the [[Evidence Fusion Outcome]], the visual evidence, the environmental evidence and the temporal trend, each labelled with its origin, and produces prose. It emits no verdict, no severity and no machine-readable symptom claim; severity is a fusion output and the explainer has no field to overrule it. A growspace with no AI task configured has no explainer and a complete report without one. See [ADR-0042](./docs/adr/0042-the-vision-explainer-explains-evidence-it-does-not-inspect.md).
+_Avoid_: Vision AI, diagnostician, the vision model
+
+**Visual Observation Pass**
+The first of the [[Vision Explainer]]'s two calls. It receives the photographs and the light window and nothing else — there is no parameter through which environmental evidence, a fusion state or a trend could reach it — and returns a description of what is visible. Optional, behind `ai_settings.vision_explainer_sees_image`; when it is off or it fails, the observation is derived from the Visual Comparison Result and recorded as `visual_comparison_only`.
+_Avoid_: Image analysis, visual diagnosis
+
+**Evidence Explanation Pass**
+The second of the [[Vision Explainer]]'s two calls. It receives the [[Visual Observation Pass]]'s text, the evidence and the trend, and **no image** — which is what makes its binding rule ("You have not seen an image") true rather than aspirational. It never returns the observation, so it cannot revise what was seen.
+_Avoid_: Interpretation call, the second prompt
+
+**Vision Explainer Report**
+The four fields a [[Vision Explainer]] produces for one capture — `observation`, `environmental_risk`, `hypothesis`, `recommendations` — stored in the `vision_explainer_report` table with the [[Evidence Fusion Outcome]] snapshotted alongside them. No severity, no symptom vocabulary. Empty values are legal: an empty hypothesis is the honest output when the evidence supports none.
+_Avoid_: Vision analysis, AI diagnosis, checkup result
 
 **Vision Evidence Store**
 The Home Assistant-owned SQLite database `growspace_vision.db` holding every artifact of a [[Vision Checkup]]: [[Vision Capture]]s, their image files, Visual Embeddings, Visual Comparison Results, Baseline Buckets and [[Vision Label]]s. Growspace Vision is stateless, so this is the only durable record that the analysis happened. Versioned by `PRAGMA user_version` and migrated by forward-only numbered steps — deliberately not the `try: ALTER TABLE / except` pattern of `strain_library.py`, which records no version. See [ADR-0041](./docs/adr/0041-home-assistant-owns-vision-evidence-in-a-dedicated-store.md).

--- a/custom_components/growspace_manager/data_access/vision_evidence_schema.py
+++ b/custom_components/growspace_manager/data_access/vision_evidence_schema.py
@@ -233,6 +233,60 @@ CREATE TABLE IF NOT EXISTS vision_comparison_result (
 CREATE INDEX IF NOT EXISTS idx_vision_result_capture
     ON vision_comparison_result (capture_id, evaluated_at);
 
+-- The Vision Explainer's narrative for one capture (ADR 0042).  Separate from the
+-- capture because the explainer is optional: the evidence rows are a complete
+-- report without it, and a growspace with no AI task configured simply has no rows
+-- here.  There is no severity column — severity is an Evidence Fusion output
+-- (ADR 0040) and the explainer must not be able to overrule it — and no symptom
+-- vocabulary, because V1 has no validated classifier to stand behind one (hub#68).
+--
+-- The fusion outcome is snapshotted rather than joined.  A narrative written
+-- against `environmental_risk` is uninterpretable once the fusion transition table
+-- moves underneath it, which is invisible to model version; the same reasoning that
+-- put `scoring_policy_version` on a comparison result.  Text is free.
+--
+-- Not unique per capture: a manual re-run against a different AI task entity is a
+-- second report, not a correction of the first.
+CREATE TABLE IF NOT EXISTS vision_explainer_report (
+    report_id          TEXT PRIMARY KEY,
+    capture_id         TEXT NOT NULL
+                       REFERENCES vision_capture (capture_id) ON DELETE CASCADE,
+    created_at         TEXT NOT NULL,
+    ai_task_entity_id  TEXT NOT NULL,
+    -- `visual_comparison_only` records that no photograph was read, whether the
+    -- Visual Observation Pass was switched off or failed.  A report can never
+    -- imply an inspection that did not happen.
+    observation_source TEXT NOT NULL
+                       CHECK (observation_source IN ('image_pass',
+                                                     'visual_comparison_only')),
+    scoring_policy_version INTEGER NOT NULL,
+    observation        TEXT NOT NULL,
+    environmental_risk TEXT NOT NULL,
+    hypothesis         TEXT NOT NULL,
+    recommendations    TEXT NOT NULL,
+    fusion_state       TEXT
+                       CHECK (fusion_state IS NULL
+                              OR fusion_state IN (
+                                  'no_detected_change',
+                                  'environmental_risk',
+                                  'visual_anomaly',
+                                  'concurrent_environmental_risk_and_visual_anomaly',
+                                  'critical_scene_issue')),
+    fusion_confidence  TEXT
+                       CHECK (fusion_confidence IS NULL
+                              OR fusion_confidence IN ('confirmed', 'monitor')),
+    fusion_coverage    TEXT
+                       CHECK (fusion_coverage IS NULL
+                              OR fusion_coverage IN ('complete', 'partial')),
+    fusion_unavailable_reasons TEXT,
+    -- An available fusion outcome carries exactly one state with both qualifiers;
+    -- an unavailable one carries none of the three.
+    CHECK ((fusion_state IS NULL) = (fusion_confidence IS NULL)),
+    CHECK ((fusion_state IS NULL) = (fusion_coverage IS NULL))
+);
+CREATE INDEX IF NOT EXISTS idx_vision_explainer_report_capture
+    ON vision_explainer_report (capture_id, created_at);
+
 -- Grower feedback.  Two kinds, because V1 emits a scene claim and never a health
 -- claim (hub#68): a `comparison_correction` corrects a verdict the model actually
 -- made, an `observation` asserts something the model never claimed and therefore

--- a/custom_components/growspace_manager/domain/evidence_fusion.py
+++ b/custom_components/growspace_manager/domain/evidence_fusion.py
@@ -1,0 +1,68 @@
+"""Evidence Fusion vocabulary.
+
+ADR 0040 names this module as the home of Evidence Fusion: its enums, its frozen
+input and output value objects, and one total ``fuse_evidence(...)``.  Only the
+vocabulary is here.  The function and its value objects stay deferred until the
+Visual Comparison Result producer exists, exactly as ADR 0040 decided; the
+Vision Explainer (ADR 0042) needs the words now, and defining them twice would
+guarantee they drift.
+
+Fusion reports observations, never plant health.  Nothing in this vocabulary
+asserts that a plant is healthy, unhealthy, stressed or visually symptomatic.
+
+Pure module: no hass, no I/O.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnvironmentalVerdict(StrEnum):
+    """The normalized reading of the stress and mold Evaluation Snapshots.
+
+    ``WITHIN_EVALUATED_RANGE`` requires both evaluations to exist, be fresh and be
+    inactive.  A zero probability produced from zero observations is
+    ``UNAVAILABLE``, never evidence of normal conditions.
+    """
+
+    RISK = "risk"
+    WITHIN_EVALUATED_RANGE = "within_evaluated_range"
+    UNAVAILABLE = "unavailable"
+
+
+class EvidenceFusionState(StrEnum):
+    """The five Evidence Fusion States of ADR 0040.
+
+    ``NO_DETECTED_CHANGE`` means only that complete available evidence found
+    neither environmental risk nor material departure from recent scene history.
+    ``CONCURRENT_...`` asserts co-occurrence, not correlation or causation.
+    ``CRITICAL_SCENE_ISSUE`` describes fusion precedence and persistence, not
+    plant danger.
+    """
+
+    NO_DETECTED_CHANGE = "no_detected_change"
+    ENVIRONMENTAL_RISK = "environmental_risk"
+    VISUAL_ANOMALY = "visual_anomaly"
+    CONCURRENT_ENVIRONMENTAL_RISK_AND_VISUAL_ANOMALY = (
+        "concurrent_environmental_risk_and_visual_anomaly"
+    )
+    CRITICAL_SCENE_ISSUE = "critical_scene_issue"
+
+
+class ConfidenceQualifier(StrEnum):
+    """How firmly an available outcome is held.
+
+    Uncertainty is a qualifier, not a sixth state.  ``MONITOR`` can never reach the
+    concurrent or critical state.
+    """
+
+    CONFIRMED = "confirmed"
+    MONITOR = "monitor"
+
+
+class EvidenceCoverage(StrEnum):
+    """Whether both evidence channels contributed to an available outcome."""
+
+    COMPLETE = "complete"
+    PARTIAL = "partial"

--- a/custom_components/growspace_manager/domain/vision_explainer_prompt.py
+++ b/custom_components/growspace_manager/domain/vision_explainer_prompt.py
@@ -1,0 +1,470 @@
+"""The Vision Explainer — the optional cloud stage that explains evidence.
+
+The stage this module replaces interpolated sensor readings, Bayesian stress and
+mold probabilities *with their reasons*, and a moisture-band interpretation
+directly above "Analyze the attached camera image(s)".  The model was told the
+plant was probably stressed and then asked what it saw, and duly reported petiole
+reddening and leaf curl on a visibly healthy canopy.  The MOISTURE INTERPRETATION
+RULE was a prose patch for exactly that failure on exactly one sensor.
+
+The fix is structural.  The explainer runs as two calls that cannot see each
+other's inputs:
+
+* the **Visual Observation Pass** receives the photograph and the timing, and
+  nothing else.  It has no parameter through which environmental evidence could
+  reach it, so contamination requires a signature change rather than a lapse of
+  instruction-following;
+* the **Evidence Explanation Pass** receives the observation text, the Evidence
+  Fusion Outcome, both evidence channels and the trend — and no photograph.  Its
+  binding rule ("You have not seen an image") is therefore true rather than
+  aspirational.
+
+The observation is carried into the report verbatim from the first pass; the
+second pass never returns it and so cannot revise it.
+
+What the explainer may not do: emit a severity (severity is an Evidence Fusion
+output — ADR 0040), emit a machine-readable symptom vocabulary (hub#68 — there is
+no validated classifier behind such a claim), or revise the fusion state.
+
+Pure module: no hass, no I/O, no clocks.  See ADR 0042.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+import voluptuous as vol
+
+from custom_components.growspace_manager.domain.evidence_fusion import (
+    ConfidenceQualifier,
+    EnvironmentalVerdict,
+    EvidenceCoverage,
+    EvidenceFusionState,
+)
+from custom_components.growspace_manager.models.vision_evidence import (
+    BaselineState,
+    ComparisonOutcome,
+    ComparisonVerdict,
+    LightWindow,
+    ObservationSource,
+)
+
+# Every word that names an environmental measurement, an evaluation of one, or a
+# piece of environmental equipment.  The Visual Observation Pass prompt must
+# contain none of them: see ``tests/domain/test_vision_explainer_prompt.py``,
+# which scans the built prompt against this list.
+#
+# Matching is by whole word, not substring — "ec" and "ph" are real measurements
+# and also live inside "each" and "photograph".  Digits are deliberately *not*
+# forbidden: the grid sector labels and the photograph count are numerals that
+# carry no environmental meaning.
+ENVIRONMENTAL_VOCABULARY: tuple[str, ...] = (
+    "bayesian",
+    "celsius",
+    "co2",
+    "deficiency",
+    "dehumidifier",
+    "dli",
+    "dryback",
+    "ec",
+    "evaluation",
+    "exhaust",
+    "fahrenheit",
+    "fan",
+    "feed",
+    "humidifier",
+    "humidity",
+    "irrigation",
+    "kpa",
+    "lux",
+    "measurement",
+    "moisture",
+    "mold",
+    "mould",
+    "nutrient",
+    "overwatering",
+    "ph",
+    "ppfd",
+    "ppm",
+    "probability",
+    "reading",
+    "readings",
+    "reservoir",
+    "runoff",
+    "sensor",
+    "sensors",
+    "stress",
+    "substrate",
+    "temperature",
+    "threshold",
+    "transpiration",
+    "underwatering",
+    "vpd",
+    "watering",
+)
+
+# Neutral descriptions of when a checkup was taken.  The strings the previous
+# prompt used were themselves interpretive — "peak transpiration period" and
+# "end-of-day stress check" told the model what to expect to see before it had
+# looked.  Scheduling metadata states the clock position and nothing more.
+_TIMING_DESCRIPTIONS: dict[LightWindow, str] = {
+    LightWindow.EARLY: "1 hour after the lights turned on",
+    LightWindow.MID: "6 hours into the light cycle",
+    LightWindow.LATE: "1 hour before the lights turn off",
+    LightWindow.MANUAL: "on request, outside the scheduled checkup times",
+}
+
+_GRID_REFERENCE = (
+    "GRID REFERENCE: each photograph carries a 4x4 grid overlay, labelled A1-A4 "
+    "across the top row through D1-D4 across the bottom row. When you name "
+    "something, say where it is by naming the sector or sectors it appears in.\n\n"
+)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ObservationPassInput:
+    """Everything the Visual Observation Pass is allowed to know.
+
+    There is deliberately no field here through which environmental evidence, a
+    fusion state, a trend or a previous narrative could arrive.  That absence is
+    the invariant; the prompt's wording is only its restatement.
+    """
+
+    light_window: LightWindow
+    photograph_count: int
+    grid_overlay: bool = True
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class EnvironmentalEvidence:
+    """The normalized environmental verdict and the reasons behind it.
+
+    Reasons come from the stress and mold Evaluation Snapshots, never from raw
+    sensor values (ADR 0040).
+    """
+
+    verdict: EnvironmentalVerdict
+    stress_reasons: tuple[str, ...] = ()
+    mold_reasons: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class VisualEvidence:
+    """The Visual Comparison Result, as the explainer sees it.
+
+    A verdict here describes departure from this camera's own recent history. It
+    is not a health measurement and never becomes one.
+    """
+
+    outcome: ComparisonOutcome
+    verdict: ComparisonVerdict | None = None
+    anomaly_score: float | None = None
+    comparison_confidence: float | None = None
+    baseline_state: BaselineState | None = None
+    samples_collected: int | None = None
+    samples_required: int | None = None
+    unavailable_reasons: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TrendEntry:
+    """One earlier scored comparison, for the temporal picture.
+
+    Measurements only.  Previous explainer narratives are never fed back in: a
+    hallucinated symptom would otherwise become tomorrow's established history.
+    """
+
+    evaluated_at: str
+    verdict: ComparisonVerdict | None = None
+    anomaly_score: float | None = None
+    fusion_state: EvidenceFusionState | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class FusionSummary:
+    """The Evidence Fusion Outcome the explanation must explain, not revise."""
+
+    state: EvidenceFusionState | None = None
+    confidence: ConfidenceQualifier | None = None
+    coverage: EvidenceCoverage | None = None
+    unavailable_reasons: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ExplanationPassInput:
+    """Everything the Evidence Explanation Pass receives.
+
+    No image and no image attachment: the pass is text-only by construction.
+    """
+
+    observation: str
+    observation_source: ObservationSource
+    fusion: FusionSummary
+    environment: EnvironmentalEvidence
+    visual: VisualEvidence
+    trend: tuple[TrendEntry, ...] = ()
+
+
+# The structured output of each call, and of the stored report.
+#
+# The explanation pass does not return ``observation``: the report's observation is
+# the observation pass's own words, carried across unchanged, so the second call
+# has no opportunity to revise what was seen.  There is no ``severity`` field and
+# no symptom keyword list in any of the three.
+VISION_OBSERVATION_SCHEMA = vol.Schema({vol.Required("observation"): str})
+
+VISION_EXPLANATION_SCHEMA = vol.Schema(
+    {
+        vol.Required("environmental_risk"): str,
+        vol.Required("hypothesis"): str,
+        vol.Required("recommendations"): [str],
+    }
+)
+
+VISION_EXPLAINER_SCHEMA = vol.Schema(
+    {
+        vol.Required("observation"): str,
+        vol.Required("environmental_risk"): str,
+        vol.Required("hypothesis"): str,
+        vol.Required("recommendations"): [str],
+    }
+)
+
+
+def build_observation_prompt(inputs: ObservationPassInput) -> str:
+    """Build the Visual Observation Pass prompt.
+
+    The returned text is a function of the photograph count, the light window and
+    whether the image carries a grid overlay. Nothing else can reach it.
+    """
+    photographs = "photograph" if inputs.photograph_count == 1 else "photographs"
+    timing = _TIMING_DESCRIPTIONS.get(inputs.light_window, "at an unrecorded time")
+    grid = _GRID_REFERENCE if inputs.grid_overlay else ""
+
+    return (
+        "You are describing what is visible in one or more photographs of a "
+        "cannabis growspace canopy.\n\n"
+        "You are given the attached photographs and nothing else. You have no "
+        "other information about this growspace, and you must not guess at any.\n\n"
+        f"TIMING: {inputs.photograph_count} {photographs}, taken {timing}.\n\n"
+        f"{grid}"
+        "Describe what you can see:\n"
+        "1. Leaf posture: drooping, curling up or down, cupping, folding, wilting\n"
+        "2. Leaf colour: yellowing, browning, purpling, bleaching, mottling, "
+        "spotting, dead tissue\n"
+        "3. Surfaces: webbing, powder, film, insects, holes, chewed edges, trails\n"
+        "4. Canopy: height variation, density, gaps, uniformity, colour consistency\n"
+        "5. Anything else visible, including the pots, the medium surface, and any "
+        "equipment in frame\n\n"
+        "Describe only what is visible in the photographs. Do not name a cause or "
+        "a diagnosis. Do not say whether the plants are healthy or unhealthy. Do "
+        "not recommend anything.\n\n"
+        "If something is unclear, or a photograph is too dark, blurred or "
+        "obstructed to judge, say so rather than guessing. Describing little is a "
+        "correct answer when little is visible.\n\n"
+        "Return your description as structured data:\n"
+        "- observation: one paragraph describing what is visible"
+        + (", naming grid sectors" if inputs.grid_overlay else "")
+        + ".\n"
+    )
+
+
+def build_explanation_prompt(inputs: ExplanationPassInput) -> str:
+    """Build the Evidence Explanation Pass prompt.
+
+    Every block is labelled with where it came from, because the explanation's
+    whole job is to keep those origins apart.
+    """
+    source = (
+        "read from the attached photographs by a separate pass"
+        if inputs.observation_source is ObservationSource.IMAGE_PASS
+        else "derived from the scene-change comparison; no photograph was read"
+    )
+
+    return (
+        "You are writing the explanation section of a growspace report.\n\n"
+        "You have not seen any photograph. Every statement in this report about "
+        "what the plants look like must come from the OBSERVATION block below.\n\n"
+        f"EVIDENCE FUSION OUTCOME (decided by Growspace Manager, not by you):\n"
+        f"{_render_fusion(inputs.fusion)}\n\n"
+        f"OBSERVATION ({source}):\n{inputs.observation.strip() or '  (none)'}\n\n"
+        "VISUAL EVIDENCE (how far this camera's view has moved from its own recent "
+        f"history):\n{_render_visual(inputs.visual)}\n\n"
+        "ENVIRONMENTAL EVIDENCE (this growspace's Bayesian evaluation of its own "
+        f"sensors):\n{_render_environment(inputs.environment)}\n\n"
+        f"TREND (earlier scored comparisons, newest first):\n"
+        f"{_render_trend(inputs.trend)}\n\n"
+        "RULES\n"
+        "1. Environmental measurements and risk evaluations describe the "
+        "growspace, not the plant's appearance. You have not seen an image. Every "
+        "statement about what the plant looks like must come from the OBSERVATION "
+        "block above, quoted or paraphrased from it and nothing else. Never write "
+        "that an environmental measurement is visible, apparent, or showing on the "
+        "plant.\n"
+        "2. The visual evidence reports how far this scene has moved from its own "
+        "recent history. It is not a measure of plant health. A material scene "
+        "change is as likely to be a camera move, an occlusion, a harvest or new "
+        "growth as anything wrong.\n"
+        "3. The fusion outcome is given. Explain it; do not revise it, do not "
+        "contradict it, and do not assign a severity of your own.\n"
+        "4. A hypothesis is a candidate explanation, not a finding. Write it "
+        "conditionally, and say what would confirm or rule it out.\n"
+        "5. Empty is a valid answer. Return an empty hypothesis when the evidence "
+        "supports none, and an empty recommendation list when no action is "
+        "warranted.\n\n"
+        "Return structured data:\n"
+        "- environmental_risk: what the environmental evidence says about the "
+        "growspace's conditions, in plain prose. Say so plainly when it is "
+        "unavailable.\n"
+        "- hypothesis: a candidate explanation that connects the evidence above, "
+        "or an empty string.\n"
+        "- recommendations: specific actions worth taking, or an empty list.\n"
+    )
+
+
+def observation_from_visual_comparison(visual: VisualEvidence) -> str:
+    """Return the observation text used when no photograph was read.
+
+    Used both when the Visual Observation Pass is switched off and when it fails.
+    It states what the scene-change comparison found and, explicitly, that nothing
+    looked at the plants — so a report can never imply an inspection that did not
+    happen.
+    """
+    preamble = "No photograph was read for this checkup. "
+
+    scored_descriptions: dict[ComparisonVerdict, str] = {
+        ComparisonVerdict.NORMAL: (
+            "this camera's view is consistent with its own recent history"
+        ),
+        ComparisonVerdict.UNCERTAIN: (
+            "this camera's view sits in the uncertain range between its recent "
+            "history and a material change"
+        ),
+        ComparisonVerdict.MATERIAL_SCENE_CHANGE: (
+            "this camera's view has departed materially from its own recent history"
+        ),
+    }
+
+    if visual.outcome is ComparisonOutcome.SCORED:
+        described = (
+            scored_descriptions[visual.verdict]
+            if visual.verdict is not None
+            else "this camera's view was scored without a verdict"
+        )
+        return (
+            f"{preamble}The scene-change comparison found that {described}. "
+            "That is a statement about the scene, not about the plants: no "
+            "assessment of how the plants look was made."
+        )
+
+    if visual.outcome is ComparisonOutcome.MONITORING:
+        collected = visual.samples_collected
+        required = visual.samples_required
+        progress = (
+            f" ({collected} of {required} captures collected)"
+            if collected is not None and required is not None
+            else ""
+        )
+        return (
+            f"{preamble}This camera's baseline is still being collected"
+            f"{progress}, so no scene-change comparison was made either. Nothing "
+            "was assessed about how the plants look."
+        )
+
+    reasons = ", ".join(visual.unavailable_reasons) or "no reason recorded"
+    return (
+        f"{preamble}No scene-change comparison was available either ({reasons}). "
+        "Nothing was assessed about how the plants look."
+    )
+
+
+def _render_fusion(fusion: FusionSummary) -> str:
+    """Render the fusion outcome block."""
+    if fusion.state is None:
+        reasons = ", ".join(fusion.unavailable_reasons) or "no reason recorded"
+        return f"  Unavailable: {reasons}"
+    lines = [f"  State: {fusion.state.value}"]
+    if fusion.confidence is not None:
+        lines.append(f"  Confidence: {fusion.confidence.value}")
+    if fusion.coverage is not None:
+        lines.append(f"  Evidence coverage: {fusion.coverage.value}")
+    return "\n".join(lines)
+
+
+def _render_visual(visual: VisualEvidence) -> str:
+    """Render the visual evidence block."""
+    if visual.outcome is ComparisonOutcome.UNAVAILABLE:
+        reasons = ", ".join(visual.unavailable_reasons) or "no reason recorded"
+        return f"  Unavailable: {reasons}"
+
+    if visual.outcome is ComparisonOutcome.MONITORING:
+        collected = visual.samples_collected
+        required = visual.samples_required
+        progress = (
+            f" — {collected} of {required} captures collected"
+            if collected is not None and required is not None
+            else ""
+        )
+        return (
+            f"  Baseline not yet valid{progress}. No comparison was made; this is "
+            "not a finding of no change."
+        )
+
+    lines = [f"  Verdict: {visual.verdict.value if visual.verdict else 'none'}"]
+    if visual.anomaly_score is not None:
+        lines.append(
+            f"  Anomaly score: {visual.anomaly_score:.2f} "
+            "(rank against this camera's own recent history, 0 to 1)"
+        )
+    if visual.comparison_confidence is not None:
+        lines.append(f"  Comparison confidence: {visual.comparison_confidence:.2f}")
+    if visual.baseline_state is not None:
+        lines.append(f"  Baseline: {visual.baseline_state.value}")
+    return "\n".join(lines)
+
+
+def _render_environment(environment: EnvironmentalEvidence) -> str:
+    """Render the environmental evidence block."""
+    if environment.verdict is EnvironmentalVerdict.UNAVAILABLE:
+        return (
+            "  Unavailable — no fresh evaluation with sufficient observations. "
+            "This is not evidence of normal conditions."
+        )
+    if environment.verdict is EnvironmentalVerdict.WITHIN_EVALUATED_RANGE:
+        return "  Within evaluated range — no active stress or mold evaluation."
+
+    lines = ["  Risk — at least one active evaluation."]
+    lines.extend(f"    Plant stress: {reason}" for reason in environment.stress_reasons)
+    lines.extend(f"    Mold risk: {reason}" for reason in environment.mold_reasons)
+    return "\n".join(lines)
+
+
+def _render_trend(trend: tuple[TrendEntry, ...]) -> str:
+    """Render the trend block."""
+    if not trend:
+        return "  No earlier comparisons recorded."
+    lines = []
+    for entry in trend:
+        parts = [entry.evaluated_at]
+        parts.append(entry.verdict.value if entry.verdict else "not scored")
+        if entry.anomaly_score is not None:
+            parts.append(f"score {entry.anomaly_score:.2f}")
+        if entry.fusion_state is not None:
+            parts.append(entry.fusion_state.value)
+        lines.append(f"  {' — '.join(parts)}")
+    return "\n".join(lines)
+
+
+def environmental_terms_in(text: str) -> tuple[str, ...]:
+    """Return every environmental term appearing as a whole word in ``text``.
+
+    Exposed so the contamination test and any future guard share one definition of
+    what counts as environmental vocabulary.
+    """
+    lowered = text.lower()
+    return tuple(
+        term
+        for term in ENVIRONMENTAL_VOCABULARY
+        if re.search(rf"\b{re.escape(term)}\b", lowered)
+    )

--- a/custom_components/growspace_manager/models/__init__.py
+++ b/custom_components/growspace_manager/models/__init__.py
@@ -88,9 +88,11 @@ from .vision_evidence import (
     LabelKind,
     LightState,
     LightWindow,
+    ObservationSource,
     VisionCapture,
     VisionCaptureFile,
     VisionEmbedding,
+    VisionExplainerReport,
     VisionLabel,
     VisualComparisonResult,
 )
@@ -164,6 +166,7 @@ __all__ = [
     "NutrientPresetDict",
     "NutrientPresetItem",
     "NutrientStock",
+    "ObservationSource",
     "PhenotypeScore",
     "Plant",
     # plant
@@ -187,6 +190,7 @@ __all__ = [
     "VisionCheckupConfig",
     "VisionCheckupResult",
     "VisionEmbedding",
+    "VisionExplainerReport",
     "VisionLabel",
     "VisualComparisonResult",
     "WaterUsageData",

--- a/custom_components/growspace_manager/models/vision_evidence.py
+++ b/custom_components/growspace_manager/models/vision_evidence.py
@@ -131,6 +131,18 @@ class ComparisonVerdict(StrEnum):
     MATERIAL_SCENE_CHANGE = "material_scene_change"
 
 
+class ObservationSource(StrEnum):
+    """Where a Vision Explainer Report's observation text came from.
+
+    ``VISUAL_COMPARISON_ONLY`` is the honest record that no photograph was read —
+    because the Visual Observation Pass is switched off, or because it failed.  A
+    report can then never imply an inspection that did not happen.
+    """
+
+    IMAGE_PASS = "image_pass"
+    VISUAL_COMPARISON_ONLY = "visual_comparison_only"
+
+
 class LabelKind(StrEnum):
     """Which kind of feedback a label carries.
 
@@ -332,3 +344,34 @@ class VisionLabel:
     excluded: bool = False
     exclusion_reason: str | None = None
     superseded_by: str | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class VisionExplainerReport:
+    """The Vision Explainer's four-field narrative for one capture.
+
+    ``observation`` is the Visual Observation Pass's own words, carried across
+    unchanged; the Evidence Explanation Pass never returns it and so cannot revise
+    it.  There is no severity — severity is an Evidence Fusion output (ADR 0040) —
+    and no symptom vocabulary, because V1 has no validated classifier to stand
+    behind one (hub#68).
+
+    The fusion outcome is snapshotted rather than referenced.  A narrative written
+    against ``environmental_risk`` becomes uninterpretable once the fusion
+    transition table moves underneath it, and text costs nothing to keep.
+    """
+
+    report_id: str
+    capture_id: str
+    created_at: str
+    ai_task_entity_id: str
+    observation_source: ObservationSource
+    scoring_policy_version: int
+    observation: str
+    environmental_risk: str
+    hypothesis: str
+    recommendations: tuple[str, ...] = ()
+    fusion_state: str | None = None
+    fusion_confidence: str | None = None
+    fusion_coverage: str | None = None
+    fusion_unavailable_reasons: tuple[str, ...] = ()

--- a/custom_components/growspace_manager/vision_checkup_scheduler.py
+++ b/custom_components/growspace_manager/vision_checkup_scheduler.py
@@ -145,9 +145,22 @@ class VisionCheckupScheduler:
         check_type: str,
         context_data: dict[str, Any],
         previous_results: list[VisionCheckupResult],
-        canopy_coverage: float | None = None,
     ) -> str:
-        """Build the vision analysis prompt with full growspace context."""
+        """Build the vision analysis prompt with full growspace context.
+
+        Interim shape. The evidence-explainer rewrite (ADR 0042) lives in
+        ``domain/vision_explainer_prompt.py`` and is wired in by hub#73, once the
+        Evidence Fusion Outcome and Visual Comparison Result seams exist. What
+        changes here now is only the canopy-coverage claim, which had no such
+        dependency: the HSV green-pixel statistic varies 31.5% inside a fixed
+        camera's healthy bucket (hub#68), so stating it as a measured fact
+        alongside the image invited the model to reason from it.
+
+        The MOISTURE INTERPRETATION RULE below deliberately stays until that
+        rewrite lands. Weak as it is, it is the only counterweight currently
+        standing between the sensor block and the image; removing it first would
+        make contamination worse, not better.
+        """
         from .services.ai_assistant import GrowAssistant  # noqa: PLC0415
 
         assistant = GrowAssistant(
@@ -174,18 +187,10 @@ class VisionCheckupScheduler:
         }
         timing_desc = check_type_descriptions.get(check_type, check_type)
 
-        canopy_line = (
-            f"CANOPY COVERAGE: {canopy_coverage}% of the image area is green plant matter "
-            "(calculated via HSV color filtering before this message was sent).\n\n"
-            if canopy_coverage is not None
-            else ""
-        )
-
         return (
             "You are an expert cannabis plant health analyst performing a visual inspection.\n\n"
             f"TIMING: This is a {check_type} checkup ({timing_desc}).\n\n"
             f"{env_context}\n\n"
-            f"{canopy_line}"
             f"{trend_context}"
             "GRID REFERENCE: The attached image has a 4x4 grid overlay with sectors labeled "
             "A1–A4 (top row) through D1–D4 (bottom row). When you identify any issue, you MUST "
@@ -566,7 +571,7 @@ class VisionCheckupScheduler:
 
         # Process camera images: apply green-coverage analysis and grid overlay.
         # Falls back to direct camera URIs if processing fails for all cameras.
-        attachments, avg_coverage, temp_paths = await self._process_camera_images(
+        attachments, _coverage, temp_paths = await self._process_camera_images(
             growspace_id, camera_entities
         )
         if not attachments:
@@ -578,14 +583,12 @@ class VisionCheckupScheduler:
                 {"media_content_id": f"media-source://camera/{cam}"}
                 for cam in camera_entities
             ]
-            avg_coverage = None
 
         prompt = self._build_vision_prompt(
             growspace_id,
             check_type,
             context_data,
             growspace.vision_checkup_history,
-            avg_coverage,
         )
 
         try:

--- a/docs/adr/0042-the-vision-explainer-explains-evidence-it-does-not-inspect.md
+++ b/docs/adr/0042-the-vision-explainer-explains-evidence-it-does-not-inspect.md
@@ -1,0 +1,210 @@
+# The Vision Explainer explains evidence; it does not inspect
+
+**Status:** Accepted
+
+Decided on 2026-08-31 in
+[hub#71](https://github.com/Venosta-web/growspace_manager_workspace/issues/71), after
+the strict Vision boundary
+([hub#67](https://github.com/Venosta-web/growspace_manager_workspace/issues/67)), the
+measured symptom limits
+([hub#68](https://github.com/Venosta-web/growspace_manager_workspace/issues/68)), the
+Evidence Fusion state machine ([ADR 0040](./0040-evidence-fusion-reports-observations-not-plant-health.md)),
+and the evidence store ([ADR 0041](./0041-home-assistant-owns-vision-evidence-in-a-dedicated-store.md)).
+
+The cloud LLM stage is demoted from diagnostician to explainer. It receives the
+Evidence Fusion Outcome, the visual evidence, the environmental evidence and the
+temporal trend, each labelled with its origin, and it produces prose. It produces no
+verdict, no severity and no machine-readable symptom claim.
+
+## The failure being fixed
+
+`VisionCheckupScheduler._build_vision_prompt` interpolated the full environment block
+— sensor readings, Bayesian stress and mold probabilities _with their reasons_, and
+the moisture-band interpretation — directly above "Analyze the attached camera
+image(s)". The model was told the plant was probably stressed and then asked what it
+saw, and duly reported petiole reddening and leaf curl on a visibly healthy canopy.
+
+The existing MOISTURE INTERPRETATION RULE is a prose patch for exactly that failure
+mode on exactly one sensor. More prose does not fix it: **a rule the model may ignore
+is not an invariant.**
+
+## Two passes that cannot see each other's inputs
+
+The explainer is two calls, not one prompt:
+
+- the **Visual Observation Pass** receives the photographs and the light window. It
+  has no parameter through which environmental evidence, a fusion state, a trend or a
+  previous narrative could arrive;
+- the **Evidence Explanation Pass** receives the observation text, the fusion outcome,
+  both evidence channels and the trend — and no image.
+
+Contamination is therefore impossible by construction rather than by instruction, and
+the binding rule's second sentence ("You have not seen an image") is _true_ rather than
+aspirational. The rule reads in full:
+
+> Environmental measurements and risk evaluations describe the growspace, not the
+> plant's appearance. You have not seen an image. Every statement about what the plant
+> looks like must come from the OBSERVATION block above, quoted or paraphrased from it
+> and nothing else. Never write that an environmental measurement is visible,
+> apparent, or showing on the plant.
+
+The split pays off three more times. The observation is carried into the report
+verbatim from the first pass and the second pass never returns it, so the explanation
+cannot revise what was seen. Removing the image from V1 later is a deletion of one
+call rather than an edit to prose. And the contamination test becomes a deterministic
+assertion with no model in the loop.
+
+A single call with an output-side validator was rejected: a scan for leaked
+measurement vocabulary is a guard with false negatives, defeated by paraphrase, and it
+would have been the only thing standing between the two evidence channels.
+
+## The timing labels were themselves contamination
+
+The previous prompt described the mid checkup as the "peak transpiration period" and
+the late one as an "end-of-day stress check". That is framing, not scheduling: it told
+the model what to expect before it had looked. The observation pass states the clock
+position and nothing more.
+
+## Inputs and their origins
+
+The explanation pass renders five labelled blocks: the fusion outcome (`decided by
+Growspace Manager, not by you`), the observation and where it came from, the visual
+evidence (`how far this camera's view has moved from its own recent history`), the
+environmental evidence (`this growspace's Bayesian evaluation of its own sensors`),
+and the trend.
+
+**The trend is measurements only** — earlier scored comparisons and their fusion
+states. Previous explainer narratives are never fed back in: a hallucinated symptom
+would otherwise become tomorrow's established history.
+
+Environmental evidence arrives as the normalized verdict and the Evaluation Snapshots'
+reasons, never raw sensor values, per ADR 0040. Environmental observations remain
+structurally forbidden from the Growspace Vision request.
+
+## Output schema
+
+Three schemas, in `domain/vision_explainer_prompt.py`:
+
+| schema                      | fields                                                |
+| --------------------------- | ----------------------------------------------------- |
+| `VISION_OBSERVATION_SCHEMA` | `observation`                                         |
+| `VISION_EXPLANATION_SCHEMA` | `environmental_risk`, `hypothesis`, `recommendations` |
+| `VISION_EXPLAINER_SCHEMA`   | all four — the stored report                          |
+
+`severity` is gone from all three. Severity is an Evidence Fusion output and the
+explainer must not be able to overrule it; the cleanest enforcement is that there is
+no field to write it into. `issues_detected` is gone too: a symptom keyword list is a
+machine-readable health claim, and hub#68 settled that V1 has no validated classifier
+to stand behind one. The explainer may still _describe_ what it sees in prose — that
+is the one thing a VLM can contribute that the local channel cannot — but a
+description is not a taxonomy, and only a taxonomy gets consumed by downstream logic.
+
+Empty values are legal and meaningful. An empty `hypothesis` is the honest output when
+the evidence supports none.
+
+**Contradiction is not suppressed.** Nothing stops the explanation from writing
+something the fusion state does not support. The prompt instructs that the state is
+given and must be explained rather than revised, and the presentation carries the rest:
+the severity badge and the state come from fusion, the narrative renders as attributed
+commentary subordinate to them. A contradiction detector was rejected because we have
+no way to validate one.
+
+## Degradation
+
+With no AI task configured there is no report, no error and no empty state. The
+evidence rendering _is_ the report: the fusion state, the visual verdict with its
+confidence, and the Bayesian reasons are complete without any LLM, and all of them
+already read as human language. An absent explainer is a configuration, not a
+degradation.
+
+Whether the observation pass runs at all is `ai_settings.vision_explainer_sees_image`,
+default `true`. When it is off — or when it fails — the observation is derived from the
+Visual Comparison Result, recorded as `observation_source = 'visual_comparison_only'`,
+and it says outright that no photograph was read and that nothing was assessed about
+how the plants look. A report can never imply an inspection that did not happen. A
+failure of the _explanation_ pass stores nothing: a report is the four fields together
+or it is not a report.
+
+## Storage
+
+A tenth table, `vision_explainer_report`, in the evidence store of ADR 0041, keyed by
+`capture_id` with the same cascade and durability as every other evidence row. The
+frozen `vision_checkup_history` keeps its existing rows and stops receiving new ones;
+it is not migrated, exactly as ADR 0041 decided. `VISION_EVIDENCE_SCHEMA_VERSION`
+stays at 1 because the store implementation is deferred and no database file has ever
+been created.
+
+The fusion outcome is **snapshotted** into the report rather than joined from the
+comparison result. A narrative written against `environmental_risk` is uninterpretable
+once the fusion transition table moves underneath it — the same reasoning that put
+`scoring_policy_version` on a comparison result, and the same conclusion: the
+reconstruction is expensive and the text is free.
+
+## Validation
+
+`tests/domain/test_vision_explainer_prompt.py` guards the invariant in three layers:
+
+1. **The sweep** — hold the photograph and timing fixed, move every environmental
+   input across its range (verdict × stress reasons × mold reasons × fusion state ×
+   visual outcome), and assert the observation prompt is byte-identical every time.
+   This is hub#71's literal acceptance criterion.
+2. **The vocabulary scan** — assert no environmental term reaches that prompt by any
+   route. Matching is by whole word, because `ec` and `ph` are real measurements that
+   also live inside `each` and `photograph`. Digits are deliberately not forbidden:
+   the grid sector labels and the photograph count are numerals with no environmental
+   meaning.
+3. **The signature** — assert the pass has no parameter through which environmental
+   evidence could arrive. Layers 1 and 2 prove the builder ignores what it is handed;
+   this proves it is handed none, so reintroducing the failure requires a visible
+   signature change that fails the test.
+
+A live-model test is not in CI. It would be measuring the model, not the boundary, and
+the boundary is the thing this decision is about.
+
+## Named home and what is deferred
+
+`domain/vision_explainer_prompt.py` holds the frozen input value objects, both prompt
+builders, the observation fallback and the three schemas. Pure: no Home Assistant
+import, no clocks, no I/O, following the `plant_lifecycle.py` and `evidence_fusion.py`
+precedents.
+
+`domain/evidence_fusion.py` is created here with its **enums only** —
+`EnvironmentalVerdict`, `EvidenceFusionState`, `ConfidenceQualifier`,
+`EvidenceCoverage`. ADR 0040 named that module and deferred it; the explainer needs the
+vocabulary now, and defining it twice would guarantee drift. `fuse_evidence(...)` and
+its value objects stay deferred exactly as ADR 0040 decided.
+
+Deferred to
+[hub#73](https://github.com/Venosta-web/growspace_manager_workspace/issues/73): every
+call site. Fetching the fusion outcome, assembling the trend, issuing either
+`ai_task.async_generate_data` call, writing the report row, and the card's migration
+off `severity` and `issues_detected`. The same line ADR 0040 and ADR 0041 drew.
+
+**One change does land in the live path**, because it had no such dependency: the
+`CANOPY COVERAGE: n% … (calculated via HSV color filtering)` line is deleted from
+`_build_vision_prompt`. The statistic varies 31.5% inside one fixed camera's healthy
+bucket (hub#68), so stating it as a measured fact beside the image handed the model a
+quantity to reason from that does not mean what it appears to mean. This absorbs
+[hub#76](https://github.com/Venosta-web/growspace_manager_workspace/issues/76).
+
+The MOISTURE INTERPRETATION RULE deliberately **stays** until the two-pass builder is
+wired in. Weak as it is, it is the only counterweight currently standing between the
+sensor block and the image; removing it before the structural replacement lands would
+make contamination worse, not better.
+
+## Considered options
+
+- **More prose in one prompt** — rejected as the failure mode itself.
+- **A single call with an output-side contamination validator** — rejected: a guard
+  with false negatives, defeated by paraphrase.
+- **Keeping `severity` and instructing the model not to overrule fusion** — rejected;
+  a field that exists gets written to.
+- **A structured `hypothesis` with machine-readable supporting evidence** — rejected as
+  a symptom taxonomy by another name.
+- **Feeding previous explainer narratives in as trend** — rejected: it turns a
+  hallucination into established history.
+- **Suppressing an explanation that contradicts the fusion state** — rejected; the
+  detector would be unvalidatable, and presentation already carries the weight.
+- **Removing the image from V1 outright** — not taken. The map's settled position is
+  that the explainer may still see it, with removal as a later flag-flip; the two-pass
+  split makes that flip a deletion rather than a rewrite.

--- a/tests/domain/test_vision_explainer_prompt.py
+++ b/tests/domain/test_vision_explainer_prompt.py
@@ -1,0 +1,423 @@
+"""Tests for the Vision Explainer prompt.
+
+The load-bearing tests here are the contamination tests.  The stage this module
+replaces reported petiole reddening and leaf curl on a visibly healthy canopy
+because the environmental block sat directly above "Analyze the attached camera
+image(s)".  Three layers guard against its return, in increasing strength:
+
+1. **The sweep** — hold the photograph fixed, move every environmental input
+   across its range, and assert the Visual Observation Pass prompt does not move.
+   This is the ticket's literal acceptance criterion.
+2. **The vocabulary scan** — assert no environmental term reaches that prompt by
+   any route, including one added later through a field that exists today.
+3. **The signature** — assert the pass has no parameter through which
+   environmental evidence could arrive at all.  Layers 1 and 2 prove the builder
+   ignores what it is given; this one proves it cannot be given it, so
+   contamination requires a visible signature change that fails this test.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import itertools
+
+import pytest
+
+from custom_components.growspace_manager.domain.evidence_fusion import (
+    ConfidenceQualifier,
+    EnvironmentalVerdict,
+    EvidenceCoverage,
+    EvidenceFusionState,
+)
+from custom_components.growspace_manager.domain.vision_explainer_prompt import (
+    ENVIRONMENTAL_VOCABULARY,
+    VISION_EXPLAINER_SCHEMA,
+    VISION_EXPLANATION_SCHEMA,
+    VISION_OBSERVATION_SCHEMA,
+    EnvironmentalEvidence,
+    ExplanationPassInput,
+    FusionSummary,
+    ObservationPassInput,
+    TrendEntry,
+    VisualEvidence,
+    build_explanation_prompt,
+    build_observation_prompt,
+    environmental_terms_in,
+    observation_from_visual_comparison,
+)
+from custom_components.growspace_manager.models.vision_evidence import (
+    BaselineState,
+    ComparisonOutcome,
+    ComparisonVerdict,
+    LightWindow,
+    ObservationSource,
+)
+
+# Every environmental state the fusion inputs can take, as the sweep ranges over
+# them.  Reasons are drawn from the real Bayesian vocabulary so that a leak would
+# be recognisable in the failure output.
+_STRESS_REASONS = (
+    (),
+    ("VPD 1.8 kPa is above the flower-stage band",),
+    ("Soil moisture 12% is below the acceptable band", "Leaf temperature high"),
+)
+_MOLD_REASONS = (
+    (),
+    ("Humidity 78% with lights off for 4 hours",),
+)
+
+
+def _environments() -> list[EnvironmentalEvidence]:
+    """Return the full environmental input range."""
+    return [
+        EnvironmentalEvidence(verdict=verdict, stress_reasons=stress, mold_reasons=mold)
+        for verdict, stress, mold in itertools.product(
+            EnvironmentalVerdict, _STRESS_REASONS, _MOLD_REASONS
+        )
+    ]
+
+
+def _visuals() -> list[VisualEvidence]:
+    """Return a representative range of Visual Comparison Results."""
+    return [
+        VisualEvidence(
+            outcome=ComparisonOutcome.SCORED,
+            verdict=verdict,
+            anomaly_score=score,
+            comparison_confidence=1.0,
+            baseline_state=BaselineState.READY,
+        )
+        for verdict, score in (
+            (ComparisonVerdict.NORMAL, 0.40),
+            (ComparisonVerdict.UNCERTAIN, 0.93),
+            (ComparisonVerdict.MATERIAL_SCENE_CHANGE, 1.0),
+        )
+    ] + [
+        VisualEvidence(
+            outcome=ComparisonOutcome.MONITORING,
+            baseline_state=BaselineState.MONITORING,
+            samples_collected=11,
+            samples_required=30,
+        ),
+        VisualEvidence(
+            outcome=ComparisonOutcome.UNAVAILABLE,
+            unavailable_reasons=("vision_unavailable", "frame_rejected"),
+        ),
+    ]
+
+
+def _fusions() -> list[FusionSummary]:
+    """Return the full fusion outcome range, available and not."""
+    return [
+        FusionSummary(
+            state=state,
+            confidence=ConfidenceQualifier.CONFIRMED,
+            coverage=EvidenceCoverage.COMPLETE,
+        )
+        for state in EvidenceFusionState
+    ] + [FusionSummary(unavailable_reasons=("baseline_monitoring",))]
+
+
+# --- Layer 1: the sweep -----------------------------------------------------
+
+
+def test_observation_prompt_does_not_move_when_the_environment_does():
+    """The ticket's acceptance criterion.
+
+    Hold the photograph and its timing fixed; sweep every environmental input
+    across its range.  The Visual Observation Pass prompt must be byte-identical
+    every time, because none of those inputs can reach it.
+    """
+    fixed = ObservationPassInput(light_window=LightWindow.MID, photograph_count=1)
+    baseline = build_observation_prompt(fixed)
+
+    for environment, visual, fusion in itertools.product(
+        _environments(), _visuals(), _fusions()
+    ):
+        # The explanation pass is what varies; the observation pass shares its
+        # world and must be untouched by it.
+        build_explanation_prompt(
+            ExplanationPassInput(
+                observation="A canopy.",
+                observation_source=ObservationSource.IMAGE_PASS,
+                fusion=fusion,
+                environment=environment,
+                visual=visual,
+                trend=(
+                    TrendEntry(
+                        evaluated_at="2026-08-30T06:00:00+00:00",
+                        verdict=ComparisonVerdict.NORMAL,
+                        anomaly_score=0.2,
+                        fusion_state=EvidenceFusionState.NO_DETECTED_CHANGE,
+                    ),
+                ),
+            )
+        )
+        assert build_observation_prompt(fixed) == baseline
+
+
+def test_observation_prompt_varies_only_with_its_own_inputs():
+    """The sweep is not passing because the prompt is a constant."""
+    one = build_observation_prompt(
+        ObservationPassInput(light_window=LightWindow.EARLY, photograph_count=1)
+    )
+    two = build_observation_prompt(
+        ObservationPassInput(light_window=LightWindow.LATE, photograph_count=2)
+    )
+    assert one != two
+
+
+# --- Layer 2: the vocabulary scan -------------------------------------------
+
+
+@pytest.mark.parametrize("light_window", list(LightWindow))
+@pytest.mark.parametrize("grid_overlay", [True, False])
+def test_observation_prompt_names_no_environmental_measurement(
+    light_window, grid_overlay
+):
+    """No environmental term reaches the observation pass by any route."""
+    prompt = build_observation_prompt(
+        ObservationPassInput(
+            light_window=light_window,
+            photograph_count=2,
+            grid_overlay=grid_overlay,
+        )
+    )
+    assert environmental_terms_in(prompt) == ()
+
+
+def test_timing_descriptions_carry_no_interpretation():
+    """The old timing labels told the model what to expect before it looked.
+
+    "peak transpiration period" and "end-of-day stress check" are framing, not
+    scheduling.  Every light window's description must survive the scan.
+    """
+    for window in LightWindow:
+        prompt = build_observation_prompt(
+            ObservationPassInput(light_window=window, photograph_count=1)
+        )
+        assert environmental_terms_in(prompt) == ()
+
+
+def test_the_vocabulary_scan_can_fail():
+    """A leak is detectable — the scan is not vacuously true."""
+    assert "vpd" in environmental_terms_in("VPD is 1.6 kPa")
+    assert environmental_terms_in("a photograph of each canopy") == ()
+
+
+# --- Layer 3: the signature -------------------------------------------------
+
+
+def test_the_observation_pass_cannot_receive_environmental_evidence():
+    """The invariant proper: there is no parameter to contaminate.
+
+    Layers 1 and 2 prove the builder ignores environmental input it is handed.
+    This proves it is handed none, so reintroducing the failure means changing a
+    signature this test reads.
+    """
+    parameters = inspect.signature(build_observation_prompt).parameters
+    assert list(parameters) == ["inputs"]
+    assert parameters["inputs"].annotation == "ObservationPassInput"
+
+    fields = {field.name for field in dataclasses.fields(ObservationPassInput)}
+    assert fields == {"light_window", "photograph_count", "grid_overlay"}
+
+    for name in fields:
+        assert environmental_terms_in(name) == ()
+
+
+def test_the_explanation_pass_receives_no_image():
+    """Its binding rule is true, not aspirational: there is no image field."""
+    fields = {field.name for field in dataclasses.fields(ExplanationPassInput)}
+    assert not {"image", "images", "attachment", "attachments"} & fields
+
+
+# --- The output schemas -----------------------------------------------------
+
+
+def test_the_explainer_emits_no_severity():
+    """Severity is an Evidence Fusion output; the LLM must not overrule it."""
+    for schema in (
+        VISION_OBSERVATION_SCHEMA,
+        VISION_EXPLANATION_SCHEMA,
+        VISION_EXPLAINER_SCHEMA,
+    ):
+        assert "severity" not in {str(key) for key in schema.schema}
+
+
+def test_the_explainer_emits_no_symptom_vocabulary():
+    """V1 has no validated classifier behind a machine-readable symptom claim."""
+    keys = {str(key) for key in VISION_EXPLAINER_SCHEMA.schema}
+    assert keys == {
+        "observation",
+        "environmental_risk",
+        "hypothesis",
+        "recommendations",
+    }
+
+
+def test_the_explanation_pass_cannot_revise_the_observation():
+    """The report's observation is the observation pass's own words."""
+    assert "observation" not in {str(key) for key in VISION_EXPLANATION_SCHEMA.schema}
+
+
+def test_an_empty_explanation_is_valid():
+    """Empty is an honest answer when the evidence supports nothing."""
+    VISION_EXPLAINER_SCHEMA(
+        {
+            "observation": "The canopy fills the frame evenly.",
+            "environmental_risk": "",
+            "hypothesis": "",
+            "recommendations": [],
+        }
+    )
+
+
+# --- Degradation ------------------------------------------------------------
+
+
+def test_a_report_without_a_photograph_says_so():
+    """No report may imply an inspection that did not happen."""
+    for visual in _visuals():
+        text = observation_from_visual_comparison(visual)
+        assert "No photograph was read" in text
+        assert "how the plants look" in text or "not about the plants" in text
+
+
+def test_monitoring_is_not_reported_as_no_change():
+    """A baseline still collecting is not a finding of no change."""
+    text = observation_from_visual_comparison(
+        VisualEvidence(
+            outcome=ComparisonOutcome.MONITORING,
+            samples_collected=11,
+            samples_required=30,
+        )
+    )
+    assert "11 of 30" in text
+    assert "no change" not in text.lower()
+
+
+def test_the_explanation_pass_works_without_a_photograph():
+    """The image-off path is the same prompt, differently labelled."""
+    prompt = build_explanation_prompt(
+        ExplanationPassInput(
+            observation=observation_from_visual_comparison(
+                VisualEvidence(
+                    outcome=ComparisonOutcome.SCORED,
+                    verdict=ComparisonVerdict.NORMAL,
+                    anomaly_score=0.3,
+                    comparison_confidence=1.0,
+                )
+            ),
+            observation_source=ObservationSource.VISUAL_COMPARISON_ONLY,
+            fusion=FusionSummary(
+                state=EvidenceFusionState.ENVIRONMENTAL_RISK,
+                confidence=ConfidenceQualifier.CONFIRMED,
+                coverage=EvidenceCoverage.COMPLETE,
+            ),
+            environment=EnvironmentalEvidence(
+                verdict=EnvironmentalVerdict.RISK,
+                stress_reasons=("VPD 1.8 kPa is above the flower-stage band",),
+            ),
+            visual=VisualEvidence(
+                outcome=ComparisonOutcome.SCORED,
+                verdict=ComparisonVerdict.NORMAL,
+                anomaly_score=0.3,
+                comparison_confidence=1.0,
+            ),
+        )
+    )
+    assert "no photograph was read" in prompt
+    assert "You have not seen any photograph" in prompt
+
+
+# --- The explanation prompt's own content -----------------------------------
+
+
+def test_the_explanation_prompt_labels_every_evidence_origin():
+    """Keeping origins apart is the whole job."""
+    prompt = build_explanation_prompt(
+        ExplanationPassInput(
+            observation="Leaf tips curl downward in B2 and C3.",
+            observation_source=ObservationSource.IMAGE_PASS,
+            fusion=FusionSummary(
+                state=EvidenceFusionState.CONCURRENT_ENVIRONMENTAL_RISK_AND_VISUAL_ANOMALY,
+                confidence=ConfidenceQualifier.CONFIRMED,
+                coverage=EvidenceCoverage.COMPLETE,
+            ),
+            environment=EnvironmentalEvidence(
+                verdict=EnvironmentalVerdict.RISK,
+                stress_reasons=("VPD 1.8 kPa is above the flower-stage band",),
+                mold_reasons=("Humidity 78% with lights off for 4 hours",),
+            ),
+            visual=VisualEvidence(
+                outcome=ComparisonOutcome.SCORED,
+                verdict=ComparisonVerdict.MATERIAL_SCENE_CHANGE,
+                anomaly_score=1.0,
+                comparison_confidence=1.0,
+                baseline_state=BaselineState.READY,
+            ),
+            trend=(
+                TrendEntry(
+                    evaluated_at="2026-08-30T12:00:00+00:00",
+                    verdict=ComparisonVerdict.NORMAL,
+                    anomaly_score=0.31,
+                ),
+            ),
+        )
+    )
+    assert (
+        "EVIDENCE FUSION OUTCOME (decided by Growspace Manager, not by you)" in prompt
+    )
+    assert "OBSERVATION (read from the attached photographs" in prompt
+    assert "VISUAL EVIDENCE (how far this camera's view has moved" in prompt
+    assert "ENVIRONMENTAL EVIDENCE (this growspace's Bayesian evaluation" in prompt
+    assert "TREND (earlier scored comparisons" in prompt
+
+
+def test_the_explanation_prompt_states_the_binding_rule():
+    """The exact wording settled in hub#71."""
+    prompt = build_explanation_prompt(
+        ExplanationPassInput(
+            observation="A canopy.",
+            observation_source=ObservationSource.IMAGE_PASS,
+            fusion=FusionSummary(unavailable_reasons=("vision_unavailable",)),
+            environment=EnvironmentalEvidence(verdict=EnvironmentalVerdict.UNAVAILABLE),
+            visual=VisualEvidence(
+                outcome=ComparisonOutcome.UNAVAILABLE,
+                unavailable_reasons=("vision_unavailable",),
+            ),
+        )
+    )
+    assert (
+        "Environmental measurements and risk evaluations describe the growspace, "
+        "not the plant's appearance. You have not seen an image."
+    ) in prompt
+    assert "do not assign a severity of your own" in prompt
+
+
+def test_unavailable_environment_is_not_reported_as_normal():
+    """A zero from zero observations is unavailable, never reassurance."""
+    prompt = build_explanation_prompt(
+        ExplanationPassInput(
+            observation="A canopy.",
+            observation_source=ObservationSource.IMAGE_PASS,
+            fusion=FusionSummary(unavailable_reasons=("vision_unavailable",)),
+            environment=EnvironmentalEvidence(verdict=EnvironmentalVerdict.UNAVAILABLE),
+            visual=VisualEvidence(outcome=ComparisonOutcome.UNAVAILABLE),
+        )
+    )
+    assert "This is not evidence of normal conditions." in prompt
+
+
+def test_the_trend_carries_no_previous_narrative():
+    """Feeding narratives back would make a hallucination into history."""
+    fields = {field.name for field in dataclasses.fields(TrendEntry)}
+    assert fields == {"evaluated_at", "verdict", "anomaly_score", "fusion_state"}
+
+
+def test_every_environmental_term_is_lowercase_and_unique():
+    """The scan lowercases its input, so an uppercase entry would never match."""
+    assert list(ENVIRONMENTAL_VOCABULARY) == sorted(set(ENVIRONMENTAL_VOCABULARY))
+    assert all(term == term.lower() for term in ENVIRONMENTAL_VOCABULARY)

--- a/tests/test_vision_checkup_scheduler.py
+++ b/tests/test_vision_checkup_scheduler.py
@@ -939,12 +939,19 @@ async def test_process_camera_images_creates_output_directory(
 
 
 # ---------------------------------------------------------------------------
-# _build_vision_prompt — canopy coverage and grid reference
+# _build_vision_prompt — grid reference
 # ---------------------------------------------------------------------------
 
 
-def test_build_vision_prompt_injects_canopy_coverage(mock_hass, mock_coordinator):
-    """Canopy coverage percentage appears in the prompt when provided."""
+def test_build_vision_prompt_makes_no_canopy_coverage_claim(
+    mock_hass, mock_coordinator
+):
+    """The HSV green-pixel statistic is not stated to the model.
+
+    It varies 31.5% inside one fixed camera's healthy bucket (hub#68), so
+    presenting it as a measured fact alongside the image gave the model a
+    quantity to reason from that does not mean what it appears to mean.
+    """
     scheduler = VisionCheckupScheduler(mock_hass, mock_coordinator)
 
     with patch(
@@ -956,30 +963,11 @@ def test_build_vision_prompt_injects_canopy_coverage(mock_hass, mock_coordinator
             "mid",
             {"growspace": {"name": "t", "id": "t1"}},
             [],
-            canopy_coverage=64.5,
-        )
-
-    assert "64.5%" in prompt
-    assert "CANOPY COVERAGE" in prompt
-
-
-def test_build_vision_prompt_omits_coverage_when_none(mock_hass, mock_coordinator):
-    """No canopy coverage line is added when canopy_coverage is None."""
-    scheduler = VisionCheckupScheduler(mock_hass, mock_coordinator)
-
-    with patch(
-        "custom_components.growspace_manager.services.ai_assistant.GrowAssistant._format_context_data",
-        return_value="",
-    ):
-        prompt = scheduler._build_vision_prompt(
-            "t1",
-            "mid",
-            {"growspace": {"name": "t", "id": "t1"}},
-            [],
-            canopy_coverage=None,
         )
 
     assert "CANOPY COVERAGE" not in prompt
+    assert "HSV" not in prompt
+    assert "green plant matter" not in prompt
 
 
 def test_build_vision_prompt_includes_grid_sector_instructions(

--- a/tests/test_vision_evidence_schema.py
+++ b/tests/test_vision_evidence_schema.py
@@ -17,6 +17,11 @@ from custom_components.growspace_manager.data_access.vision_evidence_schema impo
     VISION_EVIDENCE_SCHEMA_VERSION,
     VISION_SCORING_POLICY_VERSION,
 )
+from custom_components.growspace_manager.domain.evidence_fusion import (
+    ConfidenceQualifier,
+    EvidenceCoverage,
+    EvidenceFusionState,
+)
 from custom_components.growspace_manager.models.vision_evidence import (
     AdmissionPhase,
     AnalysisState,
@@ -32,6 +37,7 @@ from custom_components.growspace_manager.models.vision_evidence import (
     LabelKind,
     LightState,
     LightWindow,
+    ObservationSource,
 )
 
 EXPECTED_TABLES = {
@@ -41,6 +47,7 @@ EXPECTED_TABLES = {
     "vision_capture_file",
     "vision_comparison_result",
     "vision_embedding",
+    "vision_explainer_report",
     "vision_framing_epoch",
     "vision_grow_run_ref",
     "vision_label",
@@ -133,6 +140,10 @@ def test_schema_version_is_recorded_in_user_version(db):
         ("vision_comparison_result", "outcome", ComparisonOutcome),
         ("vision_comparison_result", "verdict", ComparisonVerdict),
         ("vision_label", "label_kind", LabelKind),
+        ("vision_explainer_report", "observation_source", ObservationSource),
+        ("vision_explainer_report", "fusion_state", EvidenceFusionState),
+        ("vision_explainer_report", "fusion_confidence", ConfidenceQualifier),
+        ("vision_explainer_report", "fusion_coverage", EvidenceCoverage),
     ],
 )
 def test_check_constraints_match_the_model_enums(db, table, column, enum):
@@ -292,3 +303,82 @@ def test_baseline_members_required_matches_the_bucket_default(db):
         "SELECT sql FROM sqlite_master WHERE name = 'vision_baseline_bucket'"
     ).fetchone()
     assert f"DEFAULT {VISION_BASELINE_MEMBERS_REQUIRED}" in row[0]
+
+
+def _insert_report(
+    db: sqlite3.Connection,
+    report_id: str = "report-1",
+    *,
+    capture_id: str = "capture-1",
+    fusion_state: str | None = "no_detected_change",
+    fusion_confidence: str | None = "confirmed",
+    fusion_coverage: str | None = "complete",
+) -> str:
+    """Insert a Vision Explainer Report and return its id."""
+    db.execute(
+        "INSERT INTO vision_explainer_report"
+        " (report_id, capture_id, created_at, ai_task_entity_id,"
+        "  observation_source, scoring_policy_version, observation,"
+        "  environmental_risk, hypothesis, recommendations,"
+        "  fusion_state, fusion_confidence, fusion_coverage)"
+        " VALUES (?, ?, '2026-08-31T06:05:00+00:00', 'ai_task.cloud',"
+        " 'image_pass', 1, 'Canopy is even across all sectors.',"
+        " 'No active evaluation.', '', '[]', ?, ?, ?)",
+        (report_id, capture_id, fusion_state, fusion_confidence, fusion_coverage),
+    )
+    return report_id
+
+
+def test_explainer_report_carries_no_severity(db):
+    """Severity is a fusion output; the explainer has no column to overrule it."""
+    sql = _table_sql(db, "vision_explainer_report")
+    assert "severity" not in sql.lower()
+
+
+def test_explainer_report_carries_no_symptom_vocabulary(db):
+    """V1 emits no machine-readable symptom claim (hub#68)."""
+    sql = _table_sql(db, "vision_explainer_report")
+    assert "symptom" not in sql.lower()
+    assert "issues_detected" not in sql.lower()
+
+
+def test_explainer_report_is_recordable(db):
+    """A complete report attaches to its capture."""
+    _insert_epoch(db)
+    _insert_capture(db)
+    _insert_report(db)
+    assert db.execute("SELECT COUNT(*) FROM vision_explainer_report").fetchone()[0] == 1
+
+
+def test_an_unavailable_fusion_outcome_carries_no_qualifiers(db):
+    """State, confidence and coverage are present together or not at all."""
+    _insert_epoch(db)
+    _insert_capture(db)
+    _insert_report(
+        db,
+        "report-unavailable",
+        fusion_state=None,
+        fusion_confidence=None,
+        fusion_coverage=None,
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        _insert_report(db, "report-half", fusion_confidence=None)
+
+
+def test_a_capture_may_carry_more_than_one_report(db):
+    """A re-run against another AI task entity is a second report, not an edit."""
+    _insert_epoch(db)
+    _insert_capture(db)
+    _insert_report(db, "report-1")
+    _insert_report(db, "report-2")
+    assert db.execute("SELECT COUNT(*) FROM vision_explainer_report").fetchone()[0] == 2
+
+
+def test_deleting_a_capture_removes_its_report(db):
+    """Evidence deletion is complete: no narrative outlives its capture."""
+    _insert_epoch(db)
+    _insert_capture(db)
+    _insert_report(db)
+    db.execute("DELETE FROM vision_capture WHERE capture_id = 'capture-1'")
+    assert db.execute("SELECT COUNT(*) FROM vision_explainer_report").fetchone()[0] == 0


### PR DESCRIPTION
Resolves [hub#71](https://github.com/Venosta-web/growspace_manager_workspace/issues/71). Absorbs [hub#76](https://github.com/Venosta-web/growspace_manager_workspace/issues/76).

> **Stacked on #714** (hub#70, the evidence store). Merge that first — this branch adds a tenth table to its schema file and a record to its models.

## The failure

`_build_vision_prompt` interpolated sensor readings, Bayesian stress and mold probabilities *with their reasons*, and the moisture-band interpretation directly above "Analyze the attached camera image(s)". The model was told the plant was probably stressed and then asked what it saw, and reported petiole reddening and leaf curl on a visibly healthy canopy.

The MOISTURE INTERPRETATION RULE is a prose patch for exactly that failure on exactly one sensor. More prose does not fix it: **a rule the model may ignore is not an invariant.**

## Two passes that cannot see each other's inputs

- **Visual Observation Pass** — photographs and light window. No parameter through which environmental evidence, a fusion state, a trend or a previous narrative could arrive.
- **Evidence Explanation Pass** — the observation text, the Evidence Fusion Outcome, both evidence channels, the trend. No image.

Contamination is impossible by construction rather than by instruction, and the binding rule's second sentence ("You have not seen an image") is *true* rather than aspirational. The split pays off three more times: the observation is carried into the report verbatim and the second pass never returns it, so it cannot revise what was seen; removing the image from V1 later deletes one call instead of editing prose; and the contamination test needs no model.

## Output schema

`severity` and `issues_detected` are gone. Severity is an Evidence Fusion output (ADR 0040) and the cleanest enforcement is that there is no field to write it into. A symptom keyword list is a machine-readable health claim, and hub#68 settled that V1 has no validated classifier behind one — the explainer may still *describe* what it sees in prose, but a description is not a taxonomy and only a taxonomy gets consumed by downstream logic.

| schema | fields |
| --- | --- |
| `VISION_OBSERVATION_SCHEMA` | `observation` |
| `VISION_EXPLANATION_SCHEMA` | `environmental_risk`, `hypothesis`, `recommendations` |
| `VISION_EXPLAINER_SCHEMA` | all four — the stored report |

## The contamination test

Three layers, all deterministic, in `tests/domain/test_vision_explainer_prompt.py`:

1. **The sweep** — hold the photograph and timing fixed, move every environmental input across its range, assert the observation prompt is byte-identical. hub#71's literal acceptance criterion.
2. **The vocabulary scan** — assert no environmental term reaches it by any route. Whole-word matching, because `ec` and `ph` live inside `each` and `photograph`; digits deliberately allowed, because the grid labels are numerals with no environmental meaning.
3. **The signature** — assert the pass has no parameter through which environmental evidence could arrive. Layers 1 and 2 prove the builder ignores what it is handed; this proves it is handed none.

No live-model test in CI: it would measure the model, not the boundary.

## Degradation

With no AI task configured there is no report, no error and no empty state — the evidence rendering *is* the report. When the observation pass is off (`ai_settings.vision_explainer_sees_image`) or fails, the observation comes from the Visual Comparison Result and says outright that no photograph was read and nothing was assessed about how the plants look. A failed explanation pass stores nothing.

## What lands live, and what deliberately does not

The `CANOPY COVERAGE: n% … (HSV color filtering)` line is deleted from the live prompt — the statistic varies 31.5% inside one fixed camera's healthy bucket (hub#68), and it had no deferred dependency. This absorbs hub#76.

The MOISTURE INTERPRETATION RULE **stays** until the two-pass builder is wired in. Weak as it is, it is the only counterweight currently between the sensor block and the image; removing it first would make contamination worse.

A third contamination source turned up during the build: the *timing labels*. `mid` was described as the "peak transpiration period" and `late` as an "end-of-day stress check" — framing, not scheduling, told to the model before it had looked. The observation pass now states clock position only.

## Deferred to [hub#73](https://github.com/Venosta-web/growspace_manager_workspace/issues/73)

Every call site: fetching the fusion outcome, assembling the trend, issuing either `ai_task` call, writing the report row, and the card's migration off `severity`/`issues_detected`. The same line ADR 0040 and ADR 0041 drew.

`domain/evidence_fusion.py` is created here with its **enums only**. ADR 0040 named that module and deferred it; the explainer needs the vocabulary now and defining it twice would guarantee drift. `fuse_evidence(...)` stays deferred.

## Validation

`./scripts/check backend fast` green: ruff, mypy across 215 source files, **5,284 tests and 44 snapshots**. All nine pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)