### PR TITLE
docs(vision): plan checkup contract migration

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -668,7 +668,7 @@ A user-configured reminder that fires on a specific day of a plant's lifecycle s
 A point-in-time image captured from a growspace camera. Can be triggered manually by the grower via the camera snapshots dialog or automatically as part of a scheduled [[Vision Checkup]]. Manual JPEGs and grid-overlaid `_processed.jpg` images live in the public directory `www/growspace_manager/snapshots/{growspace_id}/` for frontend display. A Vision Checkup also preserves the camera response bytes unchanged in the resolved private media root at `growspace_vision/raw/{growspace_id}/{timestamp}_{camera}_raw.{source-extension}`. These raw artifacts never appear in the snapshot-listing API and are pruned after 90 days until the [[Vision Evidence Store]] takes over their lifecycle.
 
 **Vision Checkup**
-An observation of one or more [[Camera Snapshot]]s from a growspace, scheduled at three key times in the light cycle (early, mid, late) or triggered manually. The snapshots are processed with a 4x4 grid overlay before analysis. A checkup produces a Visual Comparison Result and an [[Evidence Fusion Outcome]]; where an AI task is configured it also produces a [[Vision Explainer Report]], which narrates that evidence and never decides it. The legacy `VisionCheckupResult` history is frozen in place (ADR 0041) and its `severity` and `issues_detected` fields are not produced by the new pipeline.
+One Home Assistant-owned observation task for a growspace, scheduled in a light window or triggered manually and identified by `checkup_id`. It groups one [[Vision Capture]] per camera and has only an operational outcome (`completed`, `partial`, `failed`); visual comparison and [[Evidence Fusion Outcome]] remain capture-specific and are never aggregated across cameras. See [ADR-0043](./docs/adr/0043-vision-checkups-migrate-through-versioned-capture-contracts.md).
 _Avoid_: Vision diagnosis, AI verdict, plant health check
 
 **Vision Explainer**
@@ -688,12 +688,24 @@ The four fields a [[Vision Explainer]] produces for one capture — `observation
 _Avoid_: Vision analysis, AI diagnosis, checkup result
 
 **Vision Evidence Store**
-The Home Assistant-owned SQLite database `growspace_vision.db` holding every artifact of a [[Vision Checkup]]: [[Vision Capture]]s, their image files, Visual Embeddings, Visual Comparison Results, Baseline Buckets and [[Vision Label]]s. Growspace Vision is stateless, so this is the only durable record that the analysis happened. Versioned by `PRAGMA user_version` and migrated by forward-only numbered steps — deliberately not the `try: ALTER TABLE / except` pattern of `strain_library.py`, which records no version. See [ADR-0041](./docs/adr/0041-home-assistant-owns-vision-evidence-in-a-dedicated-store.md).
+The Home Assistant-owned SQLite database `growspace_vision.db` holding every artifact of a [[Vision Checkup]]: the checkup itself, [[Vision Capture]]s, their image files, Visual Embeddings, Visual Comparison Results, Baseline Buckets and [[Vision Label]]s. Growspace Vision is stateless, so this is the only durable record that the analysis happened. Versioned by `PRAGMA user_version` and migrated by forward-only numbered steps — deliberately not the `try: ALTER TABLE / except` pattern of `strain_library.py`, which records no version. See [ADR-0041](./docs/adr/0041-home-assistant-owns-vision-evidence-in-a-dedicated-store.md).
 _Avoid_: Vision history, embedding cache, anomaly database
 
 **Vision Capture**
-One [[Camera Snapshot]] taken for a [[Vision Checkup]], identified by a `capture_id` (UUIDv7) minted in Home Assistant **before** the Growspace Vision call. The id is the filename stem of every image variant, so a file and its record are linked without the database. The capture record is written when the bytes are persisted, so a rejected or failed analysis still leaves a tracked, prunable image; `analysis_state` carries how far it got (`pending`, `analyzed`, `rejected`, `failed`).
+One [[Camera Snapshot]] taken for a [[Vision Checkup]], identified by a `capture_id` (UUIDv7) and linked to its parent `checkup_id`. The id is minted in Home Assistant before the Growspace Vision call and names every image variant; the record is written when the bytes are persisted, so rejection or failure still leaves a tracked, prunable image.
 _Avoid_: Frame, snapshot record, image row
+
+**Vision Capture Result**
+The card-facing projection of one [[Vision Capture]]: image availability, quality outcome, visual comparison, normalized environmental evidence, [[Evidence Fusion Outcome]], measurement-only trend, provenance and optional [[Vision Explainer Report]]. It is not an embedding or database-row dump and has no severity or symptom claim.
+_Avoid_: Checkup result, AI verdict, capture diagnosis
+
+**Vision Service Status**
+The integration-owned statement of whether Growspace Vision is `ready`, `unavailable` or `incompatible`, with a typed reason and the service, schema and active-model versions when known. The card displays it but never probes or configures the service itself.
+_Avoid_: Connected boolean, App health check, model setting
+
+**Vision Connection**
+The integration-wide route to Growspace Vision: either automatic Supervisor discovery or an explicit manual endpoint and bearer token. It never belongs to a growspace, never reaches the card with its token, and never silently falls back between modes.
+_Avoid_: VisionCheckupConfig endpoint, camera connection
 
 **Capture Variant**
 Which rendering of a [[Vision Capture]] an image file holds: `raw` (the camera's original bytes) or `processed` (the grid-overlaid JPEG the cloud path produces). Stored as a path relative to the resolved image root, never as a public URL, so the serving mechanism can change without a data migration. The record outlives the file — a pruned image is distinguishable from an image that never existed.
@@ -716,6 +728,14 @@ _Avoid_: Correction, ground truth, annotation record
 **Legacy Vision Checkup History**
 The pre-local-vision `vision_checkup_history` list on each `Growspace`, holding up to ten cloud-LLM results with `analysis`, `issues_detected`, `severity` and `recommendations`. Frozen in place at the cutover: never appended to again, and never read by baselines, trends, [[Evidence Fusion]] or a training set. It is not migrated into the [[Vision Evidence Store]] — those records assert exactly the symptom claims V1 may not make, and giving them equal standing with measured evidence would re-import the false authority the local vision work exists to remove.
 _Avoid_: Vision history (unqualified)
+
+**Legacy Vision Checkup Result**
+One cloud-era entry preserved verbatim inside [[Legacy Vision Checkup History]] and discriminated as `legacy_cloud_v1` when projected to the card. Its severity and detected issues are attributed historical cloud output, never V1 evidence.
+_Avoid_: Migrated result, V1 result
+
+**Vision History**
+The newest-first card projection of V1 [[Vision Checkup]] envelopes and clearly marked [[Legacy Vision Checkup Result]]s. Pagination counts checkups rather than captures, and legacy entries never participate in V1 trends or evidence.
+_Avoid_: Legacy history, capture list
 
 **Contract Fixture**
 The golden `get_data` growspace payload committed at `tests/fixtures/contract/growspace_payload.json`, serialized from one **maximally populated** growspace (every optional sub-config set). A snapshot test fails when the payload shape changes without the fixture being deliberately regenerated; the lovelace card strict-parses the same file in its CI. Maximal population is the load-bearing property — a field absent from the fixture builder is invisible to the contract.

--- a/docs/adr/0041-home-assistant-owns-vision-evidence-in-a-dedicated-store.md
+++ b/docs/adr/0041-home-assistant-owns-vision-evidence-in-a-dedicated-store.md
@@ -1,18 +1,19 @@
 # Home Assistant owns vision evidence in a dedicated store
 
-**Status:** Accepted
+**Status:** Accepted; amended by
+[ADR 0043](./0043-vision-checkups-migrate-through-versioned-capture-contracts.md)
 
 Decided on 2026-08-31 in
 [hub#70](https://github.com/Venosta-web/growspace_manager_workspace/issues/70), under
 the stateless-service boundary of ADR 0003 and the baseline semantics of ADR 0004.
 
-Every artifact of a Vision Checkup — the capture, its image files, its Visual
-Embedding, the Baseline Bucket it was scored against, the Visual Comparison Result,
-and any grower label — is persisted by Home Assistant in a dedicated SQLite database,
-`growspace_vision.db`. Evidence rows are kept unpruned for the life of the growspace;
-images are kept on a bounded rolling window with an explicit pin rule. The existing
-cloud-era `vision_checkup_history` is frozen in place rather than migrated, and no
-`STORAGE_VERSION` bump is required.
+Every artifact of a Vision Checkup — the checkup envelope, each capture, its image
+files, its Visual Embedding, the Baseline Bucket it was scored against, the Visual
+Comparison Result, and any grower label — is persisted by Home Assistant in a
+dedicated SQLite database, `growspace_vision.db`. Evidence rows are kept unpruned for
+the life of the growspace; images are kept on a bounded rolling window with an
+explicit pin rule. The existing cloud-era `vision_checkup_history` is frozen in place
+rather than migrated, and no `STORAGE_VERSION` bump is required.
 
 ## Medium
 
@@ -86,6 +87,11 @@ URL and the path is guessable from a timestamp. The database stores a
 can change without a data migration.
 
 ## Capture identity
+
+A `checkup_id` is a UUIDv7 string minted when one scheduled or manual Vision
+Checkup begins. The `vision_checkup` row is the durable multi-camera task and every
+capture references it; close timestamps are never used as an implicit group (ADR
+0043).
 
 A `capture_id` is a UUIDv7 string minted in Home Assistant at capture time, **before**
 the Growspace Vision call, and is the filename stem of every image variant. It exists
@@ -179,9 +185,10 @@ ordinary camera history out of Run media.
 
 ## Write ordering
 
-The capture row is written first, when the bytes are persisted, before the analysis
-call. The result is written after. A capture with no result is a first-class state and
-is always visible to retention — which makes the database the index for the image
+The checkup row is written when the task begins. Each capture row is written when its
+bytes are persisted, before the analysis call, and its result is written after. A
+capture with no result is a first-class state and is always visible to retention —
+which makes the database the index for the image
 files and closes the untracked-file hole `www/snapshots` has today, where the
 filesystem _is_ the index and a glob parses the timestamp out of the filename.
 

--- a/docs/adr/0043-vision-checkups-migrate-through-versioned-capture-contracts.md
+++ b/docs/adr/0043-vision-checkups-migrate-through-versioned-capture-contracts.md
@@ -1,0 +1,315 @@
+# ADR 0043 — Vision Checkups migrate through versioned capture contracts
+
+**Status:** Accepted
+
+Decided on 2026-08-31 in
+[workspace#73](https://github.com/Venosta-web/growspace_manager_workspace/issues/73),
+after the Vision HTTP boundary, scene-comparison policy, Evidence Fusion, evidence
+store and Vision Explainer were fixed by workspace issues #67, #66, #69, #70 and
+#71.
+
+Local vision changes the unit of truth. The cloud-era pipeline produced one
+growspace-level `VisionCheckupResult` across every camera, with an LLM-authored
+`severity` and `issues_detected`. Growspace Vision analyzes exactly one image per
+request, and Home Assistant's Visual Comparison Result, Evidence Fusion Outcome,
+provenance and failures all belong to one capture. A multi-camera checkup therefore
+cannot honestly have one aggregate visual or fusion verdict.
+
+The public V1 result is a versioned **Vision Checkup** envelope identified by a
+UUIDv7 `checkup_id`. It owns the growspace, trigger source, light window, start and
+completion times, and operational status (`completed`, `partial` or `failed`). Its
+`captures` are **Vision Capture Results**, one per camera. Every capture carries its
+identity and time, image availability, analysis state, quality result, visual
+comparison, normalized environmental evidence, Evidence Fusion Outcome, a
+measurement-only trend, model and scoring provenance, and an optional Vision
+Explainer Report. It never carries an embedding vector, raw sensor readings,
+baseline internals, `severity` or `issues_detected`.
+
+There is no cross-camera fusion state. A checkup is `completed` when no capture
+failed, `partial` when at least one capture failed and at least one reached another
+terminal outcome, and `failed` when every capture failed. Quality rejection is a
+recorded non-failure outcome rather than an exception that erases the attempt. A
+known-unavailable Vision service fails a manual request before capture and scheduled work skips without
+writing repetitive failed-history rows; a failure after image persistence leaves a
+tracked failed capture.
+
+## Durable identity
+
+ADR 0041's evidence schema gains a `vision_checkup` table before the repository is
+implemented, and every `vision_capture` references its `checkup_id`. Reconstructing a
+multi-camera domain event from close timestamps was rejected: simultaneous scheduled
+checks, retries and slow cameras make timestamp coincidence non-identity. The table
+also gives the service response, history pagination and the existing growspace-level
+sensor one durable source.
+
+`limit` and `total` count checkups, not captures. The V1 history projection merges
+new envelopes and frozen legacy rows by timestamp, newest first; `capture_total` is a
+separate count where it helps the UI. A capture's trend contains at most seven earlier
+scored comparisons for the same camera, Grow Run, model version, scoring-policy
+version and Framing Epoch. It resets at any provenance boundary and contains only
+timestamp, Anomaly Score, visual verdict and fusion state. Legacy rows, narratives
+and embeddings never enter it.
+
+## Wire shapes
+
+The new WebSocket commands are
+`growspace_manager/get_vision_status` and
+`growspace_manager/get_vision_history_v2`. History items form a discriminated union:
+
+```text
+VisionCheckup {
+  result_schema: "evidence_v1"
+  checkup_id, growspace_id, trigger_source, light_window
+  started_at, completed_at, status
+  captures: VisionCaptureResult[]
+}
+
+LegacyVisionCheckupResult {
+  result_schema: "legacy_cloud_v1"
+  timestamp, check_type, snapshot_paths
+  analysis, issues_detected, severity, recommendations
+}
+```
+
+`VisionCaptureResult` is a presentation projection, not a dump of the evidence
+database:
+
+```text
+VisionCaptureResult {
+  capture_id, camera_id, captured_at, analysis_state
+  image: { available, media_content_id? }
+  quality: { accepted, reasons, metrics? }
+  provenance: {
+    vision_schema_version?, service_version?, model_id?, model_version?,
+    scoring_policy_version?
+  }
+  visual: {
+    outcome, baseline_state?, samples_collected?, samples_required?,
+    raw_distance?, anomaly_score?, verdict?, comparison_confidence?,
+    unavailable_reasons
+  }
+  environment: { verdict, evaluated_at?, stress_reasons, mold_reasons }
+  fusion: { state?, confidence?, coverage?, unavailable_reasons }
+  trend: { evaluated_at, anomaly_score, verdict, fusion_state? }[]
+  report?: { observation, environmental_risk, hypothesis, recommendations }
+}
+```
+
+Image storage paths never cross the wire. The contract carries a Home Assistant
+`media_content_id`, which the card resolves through the authenticated media API. A
+pruned image remains a valid history item with `available: false`.
+
+The existing `trigger_vision_checkup` service remains the one public action. During
+the compatibility window its response keeps the legacy keys the released card
+requires and adds the canonical V1 envelope. For a V1 run the compatibility values
+are deliberately non-assertive: `issues_detected: []`, `severity: "none"`, produced
+snapshot paths, and the optional explainer prose and recommendations when available.
+They are never stored and no new consumer reads them. Removal requires a separate
+decision after a minimum card version can be enforced.
+
+## Legacy history
+
+The existing `Growspace.vision_checkup_history` remains frozen exactly as ADR 0041
+decided. It is not migrated, amended, used by comparison, used by fusion or fed into a
+trend. `severity` and `issues_detected` survive only inside
+`LegacyVisionCheckupResult`, where the card presents them as attributed historical
+cloud output under a visible **Legacy cloud analysis** label.
+
+The new card presents one chronological Vision History. It maps each V1 capture to
+its image and evidence while preserving legacy items as a marked tail. It derives
+visual tone from the fusion contract: neutral for `no_detected_change`, informational
+for visual-only anomaly, the existing environmental tone for environmental or
+concurrent states, and warning for `critical_scene_issue`. There is no replacement
+severity field.
+
+## Availability and configuration
+
+Local vision is required for every new checkup after cutover. An absent, stopped,
+unreachable or incompatible service never silently falls back to the cloud-only
+pipeline. The cloud Vision Explainer is optional after local evidence exists; with no
+AI task configured, the visual comparison, environmental evidence and fusion outcome
+remain a complete result.
+
+Runtime status is a tagged projection:
+
+```text
+VisionStatus {
+  availability: "ready" | "unavailable" | "incompatible"
+  reason?: "not_installed" | "not_running" | "not_configured" |
+           "unreachable" | "schema_mismatch" | "model_unavailable"
+  connection_source: "supervisor" | "manual"
+  service_version?, vision_schema_version?
+  model?: { id, version, dimension }
+}
+```
+
+The integration probes `/info` and `/models` during setup or reload, periodically in
+its coordinator, and immediately before a manual checkup when the cached state is
+stale. `get_vision_status` only reads that cache. The card displays the state and
+model read-only, keeps camera and schedule editing available while disconnected, and
+disables only **Run now** unless availability is `ready`.
+
+Connection settings are integration-wide config-entry options, never repeated on a
+growspace or exposed with their bearer token to the card. `connection_mode` is
+`automatic` or `manual`: automatic pulls Supervisor discovery through `AddonManager`;
+manual exclusively uses the configured endpoint and token. Switching to automatic
+clears manual credentials, so there is no silent fallback to an unintended service.
+
+Per-growspace `VisionCheckupConfig` retains only `enabled` and the early, mid and late
+schedule. Its old `history_limit` remains accepted for legacy deserialization but is
+absent from the V1 public config; evidence retention and history page size are
+different concerns. The inert global `ai_settings.vision_checkup_enabled` is removed.
+`ai_settings.vision_explainer_sees_image` controls only the optional observation
+pass. Baseline size, scoring cuts, freshness, persistence and frame-quality policy are
+versioned constants rather than user-editable thresholds.
+
+The existing growspace Vision Checkup sensor keeps its entity identity but no longer
+pretends several cameras have one severity. Its state becomes the latest checkup's
+operational outcome (`completed`, `partial`, `failed` or `unavailable`) and its
+attributes expose per-camera fusion summaries. Automations that need a particular
+camera consume those explicit summaries.
+
+## Zero-gap rollout and ordered file plan
+
+The migration uses three release phases. The first lands the additive backend
+contract without changing the live cloud-era producer. The second releases a card
+that understands both contracts. Only the third cuts production over to local vision
+and freezes legacy history. This preserves backend-first contract development without
+creating a release window in which newly produced results disappear from the
+installed card.
+
+### Phase 1 — additive backend foundation
+
+1. **HTTP boundary:** add
+   `custom_components/growspace_manager/vision_models.py` and `vision_client.py`.
+   Parse the normative Growspace Vision V1 fixtures strictly, negotiate `/info`, load
+   `/models`, send one image per `/analyze`, and map typed transport, protocol,
+   quality-rejection and service errors. Cover them in
+   `tests/test_vision_client.py` and `tests/test_vision_models.py`.
+2. **Durable evidence:** amend
+   `custom_components/growspace_manager/models/vision_evidence.py` and
+   `custom_components/growspace_manager/data_access/vision_evidence_schema.py` with
+   the Vision Checkup record and capture foreign key, then implement
+   `custom_components/growspace_manager/data_access/vision_evidence_store.py`. Add repository, migration, grouping,
+   retention and failure-order tests beside `tests/test_vision_evidence_schema.py`.
+3. **Pure decisions:** complete
+   `custom_components/growspace_manager/domain/evidence_fusion.py` and add a pure
+   `custom_components/growspace_manager/domain/vision_comparison.py`. Extend
+   `custom_components/growspace_manager/notifications/evaluation_snapshot.py` with
+   evaluation time and observation sufficiency, retain both active and inactive
+   snapshots in `notification_manager.py`, and normalize them in a new
+   `domain/environmental_evidence.py` so `within_evaluated_range` can be proved. Add
+   `tests/domain/test_evidence_fusion.py`, `test_vision_comparison.py` and
+   `test_environmental_evidence.py` for every ADR 0040 truth-table cell, freshness
+   boundary, persistence rule, provenance reset and seven-entry trend boundary.
+4. **Connection lifecycle:** centralize the unstable Home Assistant `AddonManager`
+   import and cached status in
+   `custom_components/growspace_manager/vision_connection.py`; add connection options
+   and translations through `custom_components/growspace_manager/const.py`,
+   `config_flow.py`, `config_handlers/ai_config_handler.py`, `strings.json` and
+   `translations/en.json`. Construct and close the client/store/status collaborators
+   in `coordinator_builder.py`, `coordinator.py` and `__init__.py`. Add
+   `tests/test_vision_connection.py` and config-flow coverage for HAOS pull discovery,
+   manual precedence, credential clearing, cache refresh and every status reason.
+5. **Additive projection:** add one serializer shared by
+   `custom_components/growspace_manager/presentation/vision.py` and consume it from
+   `custom_components/growspace_manager/websocket/vision.py`,
+   `custom_components/growspace_manager/services/vision_checkup.py` and
+   `custom_components/growspace_manager/sensor/vision.py`; register
+   `get_vision_status` and `get_vision_history_v2` while leaving the old producer and
+   old history command intact. Cover the projection in
+   `tests/presentation/test_vision.py`, `tests/core/test_websocket_snapshots.py`,
+   `tests/services/test_vision_checkup.py` and `tests/test_vision_sensor.py`. This also
+   fixes the current trigger-response drift in which the card requires
+   `snapshot_paths` but the service omits it.
+6. **Executable contract:** add backend-generated
+   `tests/fixtures/contract/vision_status_response.json`,
+   `vision_history_response.json` and `trigger_vision_checkup_response.json`, plus a
+   `tests/contract/test_vision_contract.py` generator test. Fixtures cover ready and
+   unavailable status, V1 completed/partial/rejected/failed captures, mixed legacy
+   history, pruned images and both trigger response branches.
+
+Phase 1 passes the Vision contract fixtures, targeted store/fusion/client tests and
+the full backend gate. It is additive: the released card continues to parse every
+old response and the live producer still writes its legacy list.
+
+### Phase 2 — dual-contract card
+
+7. **Schemas and state:** replace the cloud-only shape in
+   `src/slices/camera/schema.ts` with the discriminated V1/legacy union and status
+   schemas. Update `src/slices/camera/index.ts` so `visionHistory$` holds checkup
+   envelopes, or remove the atom if the dialog remains its only real consumer. Remove
+   the unused duplicate Vision result interface in `src/lib/types/dialog.ts`. Extend
+   `src/slices/camera/camera.slice.test.ts`.
+8. **Contract CI:** extend `.github/workflows/contract-fixture.yml` and
+   `tests/contract/contract-fixture.test.ts` to fetch and validate all four backend
+   fixtures from the current `prerelease` branch and latest published backend release.
+   Against the release ref, the card's V1 fields and commands remain optional and it
+   falls back to the legacy command; against `prerelease`, every emitted key is
+   declared. This is the executable proof that the card phase is backward-safe.
+9. **Configuration and gating:** carry status through the config-dialog shell and
+   extend `src/features/config/viewmodels/vision-tab.viewmodel.ts` and
+   `src/features/config/components/config-vision-tab.ts` with the read-only connection
+   banner and model version. Remove the inert global switch from
+   `src/dialogs/gm-settings-panel.ts`; add the explainer-image setting instead. Update
+   `src/slices/growspace/schema.ts`, `src/adapters/growspace-adapter.ts`,
+   `src/dialogs/config-dialog-sm.ts`,
+   `src/features/config/environment-persistence.ts` and
+   `src/dialogs/config-dialog.ts` only for the remaining per-growspace schedule fields.
+10. **History UI:** replace severity-only projection in
+    `src/features/camera/viewmodels/snapshots-dialog.viewmodel.ts` and
+    `src/dialogs/snapshots-dialog.ts` with capture evidence, fusion, confidence, coverage,
+    trend, provenance, image-unavailable handling and the explicit legacy branch.
+    Resolve `media_content_id` through Home Assistant rather than constructing a
+    `/local/` path. Cover multi-camera, partial, rejected, failed, disconnected,
+    incompatible, legacy and mixed-history cases in the colocated view-model and
+    component tests, then extend `tests/e2e/specs/vision-camera-profile.spec.ts`.
+
+Phase 2 passes the release-ref backward-safety fixtures, prerelease completeness
+fixtures, card fast checks and browser coverage against the additive backend. It may
+release before the cutover because all new calls are capability-detected and the
+legacy fallback is covered by the released fixtures.
+
+### Phase 3 — backend cutover
+
+11. **One orchestrator:** refactor
+    `custom_components/growspace_manager/vision_checkup_scheduler.py` so it owns
+    timing and delegates one capture at a time: persist checkup and capture, call local vision,
+    compare, assemble fresh environmental evidence, fuse, optionally explain, store,
+    and serialize. It stops requiring an AI task, stops appending
+    `vision_checkup_history`, stops the cloud severity notification path, and never
+    falls back to the old prompt. Update
+    `custom_components/growspace_manager/services/vision_checkup.py`,
+    `custom_components/growspace_manager/websocket/vision.py`,
+    `custom_components/growspace_manager/sensor/vision.py`,
+    `custom_components/growspace_manager/services.yaml`,
+    `custom_components/growspace_manager/strings.json`,
+    `custom_components/growspace_manager/translations/en.json` and their
+    unit/integration tests.
+12. **Compatibility proof:** regenerate the three Vision fixtures from the live V1
+    producer, run the released-card fixture check against the additive compatibility
+    response, then run the dual-contract card against the cutover backend. The old
+    history command remains frozen and the trigger shim remains additive.
+
+Phase 3 passes the full backend and card gates, a real HA browser run with a
+multi-camera partial result, and an upgrade fixture containing ten legacy results.
+The timeline must remain readable, the App status and model must be visible, and no
+legacy claim may enter a V1 comparison, fusion, trend or explainer input.
+
+## Rejected alternatives
+
+- **One aggregate verdict per growspace:** rejected because the evidence, failure and
+  provenance boundaries are per capture; aggregation would invent a policy not
+  supplied by any model.
+- **Mutate or copy legacy rows into SQLite:** rejected by ADR 0041; they lack capture
+  identity and assert claims V1 intentionally cannot make.
+- **Keep or rename severity:** rejected because fusion already provides the domain
+  state and presentation mapping; a second field can disagree and the cloud-era enum
+  cannot express the V1 `info`/`warning` semantics honestly.
+- **Put endpoint, token or thresholds on `VisionCheckupConfig`:** rejected because
+  connection is integration-wide, the token is secret, and policy versions—not user
+  inputs—define comparability.
+- **Cut the producer over in the first backend release:** rejected because the
+  installed card could trigger local work but could not display its result.
+- **Card-driven health checks:** rejected because runtime ownership and credentials
+  belong to the integration, not a presentation client.


### PR DESCRIPTION
## Summary

- define the capture-granular Vision Checkup V1 wire contract and multi-camera envelope
- preserve cloud-era history as an explicitly marked legacy union branch
- settle service status, configuration ownership, sensor semantics, compatibility, and zero-gap rollout
- name the ordered backend and card file-level implementation plan

## Validation

- `./scripts/check backend fast`: 5,291 tests and 44 snapshots passed; Ruff, formatting, and mypy passed
- changed-file pre-commit hooks: codespell and Prettier passed

Planning artifact for Venosta-web/growspace_manager_workspace#73.