### PR TITLE
feat(vision): implement durable evidence store

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -701,7 +701,7 @@ The four fields a [[Vision Explainer]] produces for one capture — `observation
 _Avoid_: Vision analysis, AI diagnosis, checkup result
 
 **Vision Evidence Store**
-The Home Assistant-owned SQLite database `growspace_vision.db` holding every artifact of a [[Vision Checkup]]: the checkup itself, [[Vision Capture]]s, their image files, Visual Embeddings, Visual Comparison Results, Baseline Buckets and [[Vision Label]]s. Growspace Vision is stateless, so this is the only durable record that the analysis happened. Versioned by `PRAGMA user_version` and migrated by forward-only numbered steps — deliberately not the `try: ALTER TABLE / except` pattern of `strain_library.py`, which records no version. See [ADR-0041](./docs/adr/0041-home-assistant-owns-vision-evidence-in-a-dedicated-store.md).
+The Home Assistant-owned SQLite database `growspace_vision.db` holding every artifact of a [[Vision Checkup]]: the checkup itself, [[Vision Capture]]s, their image files, Visual Embeddings, Visual Comparison Results, Baseline Buckets, [[Evidence Fusion Outcome]]s and [[Vision Label]]s. Growspace Vision is stateless, so this is the only durable record that the analysis happened. Versioned by `PRAGMA user_version` and migrated by forward-only numbered steps — deliberately not the `try: ALTER TABLE / except` pattern of `strain_library.py`, which records no version. See [ADR-0041](./docs/adr/0041-home-assistant-owns-vision-evidence-in-a-dedicated-store.md).
 _Avoid_: Vision history, embedding cache, anomaly database
 
 **Vision Capture**

--- a/custom_components/growspace_manager/__init__.py
+++ b/custom_components/growspace_manager/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 import logging
 import pathlib
 from typing import TYPE_CHECKING, Any
@@ -12,8 +13,10 @@ from homeassistant.components.frontend import (
 )
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
@@ -22,6 +25,10 @@ from . import service_registration
 from .const import CONF_SHOW_SIDEBAR, DOMAIN, PLATFORMS, STORAGE_KEY, STORAGE_VERSION
 from .coordinator import GrowspaceCoordinator
 from .coordinator_builder import CoordinatorBuilder
+from .data_access.vision_evidence_store import (
+    DEFAULT_IMAGE_RETENTION_DAYS,
+    VisionEvidenceStore,
+)
 from .exhaust_migration import evaluate_exhaust_migration_issues
 from .intent import async_setup_intents
 from .services.seedfinder_scraper import SeedfinderScraper
@@ -35,6 +42,9 @@ _LOGGER = logging.getLogger(__name__)
 
 _LEGACY_PLANT_MANUFACTURER = "Growspace Manager"
 _LEGACY_PLANT_MODEL_PREFIX = "Plant ("
+_VISION_EVIDENCE_STORE = "vision_evidence_store"
+_VISION_RETENTION_UNSUB = "vision_retention_unsub"
+_VISION_IMAGE_RETENTION_DAYS = "image_retention_days"
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -96,6 +106,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: GrowspaceConfigEntry) ->
                     )
                 ]
             )
+
+        await _async_setup_vision_evidence_store(hass, entry)
 
     # Retrieve global Strain Library and Scraper
     strain_library_instance = hass.data[DOMAIN]["strain_library"]
@@ -228,6 +240,49 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     await hass.config_entries.async_reload(entry.entry_id)
 
 
+async def _async_setup_vision_evidence_store(
+    hass: HomeAssistant, entry: GrowspaceConfigEntry
+) -> None:
+    """Open the global evidence store and schedule its daily image retention."""
+    media_dirs = hass.config.media_dirs
+    source_dir_id = "local" if "local" in media_dirs else next(iter(media_dirs), None)
+    if source_dir_id is None:
+        _LOGGER.error("No media directory is available for the Vision Evidence Store")
+        return
+
+    store = VisionEvidenceStore(
+        pathlib.Path(hass.config.path("growspace_vision.db")),
+        pathlib.Path(media_dirs[source_dir_id]) / "growspace_vision",
+        image_retention_days=int(
+            entry.options.get(
+                _VISION_IMAGE_RETENTION_DAYS, DEFAULT_IMAGE_RETENTION_DAYS
+            )
+        ),
+    )
+    try:
+        await store.async_setup()
+    except Exception:
+        # A damaged evidence corpus must not take the cultivation integration down.
+        _LOGGER.exception("Failed to open the Vision Evidence Store")
+        return
+
+    hass.data[DOMAIN][_VISION_EVIDENCE_STORE] = store
+
+    async def _async_close_store(_event: Event) -> None:
+        await store.async_close()
+
+    async def _async_run_retention(now: datetime) -> None:
+        try:
+            await store.async_run_retention(now)
+        except Exception:
+            _LOGGER.exception("Vision image retention failed")
+
+    hass.data[DOMAIN][_VISION_RETENTION_UNSUB] = async_track_time_interval(
+        hass, _async_run_retention, timedelta(days=1), cancel_on_shutdown=True
+    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_close_store)
+
+
 async def async_register_sidebar_panel(
     hass: HomeAssistant, entry: GrowspaceConfigEntry
 ) -> None:
@@ -293,6 +348,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: GrowspaceConfigEntry) -
 
         # Clean up global Strain Library and Scraper
         if DOMAIN in hass.data:
+            if _VISION_RETENTION_UNSUB in hass.data[DOMAIN]:
+                hass.data[DOMAIN].pop(_VISION_RETENTION_UNSUB)()
+            if _VISION_EVIDENCE_STORE in hass.data[DOMAIN]:
+                await hass.data[DOMAIN].pop(_VISION_EVIDENCE_STORE).async_close()
             if "strain_library" in hass.data[DOMAIN]:
                 await hass.data[DOMAIN]["strain_library"].async_close()
                 del hass.data[DOMAIN]["strain_library"]

--- a/custom_components/growspace_manager/data_access/vision_evidence_schema.py
+++ b/custom_components/growspace_manager/data_access/vision_evidence_schema.py
@@ -1,10 +1,9 @@
 """SQLite schema for the Vision Evidence Store.
 
 Home Assistant owns every artifact of a Vision Checkup because Growspace Vision is
-stateless (ADR 0003).  This module holds the schema alone: the DDL, its version, and
-the vocabulary its ``CHECK`` constraints enforce.  Connection handling, migrations and
-queries live in ``vision_evidence_store.py``, which is deliberately deferred until the
-Visual Comparison Result producer exists — see ADR 0041.
+stateless (ADR 0003). This module holds the schema alone: the DDL, its version,
+numbered migrations, and the vocabulary its ``CHECK`` constraints enforce.
+Connection handling and queries live in ``vision_evidence_store.py``.
 
 The schema is versioned through ``PRAGMA user_version`` and migrated by forward-only
 numbered steps.  This is a deliberate departure from ``strain_library.py``, which
@@ -67,12 +66,34 @@ CREATE TABLE IF NOT EXISTS vision_grow_run_ref (
     source       TEXT NOT NULL CHECK (source IN ('surrogate', 'grow_run'))
 );
 
+-- One growspace-level observation task.  Captures are grouped by identity rather
+-- than timestamp coincidence because simultaneous checks, retries and slow cameras
+-- make timestamps unable to reconstruct a multi-camera domain event (ADR 0043).
+CREATE TABLE IF NOT EXISTS vision_checkup (
+    checkup_id     TEXT PRIMARY KEY,
+    growspace_id   TEXT NOT NULL,
+    growspace_name TEXT NOT NULL,
+    trigger_source TEXT NOT NULL
+                   CHECK (trigger_source IN ('scheduled', 'manual')),
+    light_window   TEXT NOT NULL
+                   CHECK (light_window IN ('early', 'mid', 'late', 'manual')),
+    started_at     TEXT NOT NULL,
+    completed_at   TEXT,
+    status         TEXT CHECK (status IS NULL
+                               OR status IN ('completed', 'partial', 'failed')),
+    CHECK ((completed_at IS NULL) = (status IS NULL))
+);
+CREATE INDEX IF NOT EXISTS idx_vision_checkup_growspace_time
+    ON vision_checkup (growspace_id, started_at);
+
 -- One Camera Snapshot taken for a Vision Checkup.  Written BEFORE the Growspace
 -- Vision call, at the moment the bytes are persisted, so a failed or rejected
 -- analysis still leaves the image tracked and prunable.  `growspace_name` is
 -- denormalized so a labelled capture stays readable after its Growspace is deleted.
 CREATE TABLE IF NOT EXISTS vision_capture (
     capture_id            TEXT PRIMARY KEY,
+    checkup_id            TEXT NOT NULL
+                          REFERENCES vision_checkup (checkup_id),
     growspace_id          TEXT NOT NULL,
     growspace_name        TEXT NOT NULL,
     camera_id             TEXT NOT NULL,
@@ -168,7 +189,7 @@ CREATE TABLE IF NOT EXISTS vision_baseline_bucket (
     scoring_policy_version INTEGER NOT NULL,
     created_at            TEXT NOT NULL,
     UNIQUE (camera_id, light_window, grow_run_id, model_id, model_version,
-            framing_epoch_id)
+            framing_epoch_id, scoring_policy_version)
 );
 
 -- Membership is recorded, not derived.  Admission is history-dependent — during
@@ -233,6 +254,42 @@ CREATE TABLE IF NOT EXISTS vision_comparison_result (
 CREATE INDEX IF NOT EXISTS idx_vision_result_capture
     ON vision_comparison_result (capture_id, evaluated_at);
 
+-- The capture-specific Evidence Fusion Outcome and the normalized environmental
+-- evidence used to produce it.  This row exists even when the optional cloud
+-- explainer is disabled, and remains additive across scoring-policy changes.
+CREATE TABLE IF NOT EXISTS vision_fusion_outcome (
+    outcome_id               TEXT PRIMARY KEY,
+    capture_id               TEXT NOT NULL
+                             REFERENCES vision_capture (capture_id) ON DELETE CASCADE,
+    evaluated_at             TEXT NOT NULL,
+    scoring_policy_version   INTEGER NOT NULL,
+    environmental_verdict    TEXT NOT NULL
+                             CHECK (environmental_verdict IN (
+                                 'risk', 'within_evaluated_range', 'unavailable')),
+    environmental_evaluated_at TEXT,
+    stress_reasons           TEXT NOT NULL,
+    mold_reasons             TEXT NOT NULL,
+    fusion_state             TEXT
+                             CHECK (fusion_state IS NULL OR fusion_state IN (
+                                 'no_detected_change',
+                                 'environmental_risk',
+                                 'visual_anomaly',
+                                 'concurrent_environmental_risk_and_visual_anomaly',
+                                 'persistent_visual_anomaly')),
+    fusion_confidence        TEXT
+                             CHECK (fusion_confidence IS NULL
+                                    OR fusion_confidence IN ('confirmed', 'monitor')),
+    fusion_coverage          TEXT
+                             CHECK (fusion_coverage IS NULL
+                                    OR fusion_coverage IN ('complete', 'partial')),
+    unavailable_reasons      TEXT NOT NULL,
+    CHECK ((fusion_state IS NULL) = (fusion_confidence IS NULL)),
+    CHECK ((fusion_state IS NULL) = (fusion_coverage IS NULL)),
+    UNIQUE (capture_id, scoring_policy_version)
+);
+CREATE INDEX IF NOT EXISTS idx_vision_fusion_capture
+    ON vision_fusion_outcome (capture_id, evaluated_at);
+
 -- The Vision Explainer's narrative for one capture (ADR 0042).  Separate from the
 -- capture because the explainer is optional: the evidence rows are a complete
 -- report without it, and a growspace with no AI task configured simply has no rows
@@ -271,7 +328,7 @@ CREATE TABLE IF NOT EXISTS vision_explainer_report (
                                   'environmental_risk',
                                   'visual_anomaly',
                                   'concurrent_environmental_risk_and_visual_anomaly',
-                                  'critical_scene_issue')),
+                                  'persistent_visual_anomaly')),
     fusion_confidence  TEXT
                        CHECK (fusion_confidence IS NULL
                               OR fusion_confidence IN ('confirmed', 'monitor')),
@@ -329,3 +386,7 @@ CREATE TABLE IF NOT EXISTS vision_label (
 CREATE INDEX IF NOT EXISTS idx_vision_label_capture
     ON vision_label (capture_id, created_at);
 """
+
+# Index N contains the DDL that migrates schema version N to N + 1.  Keep steps
+# append-only: an installed database advances through every intermediate version.
+VISION_EVIDENCE_MIGRATIONS: Final = (VISION_EVIDENCE_SCHEMA,)

--- a/custom_components/growspace_manager/data_access/vision_evidence_store.py
+++ b/custom_components/growspace_manager/data_access/vision_evidence_store.py
@@ -1,0 +1,1338 @@
+"""Durable repository for Home Assistant-owned vision evidence."""
+
+# Transaction bodies deliberately raise into their adjacent rollback handlers.
+# ruff: noqa: TRY301
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+import hashlib
+import json
+import logging
+from pathlib import Path
+import uuid
+
+import aiosqlite
+
+from custom_components.growspace_manager.models.vision_evidence import (
+    AdmissionPhase,
+    AnalysisState,
+    BaselineBucket,
+    BaselineMember,
+    BaselineState,
+    CaptureFileVariant,
+    CaptureTrigger,
+    CheckupStatus,
+    ComparisonOutcome,
+    ComparisonVerdict,
+    EmbeddingSource,
+    FileDeletionReason,
+    LabelKind,
+    LightState,
+    LightWindow,
+    ObservationSource,
+    VisionCapture,
+    VisionCaptureFile,
+    VisionCheckup,
+    VisionEmbedding,
+    VisionExplainerReport,
+    VisionFusionOutcome,
+    VisionLabel,
+    VisualComparisonResult,
+)
+
+from .vision_evidence_schema import (
+    VISION_EVIDENCE_MIGRATIONS,
+    VISION_EVIDENCE_SCHEMA_VERSION,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_IMAGE_RETENTION_DAYS = 90
+
+
+class VisionEvidenceSchemaTooNewError(RuntimeError):
+    """Raised when a database was written by newer integration code."""
+
+
+class VisionEvidenceStore:
+    """Own the vision evidence database and its private image corpus."""
+
+    def __init__(
+        self,
+        database_path: Path,
+        image_root: Path,
+        *,
+        image_retention_days: int = DEFAULT_IMAGE_RETENTION_DAYS,
+    ) -> None:
+        """Initialize paths without opening resources."""
+        self._database_path = database_path
+        self._image_root = image_root
+        self._image_retention_days = image_retention_days
+        self._db: aiosqlite.Connection | None = None
+        self._write_lock = asyncio.Lock()
+
+    @staticmethod
+    def mint_capture_id() -> str:
+        """Mint the time-ordered identity used before a Vision Analysis call."""
+        return str(uuid.uuid7())
+
+    @staticmethod
+    def mint_checkup_id() -> str:
+        """Mint the time-ordered identity of a growspace observation task."""
+        return str(uuid.uuid7())
+
+    async def async_setup(self) -> None:
+        """Open the database and apply every pending forward migration."""
+        await asyncio.to_thread(
+            self._database_path.parent.mkdir, parents=True, exist_ok=True
+        )
+        await asyncio.to_thread(self._image_root.mkdir, parents=True, exist_ok=True)
+
+        connection = await aiosqlite.connect(self._database_path)
+        connection.row_factory = aiosqlite.Row
+        try:
+            await connection.execute("PRAGMA foreign_keys = ON")
+            await connection.execute("PRAGMA journal_mode = WAL")
+            await connection.execute("PRAGMA synchronous = NORMAL")
+            row = await (await connection.execute("PRAGMA user_version")).fetchone()
+            if row is None:  # pragma: no cover - SQLite PRAGMA always returns one row
+                raise RuntimeError("SQLite did not report a schema version")
+            current_version = int(row[0])
+            if current_version > VISION_EVIDENCE_SCHEMA_VERSION:
+                raise VisionEvidenceSchemaTooNewError(
+                    "Vision evidence schema "
+                    f"{current_version} is newer than supported version "
+                    f"{VISION_EVIDENCE_SCHEMA_VERSION}"
+                )
+            while current_version < VISION_EVIDENCE_SCHEMA_VERSION:
+                migration = VISION_EVIDENCE_MIGRATIONS[current_version]
+                next_version = current_version + 1
+                await connection.executescript(
+                    "BEGIN IMMEDIATE;\n"
+                    f"{migration}\n"
+                    f"PRAGMA user_version = {next_version};\n"
+                    "COMMIT;"
+                )
+                current_version = next_version
+            self._db = connection
+            await self.async_prune_images(
+                image_retention_days=self._image_retention_days,
+                now=datetime.now(UTC),
+            )
+        except Exception:
+            await connection.close()
+            self._db = None
+            raise
+
+    async def async_run_retention(self, now: datetime | None = None) -> int:
+        """Run the configured retention policy for setup and daily scheduling."""
+        return await self.async_prune_images(
+            image_retention_days=self._image_retention_days,
+            now=now or datetime.now(UTC),
+        )
+
+    async def async_close(self) -> None:
+        """Close the database connection, if open."""
+        if self._db is None:
+            return
+        await self._db.close()
+        self._db = None
+
+    async def async_start_capture(
+        self,
+        *,
+        capture_id: str,
+        checkup_id: str,
+        growspace_id: str,
+        growspace_name: str,
+        camera_id: str,
+        captured_at: datetime,
+        light_window: LightWindow,
+        light_state: LightState,
+        trigger_source: CaptureTrigger,
+        image: bytes,
+        content_type: str,
+    ) -> VisionCapture:
+        """Persist an image and its pending capture before analysis begins."""
+        parsed_id = uuid.UUID(capture_id)
+        if parsed_id.version != 7 or str(parsed_id) != capture_id:
+            raise ValueError("capture_id must be a canonical UUIDv7 string")
+        if captured_at.tzinfo is None:
+            raise ValueError("captured_at must be timezone-aware")
+
+        extension = _extension_for_content_type(content_type)
+        relative_path = Path(growspace_id, camera_id, f"{capture_id}.raw{extension}")
+        destination = self._resolve_image_path(relative_path.as_posix())
+        temporary = destination.with_name(f".{destination.name}.{uuid.uuid4().hex}.tmp")
+        captured_at_text = captured_at.astimezone(UTC).isoformat()
+        created_at = datetime.now(UTC).isoformat()
+
+        await asyncio.to_thread(destination.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(temporary.write_bytes, image)
+
+        moved = False
+        try:
+            async with self._write_lock:
+                db = self._require_db()
+                await db.execute("BEGIN IMMEDIATE")
+                try:
+                    grow_run_id = await self._async_get_or_create_grow_run(
+                        growspace_id, captured_at_text
+                    )
+                    framing_epoch_id = await self._async_get_or_create_epoch(
+                        growspace_id, camera_id, captured_at_text
+                    )
+                    checkup_cursor = await db.execute(
+                        "SELECT growspace_id, trigger_source, light_window"
+                        " FROM vision_checkup WHERE checkup_id = ?",
+                        (checkup_id,),
+                    )
+                    checkup = await checkup_cursor.fetchone()
+                    if checkup is None:
+                        raise KeyError(f"Vision Checkup {checkup_id} does not exist")
+                    if (
+                        checkup["growspace_id"] != growspace_id
+                        or checkup["trigger_source"] != trigger_source.value
+                        or checkup["light_window"] != light_window.value
+                    ):
+                        raise ValueError("Capture metadata does not match its checkup")
+                    await db.execute(
+                        "INSERT INTO vision_capture"
+                        " (capture_id, checkup_id, growspace_id, growspace_name, camera_id,"
+                        " grow_run_id, framing_epoch_id, captured_at, light_window,"
+                        " light_state, trigger_source, content_sha256, analysis_state,"
+                        " quality_reasons, created_at)"
+                        " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        (
+                            capture_id,
+                            checkup_id,
+                            growspace_id,
+                            growspace_name,
+                            camera_id,
+                            grow_run_id,
+                            framing_epoch_id,
+                            captured_at_text,
+                            light_window.value,
+                            light_state.value,
+                            trigger_source.value,
+                            hashlib.sha256(image).hexdigest(),
+                            AnalysisState.PENDING.value,
+                            "[]",
+                            created_at,
+                        ),
+                    )
+                    await db.execute(
+                        "INSERT INTO vision_capture_file"
+                        " (capture_id, variant, relative_path, byte_size, content_type)"
+                        " VALUES (?, ?, ?, ?, ?)",
+                        (
+                            capture_id,
+                            CaptureFileVariant.RAW.value,
+                            relative_path.as_posix(),
+                            len(image),
+                            content_type,
+                        ),
+                    )
+                    if await asyncio.to_thread(destination.exists):
+                        raise FileExistsError(destination)
+                    await asyncio.to_thread(temporary.replace, destination)
+                    moved = True
+                    await db.commit()
+                except Exception:
+                    await db.rollback()
+                    raise
+        except Exception:
+            if moved:
+                await asyncio.to_thread(destination.unlink, missing_ok=True)
+            raise
+        finally:
+            await asyncio.to_thread(temporary.unlink, missing_ok=True)
+
+        capture = await self.async_get_capture(capture_id)
+        if capture is None:  # pragma: no cover - guarded by the transaction above
+            raise RuntimeError(f"Capture {capture_id} disappeared after commit")
+        return capture
+
+    async def async_start_checkup(
+        self,
+        *,
+        checkup_id: str,
+        growspace_id: str,
+        growspace_name: str,
+        trigger_source: CaptureTrigger,
+        light_window: LightWindow,
+        started_at: datetime,
+    ) -> VisionCheckup:
+        """Persist a pending Vision Checkup before any camera is captured."""
+        parsed_id = uuid.UUID(checkup_id)
+        if parsed_id.version != 7 or str(parsed_id) != checkup_id:
+            raise ValueError("checkup_id must be a canonical UUIDv7 string")
+        if started_at.tzinfo is None:
+            raise ValueError("started_at must be timezone-aware")
+        async with self._write_lock:
+            db = self._require_db()
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                await db.execute(
+                    "INSERT INTO vision_checkup"
+                    " (checkup_id, growspace_id, growspace_name, trigger_source,"
+                    " light_window, started_at) VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        checkup_id,
+                        growspace_id,
+                        growspace_name,
+                        trigger_source.value,
+                        light_window.value,
+                        started_at.astimezone(UTC).isoformat(),
+                    ),
+                )
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+        checkup = await self.async_get_checkup(checkup_id)
+        if checkup is None:  # pragma: no cover - guarded by the insert above
+            raise RuntimeError(f"Vision Checkup {checkup_id} disappeared after commit")
+        return checkup
+
+    async def async_finish_checkup(
+        self,
+        checkup_id: str,
+        *,
+        status: CheckupStatus,
+        completed_at: datetime,
+    ) -> VisionCheckup:
+        """Record the operational outcome of a Vision Checkup."""
+        if completed_at.tzinfo is None:
+            raise ValueError("completed_at must be timezone-aware")
+        async with self._write_lock:
+            db = self._require_db()
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = await db.execute(
+                    "UPDATE vision_checkup SET completed_at = ?, status = ?"
+                    " WHERE checkup_id = ? AND status IS NULL",
+                    (
+                        completed_at.astimezone(UTC).isoformat(),
+                        status.value,
+                        checkup_id,
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise KeyError(f"Pending Vision Checkup {checkup_id} not found")
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+        checkup = await self.async_get_checkup(checkup_id)
+        if checkup is None:  # pragma: no cover - guarded by the update above
+            raise RuntimeError(f"Vision Checkup {checkup_id} disappeared after commit")
+        return checkup
+
+    async def async_get_checkup(self, checkup_id: str) -> VisionCheckup | None:
+        """Return a Vision Checkup by identity."""
+        cursor = await self._require_db().execute(
+            "SELECT * FROM vision_checkup WHERE checkup_id = ?", (checkup_id,)
+        )
+        row = await cursor.fetchone()
+        return _checkup_from_row(row) if row is not None else None
+
+    async def async_get_checkup_captures(self, checkup_id: str) -> list[VisionCapture]:
+        """Return a checkup's captures in capture-time order."""
+        cursor = await self._require_db().execute(
+            "SELECT * FROM vision_capture WHERE checkup_id = ?"
+            " ORDER BY captured_at, capture_id",
+            (checkup_id,),
+        )
+        return [_capture_from_row(row) for row in await cursor.fetchall()]
+
+    async def async_get_capture(self, capture_id: str) -> VisionCapture | None:
+        """Return a capture by identity."""
+        cursor = await self._require_db().execute(
+            "SELECT * FROM vision_capture WHERE capture_id = ?", (capture_id,)
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return _capture_from_row(row)
+
+    async def async_get_capture_files(self, capture_id: str) -> list[VisionCaptureFile]:
+        """Return every recorded image variant for a capture."""
+        cursor = await self._require_db().execute(
+            "SELECT * FROM vision_capture_file WHERE capture_id = ? ORDER BY variant",
+            (capture_id,),
+        )
+        return [_capture_file_from_row(row) for row in await cursor.fetchall()]
+
+    async def async_add_capture_file(
+        self,
+        capture_id: str,
+        *,
+        variant: CaptureFileVariant,
+        image: bytes,
+        content_type: str,
+    ) -> VisionCaptureFile:
+        """Persist and index another rendering of an existing capture."""
+        extension = _extension_for_content_type(content_type)
+        db = self._require_db()
+        cursor = await db.execute(
+            "SELECT growspace_id, camera_id FROM vision_capture WHERE capture_id = ?",
+            (capture_id,),
+        )
+        capture = await cursor.fetchone()
+        if capture is None:
+            raise KeyError(f"Capture {capture_id} does not exist")
+        relative_path = Path(
+            capture["growspace_id"],
+            capture["camera_id"],
+            f"{capture_id}.{variant.value}{extension}",
+        )
+        destination = self._resolve_image_path(relative_path.as_posix())
+        temporary = destination.with_name(f".{destination.name}.{uuid.uuid4().hex}.tmp")
+        await asyncio.to_thread(destination.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(temporary.write_bytes, image)
+        moved = False
+        try:
+            async with self._write_lock:
+                await db.execute("BEGIN IMMEDIATE")
+                try:
+                    await db.execute(
+                        "INSERT INTO vision_capture_file"
+                        " (capture_id, variant, relative_path, byte_size, content_type)"
+                        " VALUES (?, ?, ?, ?, ?)",
+                        (
+                            capture_id,
+                            variant.value,
+                            relative_path.as_posix(),
+                            len(image),
+                            content_type,
+                        ),
+                    )
+                    if await asyncio.to_thread(destination.exists):
+                        raise FileExistsError(destination)
+                    await asyncio.to_thread(temporary.replace, destination)
+                    moved = True
+                    await db.commit()
+                except Exception:
+                    await db.rollback()
+                    raise
+        except Exception:
+            if moved:
+                await asyncio.to_thread(destination.unlink, missing_ok=True)
+            raise
+        finally:
+            await asyncio.to_thread(temporary.unlink, missing_ok=True)
+        files = await self.async_get_capture_files(capture_id)
+        return next(item for item in files if item.variant is variant)
+
+    async def async_record_analysis(
+        self,
+        capture: VisionCapture,
+        *,
+        embedding: VisionEmbedding | None = None,
+        comparison: VisualComparisonResult | None = None,
+        bucket: BaselineBucket | None = None,
+        member: BaselineMember | None = None,
+    ) -> None:
+        """Commit one analysis and all evidence it produced atomically."""
+        capture_id = capture.capture_id
+        for record in (embedding, comparison, member):
+            if record is not None and record.capture_id != capture_id:
+                raise ValueError("Every analysis artifact must belong to the capture")
+        if member is not None and (
+            bucket is None or member.bucket_id != bucket.bucket_id
+        ):
+            raise ValueError("Baseline membership requires its matching bucket")
+        if comparison is not None and comparison.bucket_id is not None:
+            if bucket is None or comparison.bucket_id != bucket.bucket_id:
+                raise ValueError("Comparison bucket must be part of the same write")
+        if (
+            embedding is not None
+            and len(embedding.values_f32) != embedding.dimension * 4
+        ):
+            raise ValueError("Embedding byte length must equal dimension * 4")
+
+        async with self._write_lock:
+            db = self._require_db()
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = await db.execute(
+                    "UPDATE vision_capture SET"
+                    " analysis_state = ?, analysis_error_code = ?, request_id = ?,"
+                    " vision_schema_version = ?, service_version = ?,"
+                    " quality_mean_luminance = ?,"
+                    " quality_clipped_pixel_fraction = ?,"
+                    " quality_mean_absolute_gradient = ?, quality_reasons = ?"
+                    " WHERE capture_id = ?",
+                    (
+                        capture.analysis_state.value,
+                        capture.analysis_error_code,
+                        capture.request_id,
+                        capture.vision_schema_version,
+                        capture.service_version,
+                        capture.quality_mean_luminance,
+                        capture.quality_clipped_pixel_fraction,
+                        capture.quality_mean_absolute_gradient,
+                        json.dumps(capture.quality_reasons),
+                        capture_id,
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise KeyError(f"Capture {capture_id} does not exist")
+                if embedding is not None:
+                    await self._async_insert_embedding(embedding)
+                if bucket is not None:
+                    await self._async_upsert_bucket(bucket)
+                if comparison is not None:
+                    await self._async_insert_comparison(comparison)
+                if member is not None:
+                    await self._async_insert_member(member)
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+
+    async def async_get_embedding(
+        self, capture_id: str, model_id: str, model_version: str
+    ) -> VisionEmbedding | None:
+        """Return one model-specific embedding for a capture."""
+        cursor = await self._require_db().execute(
+            "SELECT * FROM vision_embedding"
+            " WHERE capture_id = ? AND model_id = ? AND model_version = ?",
+            (capture_id, model_id, model_version),
+        )
+        row = await cursor.fetchone()
+        return _embedding_from_row(row) if row is not None else None
+
+    async def async_get_comparison_results(
+        self, capture_id: str
+    ) -> list[VisualComparisonResult]:
+        """Return every additive scoring-policy result for a capture."""
+        cursor = await self._require_db().execute(
+            "SELECT * FROM vision_comparison_result"
+            " WHERE capture_id = ? ORDER BY evaluated_at, result_id",
+            (capture_id,),
+        )
+        return [_comparison_from_row(row) for row in await cursor.fetchall()]
+
+    async def async_record_fusion_outcome(self, outcome: VisionFusionOutcome) -> None:
+        """Persist capture-specific environmental and fusion evidence."""
+        async with self._write_lock:
+            db = self._require_db()
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                await db.execute(
+                    "INSERT INTO vision_fusion_outcome"
+                    " (outcome_id, capture_id, evaluated_at, scoring_policy_version,"
+                    " environmental_verdict, environmental_evaluated_at, stress_reasons,"
+                    " mold_reasons, fusion_state, fusion_confidence, fusion_coverage,"
+                    " unavailable_reasons) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        outcome.outcome_id,
+                        outcome.capture_id,
+                        outcome.evaluated_at,
+                        outcome.scoring_policy_version,
+                        outcome.environmental_verdict,
+                        outcome.environmental_evaluated_at,
+                        json.dumps(outcome.stress_reasons),
+                        json.dumps(outcome.mold_reasons),
+                        outcome.fusion_state,
+                        outcome.fusion_confidence,
+                        outcome.fusion_coverage,
+                        json.dumps(outcome.unavailable_reasons),
+                    ),
+                )
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+
+    async def async_get_fusion_outcomes(
+        self, capture_id: str
+    ) -> list[VisionFusionOutcome]:
+        """Return additive fusion outcomes for one capture."""
+        cursor = await self._require_db().execute(
+            "SELECT * FROM vision_fusion_outcome WHERE capture_id = ?"
+            " ORDER BY evaluated_at, outcome_id",
+            (capture_id,),
+        )
+        return [_fusion_from_row(row) for row in await cursor.fetchall()]
+
+    async def async_add_explainer_report(self, report: VisionExplainerReport) -> None:
+        """Persist optional explainer prose with its fusion snapshot."""
+        async with self._write_lock:
+            db = self._require_db()
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                await db.execute(
+                    "INSERT INTO vision_explainer_report"
+                    " (report_id, capture_id, created_at, ai_task_entity_id,"
+                    " observation_source, scoring_policy_version, observation,"
+                    " environmental_risk, hypothesis, recommendations, fusion_state,"
+                    " fusion_confidence, fusion_coverage, fusion_unavailable_reasons)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        report.report_id,
+                        report.capture_id,
+                        report.created_at,
+                        report.ai_task_entity_id,
+                        report.observation_source.value,
+                        report.scoring_policy_version,
+                        report.observation,
+                        report.environmental_risk,
+                        report.hypothesis,
+                        json.dumps(report.recommendations),
+                        report.fusion_state,
+                        report.fusion_confidence,
+                        report.fusion_coverage,
+                        json.dumps(report.fusion_unavailable_reasons),
+                    ),
+                )
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+
+    async def async_get_explainer_reports(
+        self, capture_id: str
+    ) -> list[VisionExplainerReport]:
+        """Return optional explainer reports for one capture."""
+        cursor = await self._require_db().execute(
+            "SELECT * FROM vision_explainer_report WHERE capture_id = ?"
+            " ORDER BY created_at, report_id",
+            (capture_id,),
+        )
+        return [_report_from_row(row) for row in await cursor.fetchall()]
+
+    async def async_get_baseline_bucket(self, bucket_id: str) -> BaselineBucket | None:
+        """Return a Baseline Bucket by identity."""
+        cursor = await self._require_db().execute(
+            "SELECT * FROM vision_baseline_bucket WHERE bucket_id = ?", (bucket_id,)
+        )
+        row = await cursor.fetchone()
+        return _bucket_from_row(row) if row is not None else None
+
+    async def async_find_baseline_bucket(
+        self,
+        *,
+        camera_id: str,
+        light_window: LightWindow,
+        grow_run_id: str,
+        model_id: str,
+        model_version: str,
+        framing_epoch_id: str,
+        scoring_policy_version: int,
+    ) -> BaselineBucket | None:
+        """Find the exact provenance-compatible Baseline Bucket."""
+        cursor = await self._require_db().execute(
+            "SELECT * FROM vision_baseline_bucket"
+            " WHERE camera_id = ? AND light_window = ? AND grow_run_id = ?"
+            " AND model_id = ? AND model_version = ? AND framing_epoch_id = ?"
+            " AND scoring_policy_version = ?",
+            (
+                camera_id,
+                light_window.value,
+                grow_run_id,
+                model_id,
+                model_version,
+                framing_epoch_id,
+                scoring_policy_version,
+            ),
+        )
+        row = await cursor.fetchone()
+        return _bucket_from_row(row) if row is not None else None
+
+    async def async_get_active_baseline_members(
+        self, bucket_id: str
+    ) -> list[BaselineMember]:
+        """Return active recorded membership in admission order."""
+        cursor = await self._require_db().execute(
+            "SELECT * FROM vision_baseline_member"
+            " WHERE bucket_id = ? AND evicted_at IS NULL"
+            " ORDER BY admitted_at, capture_id",
+            (bucket_id,),
+        )
+        return [_member_from_row(row) for row in await cursor.fetchall()]
+
+    async def async_get_baseline_members(self, bucket_id: str) -> list[BaselineMember]:
+        """Return the complete admission and eviction audit trail."""
+        cursor = await self._require_db().execute(
+            "SELECT * FROM vision_baseline_member WHERE bucket_id = ?"
+            " ORDER BY admitted_at, capture_id",
+            (bucket_id,),
+        )
+        return [_member_from_row(row) for row in await cursor.fetchall()]
+
+    async def async_get_active_baseline_embeddings(
+        self, bucket_id: str
+    ) -> list[VisionEmbedding]:
+        """Return newest active embeddings matching the bucket's encoder."""
+        cursor = await self._require_db().execute(
+            "SELECT e.* FROM vision_baseline_member AS m"
+            " JOIN vision_baseline_bucket AS b ON b.bucket_id = m.bucket_id"
+            " JOIN vision_embedding AS e ON e.capture_id = m.capture_id"
+            "  AND e.model_id = b.model_id AND e.model_version = b.model_version"
+            " WHERE m.bucket_id = ? AND m.evicted_at IS NULL"
+            " ORDER BY m.admitted_at DESC, m.capture_id DESC"
+            " LIMIT (SELECT members_required FROM vision_baseline_bucket"
+            "        WHERE bucket_id = ?)",
+            (bucket_id, bucket_id),
+        )
+        return [_embedding_from_row(row) for row in await cursor.fetchall()]
+
+    async def async_evict_baseline_member(
+        self,
+        bucket_id: str,
+        capture_id: str,
+        *,
+        evicted_at: str,
+        evicted_by_capture_id: str,
+    ) -> None:
+        """Record rolling-window eviction without deleting membership."""
+        async with self._write_lock:
+            db = self._require_db()
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = await db.execute(
+                    "UPDATE vision_baseline_member"
+                    " SET evicted_at = ?, evicted_by_capture_id = ?"
+                    " WHERE bucket_id = ? AND capture_id = ? AND evicted_at IS NULL",
+                    (evicted_at, evicted_by_capture_id, bucket_id, capture_id),
+                )
+                if cursor.rowcount != 1:
+                    raise KeyError(
+                        f"Active baseline member {bucket_id}/{capture_id} not found"
+                    )
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+
+    async def async_add_label(
+        self, label: VisionLabel, *, supersedes_label_id: str | None = None
+    ) -> None:
+        """Append a label and optionally supersede its predecessor atomically."""
+        if label.superseded_by is not None:
+            raise ValueError("A newly appended label cannot already be superseded")
+        async with self._write_lock:
+            db = self._require_db()
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                await db.execute(
+                    "INSERT INTO vision_label"
+                    " (label_id, capture_id, label_kind, created_at, author,"
+                    " model_verdict, model_anomaly_score, model_id, model_version,"
+                    " scoring_policy_version, corrected_verdict, symptom_labels,"
+                    " note, observed_from, observed_to, excluded, exclusion_reason)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        label.label_id,
+                        label.capture_id,
+                        label.label_kind.value,
+                        label.created_at,
+                        label.author,
+                        label.model_verdict.value if label.model_verdict else None,
+                        label.model_anomaly_score,
+                        label.model_id,
+                        label.model_version,
+                        label.scoring_policy_version,
+                        (
+                            label.corrected_verdict.value
+                            if label.corrected_verdict
+                            else None
+                        ),
+                        (
+                            json.dumps(label.symptom_labels)
+                            if label.symptom_labels
+                            else None
+                        ),
+                        label.note,
+                        label.observed_from,
+                        label.observed_to,
+                        int(label.excluded),
+                        label.exclusion_reason,
+                    ),
+                )
+                if supersedes_label_id is not None:
+                    cursor = await db.execute(
+                        "UPDATE vision_label SET superseded_by = ?"
+                        " WHERE label_id = ? AND capture_id = ?"
+                        " AND superseded_by IS NULL",
+                        (label.label_id, supersedes_label_id, label.capture_id),
+                    )
+                    if cursor.rowcount != 1:
+                        raise KeyError(
+                            f"Active predecessor label {supersedes_label_id} not found"
+                        )
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+
+    async def async_get_labels(self, capture_id: str) -> list[VisionLabel]:
+        """Return the complete append-only label history for a capture."""
+        cursor = await self._require_db().execute(
+            "SELECT * FROM vision_label WHERE capture_id = ?"
+            " ORDER BY created_at, label_id",
+            (capture_id,),
+        )
+        return [_label_from_row(row) for row in await cursor.fetchall()]
+
+    async def async_is_capture_pinned(self, capture_id: str) -> bool:
+        """Return whether retention must preserve this capture's images."""
+        cursor = await self._require_db().execute(
+            "SELECT ("
+            " EXISTS(SELECT 1 FROM vision_baseline_member"
+            "        WHERE capture_id = ? AND evicted_at IS NULL)"
+            " OR EXISTS(SELECT 1 FROM vision_label WHERE capture_id = ?)"
+            " OR EXISTS(SELECT 1 FROM vision_comparison_result"
+            "           WHERE capture_id = ?"
+            "           AND verdict IN ('uncertain', 'material_scene_change'))"
+            ")",
+            (capture_id, capture_id, capture_id),
+        )
+        row = await cursor.fetchone()
+        if row is None:  # pragma: no cover - aggregate SELECT always returns one row
+            return False
+        return bool(row[0])
+
+    async def async_prune_images(
+        self, *, image_retention_days: int, now: datetime
+    ) -> int:
+        """Delete old unpinned tracked files while retaining every evidence row."""
+        if image_retention_days < 0:
+            raise ValueError("image_retention_days cannot be negative")
+        if image_retention_days == 0:
+            return 0
+        if now.tzinfo is None:
+            raise ValueError("now must be timezone-aware")
+        cutoff = (
+            now.astimezone(UTC) - timedelta(days=image_retention_days)
+        ).isoformat()
+        deleted_at = now.astimezone(UTC).isoformat()
+
+        async with self._write_lock:
+            db = self._require_db()
+            cursor = await db.execute(
+                "SELECT f.* FROM vision_capture_file AS f"
+                " JOIN vision_capture AS c ON c.capture_id = f.capture_id"
+                " WHERE f.deleted_at IS NULL AND c.captured_at < ?"
+                " AND NOT EXISTS ("
+                "   SELECT 1 FROM vision_baseline_member AS m"
+                "   WHERE m.capture_id = c.capture_id AND m.evicted_at IS NULL"
+                " )"
+                " AND NOT EXISTS ("
+                "   SELECT 1 FROM vision_label AS l"
+                "   WHERE l.capture_id = c.capture_id"
+                " )"
+                " AND NOT EXISTS ("
+                "   SELECT 1 FROM vision_comparison_result AS r"
+                "   WHERE r.capture_id = c.capture_id"
+                "   AND r.verdict IN ('uncertain', 'material_scene_change')"
+                " )"
+                " ORDER BY c.captured_at, f.capture_id, f.variant",
+                (cutoff,),
+            )
+            candidates = await cursor.fetchall()
+            deleted = 0
+            for row in candidates:
+                try:
+                    path = self._resolve_image_path(row["relative_path"])
+                    await asyncio.to_thread(path.unlink, missing_ok=True)
+                except OSError, ValueError:
+                    _LOGGER.warning(
+                        "Failed to prune tracked vision image %s",
+                        row["relative_path"],
+                        exc_info=True,
+                    )
+                    continue
+                await db.execute(
+                    "UPDATE vision_capture_file"
+                    " SET deleted_at = ?, deletion_reason = ?"
+                    " WHERE capture_id = ? AND variant = ? AND deleted_at IS NULL",
+                    (
+                        deleted_at,
+                        FileDeletionReason.RETENTION.value,
+                        row["capture_id"],
+                        row["variant"],
+                    ),
+                )
+                await db.commit()
+                deleted += 1
+            return deleted
+
+    async def async_delete_growspace(self, growspace_id: str) -> int:
+        """Delete ordinary evidence while preserving pinned captures as orphans."""
+        async with self._write_lock:
+            db = self._require_db()
+            cursor = await db.execute(
+                "SELECT c.capture_id FROM vision_capture AS c"
+                " WHERE c.growspace_id = ?"
+                " AND NOT EXISTS ("
+                "   SELECT 1 FROM vision_baseline_member AS m"
+                "   WHERE m.capture_id = c.capture_id AND m.evicted_at IS NULL"
+                " )"
+                " AND NOT EXISTS ("
+                "   SELECT 1 FROM vision_label AS l"
+                "   WHERE l.capture_id = c.capture_id"
+                " )"
+                " AND NOT EXISTS ("
+                "   SELECT 1 FROM vision_comparison_result AS r"
+                "   WHERE r.capture_id = c.capture_id"
+                "   AND r.verdict IN ('uncertain', 'material_scene_change')"
+                " ) ORDER BY c.capture_id",
+                (growspace_id,),
+            )
+            candidates = [str(row[0]) for row in await cursor.fetchall()]
+            deletable: list[str] = []
+            for capture_id in candidates:
+                files_cursor = await db.execute(
+                    "SELECT relative_path FROM vision_capture_file"
+                    " WHERE capture_id = ? AND deleted_at IS NULL",
+                    (capture_id,),
+                )
+                paths = [str(row[0]) for row in await files_cursor.fetchall()]
+                try:
+                    for relative_path in paths:
+                        path = self._resolve_image_path(relative_path)
+                        await asyncio.to_thread(path.unlink, missing_ok=True)
+                except OSError, ValueError:
+                    _LOGGER.warning(
+                        "Failed to delete images for removed growspace capture %s",
+                        capture_id,
+                        exc_info=True,
+                    )
+                    continue
+                deletable.append(capture_id)
+
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                if deletable:
+                    await db.executemany(
+                        "DELETE FROM vision_capture WHERE capture_id = ?",
+                        ((capture_id,) for capture_id in deletable),
+                    )
+                await db.execute(
+                    "DELETE FROM vision_baseline_bucket"
+                    " WHERE growspace_id = ? AND NOT EXISTS ("
+                    "   SELECT 1 FROM vision_baseline_member AS m"
+                    "   WHERE m.bucket_id = vision_baseline_bucket.bucket_id"
+                    " )",
+                    (growspace_id,),
+                )
+                await db.execute(
+                    "DELETE FROM vision_checkup"
+                    " WHERE growspace_id = ? AND NOT EXISTS ("
+                    "   SELECT 1 FROM vision_capture AS c"
+                    "   WHERE c.checkup_id = vision_checkup.checkup_id"
+                    " )",
+                    (growspace_id,),
+                )
+                await db.execute(
+                    "DELETE FROM vision_framing_epoch"
+                    " WHERE growspace_id = ?"
+                    " AND NOT EXISTS ("
+                    "   SELECT 1 FROM vision_capture AS c"
+                    "   WHERE c.framing_epoch_id = vision_framing_epoch.epoch_id"
+                    " )"
+                    " AND NOT EXISTS ("
+                    "   SELECT 1 FROM vision_baseline_bucket AS b"
+                    "   WHERE b.framing_epoch_id = vision_framing_epoch.epoch_id"
+                    " )",
+                    (growspace_id,),
+                )
+                await db.execute(
+                    "DELETE FROM vision_grow_run_ref WHERE growspace_id = ?",
+                    (growspace_id,),
+                )
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+            return len(deletable)
+
+    def _resolve_image_path(self, relative_path: str) -> Path:
+        """Resolve a stored path while containing corrupt rows below the image root."""
+        root = self._image_root.resolve()
+        path = (root / relative_path).resolve()
+        if not path.is_relative_to(root):
+            raise ValueError(f"Vision image path escapes its root: {relative_path}")
+        return path
+
+    async def _async_insert_embedding(self, embedding: VisionEmbedding) -> None:
+        """Insert an embedding inside the caller's transaction."""
+        await self._require_db().execute(
+            "INSERT INTO vision_embedding"
+            " (capture_id, model_id, model_version, dimension, values_f32,"
+            " derived_at, source) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                embedding.capture_id,
+                embedding.model_id,
+                embedding.model_version,
+                embedding.dimension,
+                embedding.values_f32,
+                embedding.derived_at,
+                embedding.source.value,
+            ),
+        )
+
+    async def _async_upsert_bucket(self, bucket: BaselineBucket) -> None:
+        """Insert or refresh a bucket's cached state inside a transaction."""
+        await self._require_db().execute(
+            "INSERT INTO vision_baseline_bucket"
+            " (bucket_id, growspace_id, camera_id, light_window, grow_run_id,"
+            " model_id, model_version, framing_epoch_id, state, member_count,"
+            " members_required, centroid, calibration_distances, last_admitted_at,"
+            " recomputed_at, scoring_policy_version, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            " ON CONFLICT(bucket_id) DO UPDATE SET"
+            " state = excluded.state, member_count = excluded.member_count,"
+            " members_required = excluded.members_required,"
+            " centroid = excluded.centroid,"
+            " calibration_distances = excluded.calibration_distances,"
+            " last_admitted_at = excluded.last_admitted_at,"
+            " recomputed_at = excluded.recomputed_at,"
+            " scoring_policy_version = excluded.scoring_policy_version",
+            (
+                bucket.bucket_id,
+                bucket.growspace_id,
+                bucket.camera_id,
+                bucket.light_window.value,
+                bucket.grow_run_id,
+                bucket.model_id,
+                bucket.model_version,
+                bucket.framing_epoch_id,
+                bucket.state.value,
+                bucket.member_count,
+                bucket.members_required,
+                bucket.centroid,
+                bucket.calibration_distances,
+                bucket.last_admitted_at,
+                bucket.recomputed_at,
+                bucket.scoring_policy_version,
+                bucket.created_at,
+            ),
+        )
+
+    async def _async_insert_comparison(
+        self, comparison: VisualComparisonResult
+    ) -> None:
+        """Insert an additive comparison result inside a transaction."""
+        await self._require_db().execute(
+            "INSERT INTO vision_comparison_result"
+            " (result_id, capture_id, bucket_id, evaluated_at, outcome,"
+            " baseline_state, samples_collected, samples_required, raw_distance,"
+            " anomaly_score, verdict, comparison_confidence, admitted_to_baseline,"
+            " unavailable_reasons, trigger_source, model_id, model_version,"
+            " scoring_policy_version)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                comparison.result_id,
+                comparison.capture_id,
+                comparison.bucket_id,
+                comparison.evaluated_at,
+                comparison.outcome.value,
+                (
+                    comparison.baseline_state.value
+                    if comparison.baseline_state is not None
+                    else None
+                ),
+                comparison.samples_collected,
+                comparison.samples_required,
+                comparison.raw_distance,
+                comparison.anomaly_score,
+                comparison.verdict.value if comparison.verdict is not None else None,
+                comparison.comparison_confidence,
+                int(comparison.admitted_to_baseline),
+                json.dumps(comparison.unavailable_reasons),
+                comparison.trigger_source.value,
+                comparison.model_id,
+                comparison.model_version,
+                comparison.scoring_policy_version,
+            ),
+        )
+
+    async def _async_insert_member(self, member: BaselineMember) -> None:
+        """Record an admission fact inside a transaction."""
+        await self._require_db().execute(
+            "INSERT INTO vision_baseline_member"
+            " (bucket_id, capture_id, admitted_at, admission_phase, evicted_at,"
+            " evicted_by_capture_id) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                member.bucket_id,
+                member.capture_id,
+                member.admitted_at,
+                member.admission_phase.value,
+                member.evicted_at,
+                member.evicted_by_capture_id,
+            ),
+        )
+
+    async def _async_get_or_create_grow_run(
+        self, growspace_id: str, started_at: str
+    ) -> str:
+        """Return the persisted surrogate Grow Run identity for a growspace."""
+        db = self._require_db()
+        cursor = await db.execute(
+            "SELECT grow_run_id FROM vision_grow_run_ref WHERE growspace_id = ?",
+            (growspace_id,),
+        )
+        row = await cursor.fetchone()
+        if row is not None:
+            return str(row[0])
+        grow_run_id = str(uuid.uuid7())
+        await db.execute(
+            "INSERT INTO vision_grow_run_ref"
+            " (growspace_id, grow_run_id, started_at, source)"
+            " VALUES (?, ?, ?, 'surrogate')",
+            (growspace_id, grow_run_id, started_at),
+        )
+        return grow_run_id
+
+    async def _async_get_or_create_epoch(
+        self, growspace_id: str, camera_id: str, started_at: str
+    ) -> str:
+        """Return the current Framing Epoch, creating the initial one if absent."""
+        db = self._require_db()
+        cursor = await db.execute(
+            "SELECT epoch_id FROM vision_framing_epoch"
+            " WHERE growspace_id = ? AND camera_id = ?"
+            " ORDER BY started_at DESC LIMIT 1",
+            (growspace_id, camera_id),
+        )
+        row = await cursor.fetchone()
+        if row is not None:
+            return str(row[0])
+        epoch_id = str(uuid.uuid7())
+        await db.execute(
+            "INSERT INTO vision_framing_epoch"
+            " (epoch_id, growspace_id, camera_id, started_at, reason)"
+            " VALUES (?, ?, ?, ?, 'initial')",
+            (epoch_id, growspace_id, camera_id, started_at),
+        )
+        return epoch_id
+
+    def _require_db(self) -> aiosqlite.Connection:
+        """Return the open connection or reject use outside its lifecycle."""
+        if self._db is None:
+            raise RuntimeError("Vision Evidence Store is not open")
+        return self._db
+
+
+def _extension_for_content_type(content_type: str) -> str:
+    """Return the truthful extension accepted by the Vision V1 contract."""
+    media_type = content_type.partition(";")[0].strip().lower()
+    if media_type == "image/jpeg":
+        return ".jpg"
+    if media_type == "image/png":
+        return ".png"
+    raise ValueError("Vision captures must be JPEG or PNG")
+
+
+def _capture_from_row(row: aiosqlite.Row) -> VisionCapture:
+    """Decode a capture row into the locked record model."""
+    return VisionCapture(
+        capture_id=row["capture_id"],
+        checkup_id=row["checkup_id"],
+        growspace_id=row["growspace_id"],
+        growspace_name=row["growspace_name"],
+        camera_id=row["camera_id"],
+        grow_run_id=row["grow_run_id"],
+        framing_epoch_id=row["framing_epoch_id"],
+        captured_at=row["captured_at"],
+        light_window=LightWindow(row["light_window"]),
+        light_state=LightState(row["light_state"]),
+        trigger_source=CaptureTrigger(row["trigger_source"]),
+        content_sha256=row["content_sha256"],
+        analysis_state=AnalysisState(row["analysis_state"]),
+        analysis_error_code=row["analysis_error_code"],
+        request_id=row["request_id"],
+        vision_schema_version=row["vision_schema_version"],
+        service_version=row["service_version"],
+        quality_mean_luminance=row["quality_mean_luminance"],
+        quality_clipped_pixel_fraction=row["quality_clipped_pixel_fraction"],
+        quality_mean_absolute_gradient=row["quality_mean_absolute_gradient"],
+        quality_reasons=tuple(json.loads(row["quality_reasons"] or "[]")),
+        created_at=row["created_at"],
+    )
+
+
+def _checkup_from_row(row: aiosqlite.Row) -> VisionCheckup:
+    """Decode a durable Vision Checkup row."""
+    status = row["status"]
+    return VisionCheckup(
+        checkup_id=row["checkup_id"],
+        growspace_id=row["growspace_id"],
+        growspace_name=row["growspace_name"],
+        trigger_source=CaptureTrigger(row["trigger_source"]),
+        light_window=LightWindow(row["light_window"]),
+        started_at=row["started_at"],
+        completed_at=row["completed_at"],
+        status=CheckupStatus(status) if status is not None else None,
+    )
+
+
+def _capture_file_from_row(row: aiosqlite.Row) -> VisionCaptureFile:
+    """Decode a file row into the locked record model."""
+    deletion_reason = row["deletion_reason"]
+    return VisionCaptureFile(
+        capture_id=row["capture_id"],
+        variant=CaptureFileVariant(row["variant"]),
+        relative_path=row["relative_path"],
+        byte_size=row["byte_size"],
+        content_type=row["content_type"],
+        deleted_at=row["deleted_at"],
+        deletion_reason=(
+            FileDeletionReason(deletion_reason) if deletion_reason is not None else None
+        ),
+    )
+
+
+def _embedding_from_row(row: aiosqlite.Row) -> VisionEmbedding:
+    """Decode an embedding row."""
+    return VisionEmbedding(
+        capture_id=row["capture_id"],
+        model_id=row["model_id"],
+        model_version=row["model_version"],
+        dimension=row["dimension"],
+        values_f32=row["values_f32"],
+        derived_at=row["derived_at"],
+        source=EmbeddingSource(row["source"]),
+    )
+
+
+def _comparison_from_row(row: aiosqlite.Row) -> VisualComparisonResult:
+    """Decode a Visual Comparison Result row."""
+    baseline_state = row["baseline_state"]
+    verdict = row["verdict"]
+    return VisualComparisonResult(
+        result_id=row["result_id"],
+        capture_id=row["capture_id"],
+        bucket_id=row["bucket_id"],
+        evaluated_at=row["evaluated_at"],
+        outcome=ComparisonOutcome(row["outcome"]),
+        baseline_state=(
+            BaselineState(baseline_state) if baseline_state is not None else None
+        ),
+        samples_collected=row["samples_collected"],
+        samples_required=row["samples_required"],
+        raw_distance=row["raw_distance"],
+        anomaly_score=row["anomaly_score"],
+        verdict=ComparisonVerdict(verdict) if verdict is not None else None,
+        comparison_confidence=row["comparison_confidence"],
+        admitted_to_baseline=bool(row["admitted_to_baseline"]),
+        unavailable_reasons=tuple(json.loads(row["unavailable_reasons"] or "[]")),
+        trigger_source=CaptureTrigger(row["trigger_source"]),
+        model_id=row["model_id"],
+        model_version=row["model_version"],
+        scoring_policy_version=row["scoring_policy_version"],
+    )
+
+
+def _fusion_from_row(row: aiosqlite.Row) -> VisionFusionOutcome:
+    """Decode a capture-specific Evidence Fusion Outcome row."""
+    return VisionFusionOutcome(
+        outcome_id=row["outcome_id"],
+        capture_id=row["capture_id"],
+        evaluated_at=row["evaluated_at"],
+        scoring_policy_version=row["scoring_policy_version"],
+        environmental_verdict=row["environmental_verdict"],
+        environmental_evaluated_at=row["environmental_evaluated_at"],
+        stress_reasons=tuple(json.loads(row["stress_reasons"])),
+        mold_reasons=tuple(json.loads(row["mold_reasons"])),
+        fusion_state=row["fusion_state"],
+        fusion_confidence=row["fusion_confidence"],
+        fusion_coverage=row["fusion_coverage"],
+        unavailable_reasons=tuple(json.loads(row["unavailable_reasons"])),
+    )
+
+
+def _report_from_row(row: aiosqlite.Row) -> VisionExplainerReport:
+    """Decode an optional Vision Explainer Report row."""
+    return VisionExplainerReport(
+        report_id=row["report_id"],
+        capture_id=row["capture_id"],
+        created_at=row["created_at"],
+        ai_task_entity_id=row["ai_task_entity_id"],
+        observation_source=ObservationSource(row["observation_source"]),
+        scoring_policy_version=row["scoring_policy_version"],
+        observation=row["observation"],
+        environmental_risk=row["environmental_risk"],
+        hypothesis=row["hypothesis"],
+        recommendations=tuple(json.loads(row["recommendations"])),
+        fusion_state=row["fusion_state"],
+        fusion_confidence=row["fusion_confidence"],
+        fusion_coverage=row["fusion_coverage"],
+        fusion_unavailable_reasons=tuple(
+            json.loads(row["fusion_unavailable_reasons"] or "[]")
+        ),
+    )
+
+
+def _bucket_from_row(row: aiosqlite.Row) -> BaselineBucket:
+    """Decode a Baseline Bucket row."""
+    return BaselineBucket(
+        bucket_id=row["bucket_id"],
+        growspace_id=row["growspace_id"],
+        camera_id=row["camera_id"],
+        light_window=LightWindow(row["light_window"]),
+        grow_run_id=row["grow_run_id"],
+        model_id=row["model_id"],
+        model_version=row["model_version"],
+        framing_epoch_id=row["framing_epoch_id"],
+        state=BaselineState(row["state"]),
+        member_count=row["member_count"],
+        members_required=row["members_required"],
+        centroid=row["centroid"],
+        calibration_distances=row["calibration_distances"],
+        last_admitted_at=row["last_admitted_at"],
+        recomputed_at=row["recomputed_at"],
+        scoring_policy_version=row["scoring_policy_version"],
+        created_at=row["created_at"],
+    )
+
+
+def _member_from_row(row: aiosqlite.Row) -> BaselineMember:
+    """Decode a recorded Baseline Bucket membership row."""
+    return BaselineMember(
+        bucket_id=row["bucket_id"],
+        capture_id=row["capture_id"],
+        admitted_at=row["admitted_at"],
+        admission_phase=AdmissionPhase(row["admission_phase"]),
+        evicted_at=row["evicted_at"],
+        evicted_by_capture_id=row["evicted_by_capture_id"],
+    )
+
+
+def _label_from_row(row: aiosqlite.Row) -> VisionLabel:
+    """Decode an append-only Vision Label row."""
+    model_verdict = row["model_verdict"]
+    corrected_verdict = row["corrected_verdict"]
+    return VisionLabel(
+        label_id=row["label_id"],
+        capture_id=row["capture_id"],
+        label_kind=LabelKind(row["label_kind"]),
+        created_at=row["created_at"],
+        author=row["author"],
+        model_verdict=(
+            ComparisonVerdict(model_verdict) if model_verdict is not None else None
+        ),
+        model_anomaly_score=row["model_anomaly_score"],
+        model_id=row["model_id"],
+        model_version=row["model_version"],
+        scoring_policy_version=row["scoring_policy_version"],
+        corrected_verdict=(
+            ComparisonVerdict(corrected_verdict)
+            if corrected_verdict is not None
+            else None
+        ),
+        symptom_labels=tuple(json.loads(row["symptom_labels"] or "[]")),
+        note=row["note"],
+        observed_from=row["observed_from"],
+        observed_to=row["observed_to"],
+        excluded=bool(row["excluded"]),
+        exclusion_reason=row["exclusion_reason"],
+        superseded_by=row["superseded_by"],
+    )

--- a/custom_components/growspace_manager/domain/evidence_fusion.py
+++ b/custom_components/growspace_manager/domain/evidence_fusion.py
@@ -37,7 +37,7 @@ class EvidenceFusionState(StrEnum):
     ``NO_DETECTED_CHANGE`` means only that complete available evidence found
     neither environmental risk nor material departure from recent scene history.
     ``CONCURRENT_...`` asserts co-occurrence, not correlation or causation.
-    ``CRITICAL_SCENE_ISSUE`` describes fusion precedence and persistence, not
+    ``PERSISTENT_VISUAL_ANOMALY`` describes fusion precedence and persistence, not
     plant danger.
     """
 
@@ -47,7 +47,7 @@ class EvidenceFusionState(StrEnum):
     CONCURRENT_ENVIRONMENTAL_RISK_AND_VISUAL_ANOMALY = (
         "concurrent_environmental_risk_and_visual_anomaly"
     )
-    CRITICAL_SCENE_ISSUE = "critical_scene_issue"
+    PERSISTENT_VISUAL_ANOMALY = "persistent_visual_anomaly"
 
 
 class ConfidenceQualifier(StrEnum):

--- a/custom_components/growspace_manager/models/vision_evidence.py
+++ b/custom_components/growspace_manager/models/vision_evidence.py
@@ -1,8 +1,8 @@
 """Records of the Vision Evidence Store.
 
 Growspace Vision is stateless (ADR 0003), so Home Assistant owns every artifact of a
-Vision Checkup: the capture, its image files, its Visual Embedding, the Visual
-Comparison Result, the Baseline Bucket it was scored against, and any grower label.
+Vision Checkup: its envelope, each capture, image files, Visual Embedding, Visual
+Comparison Result, Baseline Bucket, fusion outcome, report, and grower labels.
 These are the row shapes of ``growspace_vision.db`` — see ADR 0041 and
 ``data_access/vision_evidence_schema.py``.
 
@@ -60,6 +60,14 @@ class CaptureTrigger(StrEnum):
 
     SCHEDULED = "scheduled"
     MANUAL = "manual"
+
+
+class CheckupStatus(StrEnum):
+    """The operational outcome of a multi-camera Vision Checkup."""
+
+    COMPLETED = "completed"
+    PARTIAL = "partial"
+    FAILED = "failed"
 
 
 class AnalysisState(StrEnum):
@@ -178,6 +186,20 @@ class GrowRunRef:
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
+class VisionCheckup:
+    """One growspace-level observation task grouping capture-specific evidence."""
+
+    checkup_id: str
+    growspace_id: str
+    growspace_name: str
+    trigger_source: CaptureTrigger
+    light_window: LightWindow
+    started_at: str
+    completed_at: str | None = None
+    status: CheckupStatus | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
 class VisionCapture:
     """One Camera Snapshot taken for a Vision Checkup.
 
@@ -186,6 +208,7 @@ class VisionCapture:
     """
 
     capture_id: str
+    checkup_id: str
     growspace_id: str
     growspace_name: str
     camera_id: str
@@ -313,6 +336,24 @@ class VisualComparisonResult:
     verdict: ComparisonVerdict | None = None
     comparison_confidence: float | None = None
     admitted_to_baseline: bool = False
+    unavailable_reasons: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class VisionFusionOutcome:
+    """Capture-specific normalized environmental evidence and fusion result."""
+
+    outcome_id: str
+    capture_id: str
+    evaluated_at: str
+    scoring_policy_version: int
+    environmental_verdict: str
+    environmental_evaluated_at: str | None = None
+    stress_reasons: tuple[str, ...] = ()
+    mold_reasons: tuple[str, ...] = ()
+    fusion_state: str | None = None
+    fusion_confidence: str | None = None
+    fusion_coverage: str | None = None
     unavailable_reasons: tuple[str, ...] = ()
 
 

--- a/docs/adr/0041-home-assistant-owns-vision-evidence-in-a-dedicated-store.md
+++ b/docs/adr/0041-home-assistant-owns-vision-evidence-in-a-dedicated-store.md
@@ -9,11 +9,12 @@ the stateless-service boundary of ADR 0003 and the baseline semantics of ADR 000
 
 Every artifact of a Vision Checkup — the checkup envelope, each capture, its image
 files, its Visual Embedding, the Baseline Bucket it was scored against, the Visual
-Comparison Result, and any grower label — is persisted by Home Assistant in a
-dedicated SQLite database, `growspace_vision.db`. Evidence rows are kept unpruned for
-the life of the growspace; images are kept on a bounded rolling window with an
-explicit pin rule. The existing cloud-era `vision_checkup_history` is frozen in place
-rather than migrated, and no `STORAGE_VERSION` bump is required.
+Comparison Result, its Evidence Fusion Outcome, and any grower label — is persisted
+by Home Assistant in a dedicated SQLite database, `growspace_vision.db`. Evidence
+rows are kept unpruned for the life of the growspace; images are kept on a bounded
+rolling window with an explicit pin rule. The existing cloud-era
+`vision_checkup_history` is frozen in place rather than migrated, and no
+`STORAGE_VERSION` bump is required.
 
 ## Medium
 
@@ -223,9 +224,8 @@ decision once real installs have rolled over.
 - `custom_components/growspace_manager/models/vision_evidence.py` — frozen records and
   the enums the `CHECK` constraints enforce.
 - `custom_components/growspace_manager/data_access/vision_evidence_store.py` — the
-  repository: connection, migrations, queries. **Deferred**, following [hub#69]: the
-  Visual Comparison Result producer does not exist yet, and building plumbing against
-  an unimplemented producer is speculative.
+  repository: connection lifecycle, migrations, evidence queries, atomic image writes,
+  retention and deletion.
 
 `domain/` gets nothing. There is no pure logic here; ADR 0004's baseline mathematics
 belongs with the scoring work, not with the store.
@@ -252,8 +252,9 @@ Unknown camera content types use `.bin` rather than claiming the bytes are JPEG.
 artifacts are retained for 90 days and pruning matches only `_raw` files. They are not
 returned by `get_snapshots` because that API only reads the separate `www/` tree; no
 filename filter is needed. A failed overlay still leaves the already-fetched raw
-artifact available. This file-only bridge is replaced by the capture and file rows
-specified above when the evidence repository lands.
+artifact available. This file-only bridge remains until the Vision Checkup producer
+is cut over to the repository; that cutover replaces it with the capture and file rows
+specified above.
 
 [hub#68]: https://github.com/Venosta-web/growspace_manager_workspace/issues/68
 [hub#69]: https://github.com/Venosta-web/growspace_manager_workspace/issues/69

--- a/tests/core/test_core_init.py
+++ b/tests/core/test_core_init.py
@@ -4,7 +4,7 @@ This file contains tests to ensure that the integration can be successfully set 
 and unloaded within Home Assistant.
 """
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 import json
 import tempfile
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -14,6 +14,7 @@ import pytest
 
 from custom_components.growspace_manager import (
     _async_cancel_coordinators,
+    _async_setup_vision_evidence_store,
     _async_update_listener,
     async_reload_entry,
     async_setup,
@@ -234,6 +235,86 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
 
         # WebSocket API is now registered in async_setup_entry, not async_setup
         mock_ws_reg.assert_called_once_with(hass)
+
+
+@pytest.mark.asyncio
+async def test_vision_evidence_store_lifecycle_and_retention_errors(
+    mock_hass, tmp_path, caplog
+) -> None:
+    """The global store uses private media, schedules retention and closes cleanly."""
+    entry = MockConfigEntry(domain=DOMAIN, data={}, options={"image_retention_days": 7})
+    mock_hass.data = {DOMAIN: {}}
+    mock_hass.config.media_dirs = {"local": str(tmp_path / "media")}
+    mock_hass.config.path = MagicMock(return_value=str(tmp_path / "vision.db"))
+    store = MagicMock()
+    store.async_setup = AsyncMock()
+    store.async_run_retention = AsyncMock(
+        side_effect=RuntimeError("retention unavailable")
+    )
+    store.async_close = AsyncMock()
+    unsubscribe = MagicMock()
+
+    with (
+        patch(
+            "custom_components.growspace_manager.VisionEvidenceStore",
+            return_value=store,
+        ) as store_cls,
+        patch(
+            "custom_components.growspace_manager.async_track_time_interval",
+            return_value=unsubscribe,
+        ) as track_interval,
+    ):
+        await _async_setup_vision_evidence_store(mock_hass, entry)
+
+    store_cls.assert_called_once_with(
+        tmp_path / "vision.db",
+        tmp_path / "media" / "growspace_vision",
+        image_retention_days=7,
+    )
+    assert mock_hass.data[DOMAIN]["vision_evidence_store"] is store
+    retention_callback = track_interval.call_args.args[1]
+    await retention_callback(datetime.now())
+    assert "Vision image retention failed" in caplog.text
+
+    stop_callback = mock_hass.bus.async_listen_once.call_args.args[1]
+    await stop_callback(MagicMock())
+    store.async_close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_vision_evidence_store_setup_degrades_without_private_media(
+    mock_hass, caplog
+) -> None:
+    """A missing media root leaves the cultivation integration available."""
+    mock_hass.data = {DOMAIN: {}}
+    mock_hass.config.media_dirs = {}
+    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+
+    await _async_setup_vision_evidence_store(mock_hass, entry)
+
+    assert "vision_evidence_store" not in mock_hass.data[DOMAIN]
+    assert "No media directory" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_vision_evidence_store_setup_degrades_on_database_failure(
+    mock_hass, tmp_path, caplog
+) -> None:
+    """A damaged evidence database never prevents the integration from loading."""
+    mock_hass.data = {DOMAIN: {}}
+    mock_hass.config.media_dirs = {"local": str(tmp_path / "media")}
+    mock_hass.config.path = MagicMock(return_value=str(tmp_path / "vision.db"))
+    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+    store = MagicMock()
+    store.async_setup = AsyncMock(side_effect=RuntimeError("damaged database"))
+
+    with patch(
+        "custom_components.growspace_manager.VisionEvidenceStore", return_value=store
+    ):
+        await _async_setup_vision_evidence_store(mock_hass, entry)
+
+    assert "vision_evidence_store" not in mock_hass.data[DOMAIN]
+    assert "Failed to open the Vision Evidence Store" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_vision_evidence_schema.py
+++ b/tests/test_vision_evidence_schema.py
@@ -19,6 +19,7 @@ from custom_components.growspace_manager.data_access.vision_evidence_schema impo
 )
 from custom_components.growspace_manager.domain.evidence_fusion import (
     ConfidenceQualifier,
+    EnvironmentalVerdict,
     EvidenceCoverage,
     EvidenceFusionState,
 )
@@ -28,6 +29,7 @@ from custom_components.growspace_manager.models.vision_evidence import (
     BaselineState,
     CaptureFileVariant,
     CaptureTrigger,
+    CheckupStatus,
     ComparisonOutcome,
     ComparisonVerdict,
     EmbeddingSource,
@@ -45,10 +47,12 @@ EXPECTED_TABLES = {
     "vision_baseline_member",
     "vision_capture",
     "vision_capture_file",
+    "vision_checkup",
     "vision_comparison_result",
     "vision_embedding",
     "vision_explainer_report",
     "vision_framing_epoch",
+    "vision_fusion_outcome",
     "vision_grow_run_ref",
     "vision_label",
 }
@@ -85,6 +89,18 @@ def _insert_epoch(db: sqlite3.Connection, epoch_id: str = "epoch-1") -> str:
     return epoch_id
 
 
+def _insert_checkup(db: sqlite3.Connection, checkup_id: str = "checkup-1") -> str:
+    """Insert a Vision Checkup and return its id."""
+    db.execute(
+        "INSERT INTO vision_checkup"
+        " (checkup_id, growspace_id, growspace_name, trigger_source, light_window,"
+        " started_at) VALUES (?, 'gs-1', 'Flower Tent', 'scheduled', 'early',"
+        " '2026-08-31T06:00:00+00:00')",
+        (checkup_id,),
+    )
+    return checkup_id
+
+
 def _insert_capture(
     db: sqlite3.Connection,
     capture_id: str = "capture-1",
@@ -94,12 +110,13 @@ def _insert_capture(
     trigger_source: str = "scheduled",
 ) -> str:
     """Insert a capture and return its id."""
+    _insert_checkup(db)
     db.execute(
         "INSERT INTO vision_capture"
-        " (capture_id, growspace_id, growspace_name, camera_id, grow_run_id,"
+        " (capture_id, checkup_id, growspace_id, growspace_name, camera_id, grow_run_id,"
         "  framing_epoch_id, captured_at, light_window, light_state,"
         "  trigger_source, analysis_state, created_at)"
-        " VALUES (?, 'gs-1', 'Flower Tent', 'camera.growcam', 'run-1', 'epoch-1',"
+        " VALUES (?, 'checkup-1', 'gs-1', 'Flower Tent', 'camera.growcam', 'run-1', 'epoch-1',"
         " '2026-08-31T06:00:00+00:00', ?, 'on', ?, ?,"
         " '2026-08-31T06:00:00+00:00')",
         (capture_id, light_window, trigger_source, analysis_state),
@@ -132,6 +149,7 @@ def test_schema_version_is_recorded_in_user_version(db):
         ("vision_capture", "light_state", LightState),
         ("vision_capture", "trigger_source", CaptureTrigger),
         ("vision_capture", "analysis_state", AnalysisState),
+        ("vision_checkup", "status", CheckupStatus),
         ("vision_capture_file", "variant", CaptureFileVariant),
         ("vision_capture_file", "deletion_reason", FileDeletionReason),
         ("vision_embedding", "source", EmbeddingSource),
@@ -144,6 +162,10 @@ def test_schema_version_is_recorded_in_user_version(db):
         ("vision_explainer_report", "fusion_state", EvidenceFusionState),
         ("vision_explainer_report", "fusion_confidence", ConfidenceQualifier),
         ("vision_explainer_report", "fusion_coverage", EvidenceCoverage),
+        ("vision_fusion_outcome", "environmental_verdict", EnvironmentalVerdict),
+        ("vision_fusion_outcome", "fusion_state", EvidenceFusionState),
+        ("vision_fusion_outcome", "fusion_confidence", ConfidenceQualifier),
+        ("vision_fusion_outcome", "fusion_coverage", EvidenceCoverage),
     ],
 )
 def test_check_constraints_match_the_model_enums(db, table, column, enum):
@@ -303,6 +325,23 @@ def test_baseline_members_required_matches_the_bucket_default(db):
         "SELECT sql FROM sqlite_master WHERE name = 'vision_baseline_bucket'"
     ).fetchone()
     assert f"DEFAULT {VISION_BASELINE_MEMBERS_REQUIRED}" in row[0]
+
+
+def test_new_scoring_policy_gets_a_distinct_baseline_bucket(db):
+    """Changing HA scoring rules never mutates the bucket used by old results."""
+    _insert_epoch(db)
+    for policy in (1, 2):
+        db.execute(
+            "INSERT INTO vision_baseline_bucket"
+            " (bucket_id, growspace_id, camera_id, light_window, grow_run_id,"
+            " model_id, model_version, framing_epoch_id, state,"
+            " scoring_policy_version, created_at)"
+            " VALUES (?, 'gs-1', 'camera.growcam', 'early', 'run-1',"
+            " 'dinov2-vits14', '1.0.0', 'epoch-1', 'monitoring', ?,"
+            " '2026-08-31T06:00:00+00:00')",
+            (f"bucket-{policy}", policy),
+        )
+    assert db.execute("SELECT COUNT(*) FROM vision_baseline_bucket").fetchone()[0] == 2
 
 
 def _insert_report(

--- a/tests/test_vision_evidence_store.py
+++ b/tests/test_vision_evidence_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
+from unittest.mock import AsyncMock
 import uuid
 
 import aiosqlite
@@ -715,4 +716,403 @@ async def test_growspace_deletion_keeps_pinned_captures_as_named_orphans(
     assert not (image_root / ordinary_file.relative_path).exists()
     assert (image_root / pinned_file.relative_path).exists()
     assert await store.async_get_labels(pinned.capture_id)
+    await store.async_close()
+
+
+@pytest.mark.asyncio
+async def test_public_boundaries_reject_invalid_identity_time_and_media(
+    tmp_path: Path,
+) -> None:
+    """Invalid caller data is rejected before it can become durable evidence."""
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", tmp_path / "images")
+    await store.async_setup()
+    now = datetime(2026, 9, 1, 6, tzinfo=UTC)
+
+    assert await store.async_run_retention(now) == 0
+    with pytest.raises(ValueError, match="checkup_id"):
+        await store.async_start_checkup(
+            checkup_id=str(uuid.uuid4()),
+            growspace_id="gs-1",
+            growspace_name="Flower Tent",
+            trigger_source=CaptureTrigger.SCHEDULED,
+            light_window=LightWindow.EARLY,
+            started_at=now,
+        )
+    with pytest.raises(ValueError, match="started_at"):
+        await store.async_start_checkup(
+            checkup_id=store.mint_checkup_id(),
+            growspace_id="gs-1",
+            growspace_name="Flower Tent",
+            trigger_source=CaptureTrigger.SCHEDULED,
+            light_window=LightWindow.EARLY,
+            started_at=now.replace(tzinfo=None),
+        )
+
+    checkup_id = store.mint_checkup_id()
+    await store.async_start_checkup(
+        checkup_id=checkup_id,
+        growspace_id="gs-1",
+        growspace_name="Flower Tent",
+        trigger_source=CaptureTrigger.SCHEDULED,
+        light_window=LightWindow.EARLY,
+        started_at=now,
+    )
+    capture_arguments = {
+        "checkup_id": checkup_id,
+        "growspace_id": "gs-1",
+        "growspace_name": "Flower Tent",
+        "camera_id": "camera.canopy",
+        "captured_at": now,
+        "light_window": LightWindow.EARLY,
+        "light_state": LightState.ON,
+        "trigger_source": CaptureTrigger.SCHEDULED,
+        "image": b"capture",
+        "content_type": "image/jpeg",
+    }
+    with pytest.raises(ValueError, match="capture_id"):
+        await store.async_start_capture(
+            capture_id=str(uuid.uuid4()), **capture_arguments
+        )
+    with pytest.raises(ValueError, match="captured_at"):
+        await store.async_start_capture(
+            capture_id=store.mint_capture_id(),
+            **(capture_arguments | {"captured_at": now.replace(tzinfo=None)}),
+        )
+    with pytest.raises(ValueError, match="JPEG or PNG"):
+        await store.async_start_capture(
+            capture_id=store.mint_capture_id(),
+            **(capture_arguments | {"content_type": "image/webp"}),
+        )
+    with pytest.raises(KeyError, match="does not exist"):
+        await store.async_start_capture(
+            capture_id=store.mint_capture_id(),
+            **(capture_arguments | {"checkup_id": store.mint_checkup_id()}),
+        )
+    with pytest.raises(ValueError, match="does not match"):
+        await store.async_start_capture(
+            capture_id=store.mint_capture_id(),
+            **(capture_arguments | {"growspace_id": "gs-other"}),
+        )
+    with pytest.raises(KeyError, match="does not exist"):
+        await store.async_add_capture_file(
+            "missing",
+            variant=CaptureFileVariant.PROCESSED,
+            image=b"png",
+            content_type="image/png",
+        )
+    with pytest.raises(ValueError, match="cannot be negative"):
+        await store.async_prune_images(image_retention_days=-1, now=now)
+    with pytest.raises(ValueError, match="timezone-aware"):
+        await store.async_prune_images(
+            image_retention_days=90, now=now.replace(tzinfo=None)
+        )
+
+    capture = await store.async_start_capture(
+        capture_id=store.mint_capture_id(), **capture_arguments
+    )
+    processed = await store.async_add_capture_file(
+        capture.capture_id,
+        variant=CaptureFileVariant.PROCESSED,
+        image=b"png",
+        content_type="image/png; charset=binary",
+    )
+    assert processed.relative_path.endswith(".processed.png")
+
+    await store.async_close()
+    await store.async_close()
+    with pytest.raises(RuntimeError, match="not open"):
+        await store.async_get_capture(capture.capture_id)
+
+
+@pytest.mark.asyncio
+async def test_checkup_state_transitions_roll_back_invalid_updates(
+    tmp_path: Path,
+) -> None:
+    """Duplicate starts and invalid finishes leave the original envelope intact."""
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", tmp_path / "images")
+    await store.async_setup()
+    checkup_id = store.mint_checkup_id()
+    now = datetime(2026, 9, 1, 6, tzinfo=UTC)
+    arguments = {
+        "checkup_id": checkup_id,
+        "growspace_id": "gs-1",
+        "growspace_name": "Flower Tent",
+        "trigger_source": CaptureTrigger.SCHEDULED,
+        "light_window": LightWindow.EARLY,
+        "started_at": now,
+    }
+    pending = await store.async_start_checkup(**arguments)
+
+    with pytest.raises(aiosqlite.IntegrityError):
+        await store.async_start_checkup(**arguments)
+    with pytest.raises(ValueError, match="completed_at"):
+        await store.async_finish_checkup(
+            checkup_id,
+            status=CheckupStatus.COMPLETED,
+            completed_at=now.replace(tzinfo=None),
+        )
+    with pytest.raises(KeyError, match="not found"):
+        await store.async_finish_checkup(
+            "missing",
+            status=CheckupStatus.FAILED,
+            completed_at=now,
+        )
+    assert await store.async_get_checkup(checkup_id) == pending
+
+    await store.async_finish_checkup(
+        checkup_id, status=CheckupStatus.COMPLETED, completed_at=now
+    )
+    with pytest.raises(KeyError, match="not found"):
+        await store.async_finish_checkup(
+            checkup_id, status=CheckupStatus.COMPLETED, completed_at=now
+        )
+    await store.async_close()
+
+
+@pytest.mark.asyncio
+async def test_image_index_refuses_existing_paths_and_cleans_up_commit_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The filesystem side never overwrites a file or outlives a failed commit."""
+    image_root = tmp_path / "images"
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", image_root)
+    await store.async_setup()
+    now = datetime(2026, 9, 1, 6, tzinfo=UTC)
+    checkup_id = store.mint_checkup_id()
+    await store.async_start_checkup(
+        checkup_id=checkup_id,
+        growspace_id="gs-1",
+        growspace_name="Flower Tent",
+        trigger_source=CaptureTrigger.SCHEDULED,
+        light_window=LightWindow.EARLY,
+        started_at=now,
+    )
+    arguments = {
+        "checkup_id": checkup_id,
+        "growspace_id": "gs-1",
+        "growspace_name": "Flower Tent",
+        "camera_id": "camera.canopy",
+        "captured_at": now,
+        "light_window": LightWindow.EARLY,
+        "light_state": LightState.ON,
+        "trigger_source": CaptureTrigger.SCHEDULED,
+        "image": b"capture",
+        "content_type": "image/jpeg",
+    }
+
+    occupied_id = store.mint_capture_id()
+    occupied = image_root / "gs-1" / "camera.canopy" / f"{occupied_id}.raw.jpg"
+    occupied.parent.mkdir(parents=True)
+    occupied.write_bytes(b"do-not-replace")
+    with pytest.raises(FileExistsError):
+        await store.async_start_capture(capture_id=occupied_id, **arguments)
+    assert occupied.read_bytes() == b"do-not-replace"
+    assert await store.async_get_capture(occupied_id) is None
+
+    db = store._require_db()
+    original_commit = db.commit
+    monkeypatch.setattr(
+        db, "commit", AsyncMock(side_effect=aiosqlite.OperationalError("disk full"))
+    )
+    failed_id = store.mint_capture_id()
+    with pytest.raises(aiosqlite.OperationalError, match="disk full"):
+        await store.async_start_capture(capture_id=failed_id, **arguments)
+    monkeypatch.setattr(db, "commit", original_commit)
+    failed_path = image_root / "gs-1" / "camera.canopy" / f"{failed_id}.raw.jpg"
+    assert not failed_path.exists()
+    assert await store.async_get_capture(failed_id) is None
+
+    capture = await store.async_start_capture(
+        capture_id=store.mint_capture_id(), **arguments
+    )
+    processed_path = (
+        image_root / "gs-1" / "camera.canopy" / f"{capture.capture_id}.processed.jpg"
+    )
+    processed_path.write_bytes(b"occupied")
+    with pytest.raises(FileExistsError):
+        await store.async_add_capture_file(
+            capture.capture_id,
+            variant=CaptureFileVariant.PROCESSED,
+            image=b"processed",
+            content_type="image/jpeg",
+        )
+    assert processed_path.read_bytes() == b"occupied"
+
+    processed_path.unlink()
+    monkeypatch.setattr(
+        db, "commit", AsyncMock(side_effect=aiosqlite.OperationalError("disk full"))
+    )
+    with pytest.raises(aiosqlite.OperationalError, match="disk full"):
+        await store.async_add_capture_file(
+            capture.capture_id,
+            variant=CaptureFileVariant.PROCESSED,
+            image=b"processed",
+            content_type="image/jpeg",
+        )
+    monkeypatch.setattr(db, "commit", original_commit)
+    assert not processed_path.exists()
+    assert {
+        item.variant for item in await store.async_get_capture_files(capture.capture_id)
+    } == {CaptureFileVariant.RAW}
+    await store.async_close()
+
+
+@pytest.mark.asyncio
+async def test_analysis_rejects_cross_capture_and_incomplete_artifacts(
+    tmp_path: Path,
+) -> None:
+    """Repository invariants reject evidence that cannot form one atomic analysis."""
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", tmp_path / "images")
+    await store.async_setup()
+    capture = await _start_capture(store)
+    completed, embedding, bucket, member, result = _analysis_records(capture)
+
+    with pytest.raises(ValueError, match="belong to the capture"):
+        await store.async_record_analysis(
+            completed, embedding=replace(embedding, capture_id="other")
+        )
+    with pytest.raises(ValueError, match="matching bucket"):
+        await store.async_record_analysis(completed, member=member)
+    with pytest.raises(ValueError, match="same write"):
+        await store.async_record_analysis(completed, comparison=result)
+    with pytest.raises(ValueError, match="dimension"):
+        await store.async_record_analysis(
+            completed, embedding=replace(embedding, values_f32=b"short")
+        )
+    with pytest.raises(KeyError, match="does not exist"):
+        await store.async_record_analysis(
+            replace(completed, capture_id=store.mint_capture_id())
+        )
+    assert await store.async_get_capture(capture.capture_id) == capture
+    await store.async_close()
+
+
+@pytest.mark.asyncio
+async def test_additive_repositories_roll_back_duplicate_and_invalid_writes(
+    tmp_path: Path,
+) -> None:
+    """Fusion, report, membership and label failures leave prior evidence intact."""
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", tmp_path / "images")
+    await store.async_setup()
+    capture = await _start_capture(store)
+    completed, embedding, bucket, member, result = _analysis_records(capture)
+    await store.async_record_analysis(
+        completed,
+        embedding=embedding,
+        comparison=result,
+        bucket=bucket,
+        member=member,
+    )
+    outcome = VisionFusionOutcome(
+        outcome_id="fusion-duplicate",
+        capture_id=capture.capture_id,
+        evaluated_at="2026-09-01T06:00:02+00:00",
+        scoring_policy_version=1,
+        environmental_verdict="unavailable",
+    )
+    await store.async_record_fusion_outcome(outcome)
+    with pytest.raises(aiosqlite.IntegrityError):
+        await store.async_record_fusion_outcome(outcome)
+
+    report = VisionExplainerReport(
+        report_id="report-duplicate",
+        capture_id=capture.capture_id,
+        created_at="2026-09-01T06:00:03+00:00",
+        ai_task_entity_id="ai_task.cloud",
+        observation_source=ObservationSource.VISUAL_COMPARISON_ONLY,
+        scoring_policy_version=1,
+        observation="No image was inspected.",
+        environmental_risk="",
+        hypothesis="",
+    )
+    await store.async_add_explainer_report(report)
+    with pytest.raises(aiosqlite.IntegrityError):
+        await store.async_add_explainer_report(report)
+    with pytest.raises(KeyError, match="not found"):
+        await store.async_evict_baseline_member(
+            bucket.bucket_id,
+            "missing",
+            evicted_at="2026-09-02T06:00:00+00:00",
+            evicted_by_capture_id="newer",
+        )
+
+    invalid_label = VisionLabel(
+        label_id="invalid-label",
+        capture_id=capture.capture_id,
+        label_kind=LabelKind.OBSERVATION,
+        created_at="2026-09-01T07:00:00+00:00",
+        author="grower",
+        superseded_by="already-set",
+    )
+    with pytest.raises(ValueError, match="cannot already be superseded"):
+        await store.async_add_label(invalid_label)
+
+    assert await store.async_get_fusion_outcomes(capture.capture_id) == [outcome]
+    assert await store.async_get_explainer_reports(capture.capture_id) == [report]
+    assert await store.async_get_active_baseline_members(bucket.bucket_id) == [member]
+    await store.async_close()
+
+
+@pytest.mark.asyncio
+async def test_corrupt_paths_are_contained_during_retention_and_deletion(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A corrupt row cannot make either cleanup operation escape the image root."""
+    image_root = tmp_path / "images"
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", image_root)
+    await store.async_setup()
+    old = datetime(2026, 5, 1, 6, tzinfo=UTC)
+    capture = await _start_capture(store, captured_at=old)
+    outside = tmp_path / "outside.jpg"
+    outside.write_bytes(b"unrelated")
+    db = store._require_db()
+    await db.execute(
+        "UPDATE vision_capture_file SET relative_path = '../outside.jpg'"
+        " WHERE capture_id = ?",
+        (capture.capture_id,),
+    )
+    await db.commit()
+
+    assert (
+        await store.async_prune_images(
+            image_retention_days=90,
+            now=datetime(2026, 9, 1, tzinfo=UTC),
+        )
+        == 0
+    )
+    assert await store.async_delete_growspace("gs-1") == 0
+    assert outside.read_bytes() == b"unrelated"
+    assert await store.async_get_capture(capture.capture_id) == capture
+    assert "Failed to prune tracked vision image" in caplog.text
+    assert "Failed to delete images" in caplog.text
+    await store.async_close()
+
+
+@pytest.mark.asyncio
+async def test_growspace_delete_rolls_back_rows_when_database_cleanup_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A database failure retains recoverable rows after files are deleted first."""
+    image_root = tmp_path / "images"
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", image_root)
+    await store.async_setup()
+    capture = await _start_capture(store)
+    capture_file = (await store.async_get_capture_files(capture.capture_id))[0]
+    db = store._require_db()
+    original_execute = db.execute
+
+    async def failing_execute(sql, parameters=None):
+        if sql.startswith("DELETE FROM vision_grow_run_ref"):
+            raise aiosqlite.OperationalError("database is read-only")
+        if parameters is None:
+            return await original_execute(sql)
+        return await original_execute(sql, parameters)
+
+    monkeypatch.setattr(db, "execute", failing_execute)
+    with pytest.raises(aiosqlite.OperationalError, match="read-only"):
+        await store.async_delete_growspace("gs-1")
+    monkeypatch.setattr(db, "execute", original_execute)
+
+    assert await store.async_get_capture(capture.capture_id) == capture
+    assert not (image_root / capture_file.relative_path).exists()
     await store.async_close()

--- a/tests/test_vision_evidence_store.py
+++ b/tests/test_vision_evidence_store.py
@@ -1,0 +1,718 @@
+"""Behavior tests for the durable Vision Evidence Store."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+import uuid
+
+import aiosqlite
+import pytest
+
+from custom_components.growspace_manager.data_access.vision_evidence_schema import (
+    VISION_EVIDENCE_SCHEMA_VERSION,
+)
+from custom_components.growspace_manager.data_access.vision_evidence_store import (
+    VisionEvidenceSchemaTooNewError,
+    VisionEvidenceStore,
+)
+from custom_components.growspace_manager.models.vision_evidence import (
+    AdmissionPhase,
+    AnalysisState,
+    BaselineBucket,
+    BaselineMember,
+    BaselineState,
+    CaptureFileVariant,
+    CaptureTrigger,
+    CheckupStatus,
+    ComparisonOutcome,
+    ComparisonVerdict,
+    EmbeddingSource,
+    FileDeletionReason,
+    LabelKind,
+    LightState,
+    LightWindow,
+    ObservationSource,
+    VisionEmbedding,
+    VisionExplainerReport,
+    VisionFusionOutcome,
+    VisionLabel,
+    VisualComparisonResult,
+)
+
+
+async def _start_capture(
+    store: VisionEvidenceStore,
+    *,
+    captured_at: datetime = datetime(2026, 9, 1, 6, tzinfo=UTC),
+    checkup_id: str | None = None,
+):
+    """Create the common pending capture used by repository behavior tests."""
+    if checkup_id is None:
+        checkup_id = store.mint_checkup_id()
+        await store.async_start_checkup(
+            checkup_id=checkup_id,
+            growspace_id="gs-1",
+            growspace_name="Flower Tent",
+            trigger_source=CaptureTrigger.SCHEDULED,
+            light_window=LightWindow.EARLY,
+            started_at=captured_at,
+        )
+    capture_id = store.mint_capture_id()
+    return await store.async_start_capture(
+        capture_id=capture_id,
+        checkup_id=checkup_id,
+        growspace_id="gs-1",
+        growspace_name="Flower Tent",
+        camera_id="camera.canopy",
+        captured_at=captured_at,
+        light_window=LightWindow.EARLY,
+        light_state=LightState.ON,
+        trigger_source=CaptureTrigger.SCHEDULED,
+        image=b"jpeg-capture-bytes",
+        content_type="image/jpeg",
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_migrates_once_and_survives_restart(tmp_path: Path) -> None:
+    """A reopened store keeps evidence and its forward-only schema version."""
+    database = tmp_path / "growspace_vision.db"
+    images = tmp_path / "media" / "growspace_vision"
+
+    store = VisionEvidenceStore(database, images)
+    await store.async_setup()
+    await store.async_close()
+
+    reopened = VisionEvidenceStore(database, images)
+    await reopened.async_setup()
+    await reopened.async_close()
+
+    async with aiosqlite.connect(database) as connection:
+        version = await (await connection.execute("PRAGMA user_version")).fetchone()
+        mode = await (await connection.execute("PRAGMA journal_mode")).fetchone()
+
+    assert version == (VISION_EVIDENCE_SCHEMA_VERSION,)
+    assert mode == ("wal",)
+    assert images.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_setup_refuses_a_database_from_newer_code(tmp_path: Path) -> None:
+    """Opening a future schema never attempts an implicit downgrade."""
+    database = tmp_path / "growspace_vision.db"
+    async with aiosqlite.connect(database) as connection:
+        await connection.execute(
+            f"PRAGMA user_version = {VISION_EVIDENCE_SCHEMA_VERSION + 1}"
+        )
+        await connection.commit()
+
+    with pytest.raises(VisionEvidenceSchemaTooNewError):
+        await VisionEvidenceStore(database, tmp_path / "images").async_setup()
+
+
+@pytest.mark.asyncio
+async def test_failed_migration_does_not_publish_a_partial_schema(
+    tmp_path: Path,
+) -> None:
+    """A migration error leaves its version and newly-created tables uncommitted."""
+    database = tmp_path / "growspace_vision.db"
+    async with aiosqlite.connect(database) as connection:
+        await connection.execute("CREATE TABLE vision_capture (capture_id TEXT)")
+        await connection.commit()
+
+    with pytest.raises(aiosqlite.OperationalError):
+        await VisionEvidenceStore(database, tmp_path / "images").async_setup()
+
+    async with aiosqlite.connect(database) as connection:
+        version = await (await connection.execute("PRAGMA user_version")).fetchone()
+        tables = await (
+            await connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+            )
+        ).fetchall()
+    assert version == (0,)
+    assert tables == [("vision_capture",)]
+
+
+@pytest.mark.asyncio
+async def test_capture_identity_and_image_survive_restart(tmp_path: Path) -> None:
+    """A UUIDv7 capture is durable before any Vision Analysis exists."""
+    database = tmp_path / "growspace_vision.db"
+    image_root = tmp_path / "images"
+    store = VisionEvidenceStore(database, image_root)
+    await store.async_setup()
+    capture_id = store.mint_capture_id()
+    checkup_id = store.mint_checkup_id()
+    await store.async_start_checkup(
+        checkup_id=checkup_id,
+        growspace_id="gs-1",
+        growspace_name="Flower Tent",
+        trigger_source=CaptureTrigger.SCHEDULED,
+        light_window=LightWindow.EARLY,
+        started_at=datetime(2026, 9, 1, 6, tzinfo=UTC),
+    )
+
+    created = await store.async_start_capture(
+        capture_id=capture_id,
+        checkup_id=checkup_id,
+        growspace_id="gs-1",
+        growspace_name="Flower Tent",
+        camera_id="camera.canopy",
+        captured_at=datetime(2026, 9, 1, 6, tzinfo=UTC),
+        light_window=LightWindow.EARLY,
+        light_state=LightState.ON,
+        trigger_source=CaptureTrigger.SCHEDULED,
+        image=b"jpeg-capture-bytes",
+        content_type="image/jpeg",
+    )
+
+    assert uuid.UUID(capture_id).version == 7
+    assert created.analysis_state is AnalysisState.PENDING
+    assert created.grow_run_id
+    assert created.framing_epoch_id
+    await store.async_close()
+
+    reopened = VisionEvidenceStore(database, image_root)
+    await reopened.async_setup()
+    persisted = await reopened.async_get_capture(capture_id)
+    files = await reopened.async_get_capture_files(capture_id)
+    await reopened.async_close()
+
+    assert persisted == created
+    assert files[0].variant is CaptureFileVariant.RAW
+    assert files[0].relative_path == f"gs-1/camera.canopy/{capture_id}.raw.jpg"
+    assert (image_root / files[0].relative_path).read_bytes() == b"jpeg-capture-bytes"
+
+
+@pytest.mark.asyncio
+async def test_failed_capture_write_does_not_replace_the_tracked_image(
+    tmp_path: Path,
+) -> None:
+    """A rejected database write leaves neither a new nor overwritten file."""
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", tmp_path / "images")
+    await store.async_setup()
+    capture_id = store.mint_capture_id()
+    arguments = {
+        "capture_id": capture_id,
+        "checkup_id": store.mint_checkup_id(),
+        "growspace_id": "gs-1",
+        "growspace_name": "Flower Tent",
+        "camera_id": "camera.canopy",
+        "captured_at": datetime(2026, 9, 1, 6, tzinfo=UTC),
+        "light_window": LightWindow.EARLY,
+        "light_state": LightState.ON,
+        "trigger_source": CaptureTrigger.SCHEDULED,
+        "content_type": "image/jpeg",
+    }
+    await store.async_start_checkup(
+        checkup_id=arguments["checkup_id"],
+        growspace_id="gs-1",
+        growspace_name="Flower Tent",
+        trigger_source=CaptureTrigger.SCHEDULED,
+        light_window=LightWindow.EARLY,
+        started_at=arguments["captured_at"],
+    )
+    await store.async_start_capture(image=b"original", **arguments)
+
+    with pytest.raises(aiosqlite.IntegrityError):
+        await store.async_start_capture(image=b"replacement", **arguments)
+
+    files = await store.async_get_capture_files(capture_id)
+    assert (tmp_path / "images" / files[0].relative_path).read_bytes() == b"original"
+    await store.async_close()
+
+
+@pytest.mark.asyncio
+async def test_checkup_groups_captures_and_records_operational_outcome(
+    tmp_path: Path,
+) -> None:
+    """Multi-camera identity is durable and never reconstructed from timestamps."""
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", tmp_path / "images")
+    await store.async_setup()
+    checkup_id = store.mint_checkup_id()
+    checkup = await store.async_start_checkup(
+        checkup_id=checkup_id,
+        growspace_id="gs-1",
+        growspace_name="Flower Tent",
+        trigger_source=CaptureTrigger.SCHEDULED,
+        light_window=LightWindow.EARLY,
+        started_at=datetime(2026, 9, 1, 6, tzinfo=UTC),
+    )
+    first = await _start_capture(store, checkup_id=checkup_id)
+    second = await store.async_start_capture(
+        capture_id=store.mint_capture_id(),
+        checkup_id=checkup_id,
+        growspace_id="gs-1",
+        growspace_name="Flower Tent",
+        camera_id="camera.side",
+        captured_at=datetime(2026, 9, 1, 6, 0, 2, tzinfo=UTC),
+        light_window=LightWindow.EARLY,
+        light_state=LightState.ON,
+        trigger_source=CaptureTrigger.SCHEDULED,
+        image=b"second-camera",
+        content_type="image/jpeg",
+    )
+    finished = await store.async_finish_checkup(
+        checkup_id,
+        status=CheckupStatus.COMPLETED,
+        completed_at=datetime(2026, 9, 1, 6, 0, 4, tzinfo=UTC),
+    )
+
+    assert uuid.UUID(checkup.checkup_id).version == 7
+    assert checkup.status is None
+    assert finished.status is CheckupStatus.COMPLETED
+    assert await store.async_get_checkup_captures(checkup_id) == [first, second]
+    await store.async_close()
+
+
+@pytest.mark.asyncio
+async def test_processed_capture_variant_is_tracked_by_the_same_identity(
+    tmp_path: Path,
+) -> None:
+    """A processed rendering shares the capture stem and becomes retention-visible."""
+    image_root = tmp_path / "images"
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", image_root)
+    await store.async_setup()
+    capture = await _start_capture(store)
+
+    processed = await store.async_add_capture_file(
+        capture.capture_id,
+        variant=CaptureFileVariant.PROCESSED,
+        image=b"processed-jpeg",
+        content_type="image/jpeg",
+    )
+
+    assert processed.relative_path.endswith(f"{capture.capture_id}.processed.jpg")
+    assert (image_root / processed.relative_path).read_bytes() == b"processed-jpeg"
+    assert {
+        item.variant for item in await store.async_get_capture_files(capture.capture_id)
+    } == {
+        CaptureFileVariant.RAW,
+        CaptureFileVariant.PROCESSED,
+    }
+    await store.async_close()
+
+
+def _analysis_records(capture):
+    """Build one complete comparison write rooted in a pending capture."""
+    completed = replace(
+        capture,
+        analysis_state=AnalysisState.ANALYZED,
+        request_id="request-1",
+        vision_schema_version=1,
+        service_version="1.0.0",
+        quality_mean_luminance=0.52,
+        quality_clipped_pixel_fraction=0.01,
+        quality_mean_absolute_gradient=0.12,
+    )
+    embedding = VisionEmbedding(
+        capture_id=capture.capture_id,
+        model_id="dinov2-vits14",
+        model_version="1.0.0",
+        dimension=2,
+        values_f32=b"\x00\x00\x80?\x00\x00\x00@",
+        derived_at="2026-09-01T06:00:01+00:00",
+        source=EmbeddingSource.LIVE,
+    )
+    bucket = BaselineBucket(
+        bucket_id="bucket-1",
+        growspace_id=capture.growspace_id,
+        camera_id=capture.camera_id,
+        light_window=LightWindow.EARLY,
+        grow_run_id=capture.grow_run_id,
+        model_id=embedding.model_id,
+        model_version=embedding.model_version,
+        framing_epoch_id=capture.framing_epoch_id,
+        state=BaselineState.MONITORING,
+        scoring_policy_version=1,
+        created_at="2026-09-01T06:00:01+00:00",
+        member_count=1,
+    )
+    member = BaselineMember(
+        bucket_id=bucket.bucket_id,
+        capture_id=capture.capture_id,
+        admitted_at="2026-09-01T06:00:01+00:00",
+        admission_phase=AdmissionPhase.BOOTSTRAP,
+    )
+    result = VisualComparisonResult(
+        result_id="result-1",
+        capture_id=capture.capture_id,
+        bucket_id=bucket.bucket_id,
+        evaluated_at="2026-09-01T06:00:01+00:00",
+        outcome=ComparisonOutcome.MONITORING,
+        baseline_state=BaselineState.MONITORING,
+        samples_collected=0,
+        samples_required=30,
+        trigger_source=CaptureTrigger.SCHEDULED,
+        model_id=embedding.model_id,
+        model_version=embedding.model_version,
+        scoring_policy_version=1,
+        admitted_to_baseline=True,
+    )
+    return completed, embedding, bucket, member, result
+
+
+@pytest.mark.asyncio
+async def test_analysis_evidence_is_one_durable_write(tmp_path: Path) -> None:
+    """Provenance, embedding, result and recorded membership commit together."""
+    database = tmp_path / "growspace_vision.db"
+    store = VisionEvidenceStore(database, tmp_path / "images")
+    await store.async_setup()
+    capture = await _start_capture(store)
+    completed, embedding, bucket, member, result = _analysis_records(capture)
+
+    await store.async_record_analysis(
+        completed,
+        embedding=embedding,
+        comparison=result,
+        bucket=bucket,
+        member=member,
+    )
+    await store.async_close()
+
+    reopened = VisionEvidenceStore(database, tmp_path / "images")
+    await reopened.async_setup()
+    assert await reopened.async_get_capture(capture.capture_id) == completed
+    assert (
+        await reopened.async_get_embedding(
+            capture.capture_id, embedding.model_id, embedding.model_version
+        )
+        == embedding
+    )
+    assert await reopened.async_get_comparison_results(capture.capture_id) == [result]
+    assert await reopened.async_get_baseline_bucket(bucket.bucket_id) == bucket
+    assert await reopened.async_get_active_baseline_members(bucket.bucket_id) == [
+        member
+    ]
+    assert (
+        await reopened.async_find_baseline_bucket(
+            camera_id=bucket.camera_id,
+            light_window=bucket.light_window,
+            grow_run_id=bucket.grow_run_id,
+            model_id=bucket.model_id,
+            model_version=bucket.model_version,
+            framing_epoch_id=bucket.framing_epoch_id,
+            scoring_policy_version=bucket.scoring_policy_version,
+        )
+        == bucket
+    )
+    assert await reopened.async_get_active_baseline_embeddings(bucket.bucket_id) == [
+        embedding
+    ]
+    await reopened.async_close()
+
+
+@pytest.mark.asyncio
+async def test_baseline_eviction_remains_auditable(tmp_path: Path) -> None:
+    """Rolling-window eviction changes active membership without deleting history."""
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", tmp_path / "images")
+    await store.async_setup()
+    capture = await _start_capture(store)
+    completed, embedding, bucket, member, result = _analysis_records(capture)
+    await store.async_record_analysis(
+        completed,
+        embedding=embedding,
+        comparison=result,
+        bucket=bucket,
+        member=member,
+    )
+
+    await store.async_evict_baseline_member(
+        bucket.bucket_id,
+        capture.capture_id,
+        evicted_at="2026-09-02T06:00:00+00:00",
+        evicted_by_capture_id="newer-capture",
+    )
+
+    assert await store.async_get_active_baseline_members(bucket.bucket_id) == []
+    assert await store.async_get_baseline_members(bucket.bucket_id) == [
+        replace(
+            member,
+            evicted_at="2026-09-02T06:00:00+00:00",
+            evicted_by_capture_id="newer-capture",
+        )
+    ]
+    await store.async_close()
+
+
+@pytest.mark.asyncio
+async def test_failed_analysis_write_rolls_back_every_artifact(tmp_path: Path) -> None:
+    """A bad result cannot leave provenance or an embedding half-committed."""
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", tmp_path / "images")
+    await store.async_setup()
+    capture = await _start_capture(store)
+    completed, embedding, bucket, member, result = _analysis_records(capture)
+    invalid_result = replace(
+        result,
+        outcome=ComparisonOutcome.SCORED,
+        anomaly_score=None,
+        verdict=None,
+    )
+
+    with pytest.raises(aiosqlite.IntegrityError):
+        await store.async_record_analysis(
+            completed,
+            embedding=embedding,
+            comparison=invalid_result,
+            bucket=bucket,
+            member=member,
+        )
+
+    assert await store.async_get_capture(capture.capture_id) == capture
+    assert (
+        await store.async_get_embedding(
+            capture.capture_id, embedding.model_id, embedding.model_version
+        )
+        is None
+    )
+    assert await store.async_get_comparison_results(capture.capture_id) == []
+    assert await store.async_get_baseline_bucket(bucket.bucket_id) is None
+    await store.async_close()
+
+
+@pytest.mark.asyncio
+async def test_fusion_outcome_is_durable_without_an_explainer_report(
+    tmp_path: Path,
+) -> None:
+    """Local-only checkups retain environment and fusion evidence independently."""
+    database = tmp_path / "growspace_vision.db"
+    store = VisionEvidenceStore(database, tmp_path / "images")
+    await store.async_setup()
+    capture = await _start_capture(store)
+    outcome = VisionFusionOutcome(
+        outcome_id="fusion-1",
+        capture_id=capture.capture_id,
+        evaluated_at="2026-09-01T06:00:02+00:00",
+        scoring_policy_version=1,
+        environmental_verdict="risk",
+        environmental_evaluated_at="2026-09-01T05:55:00+00:00",
+        stress_reasons=("high_vpd",),
+        fusion_state="environmental_risk",
+        fusion_confidence="confirmed",
+        fusion_coverage="complete",
+    )
+
+    await store.async_record_fusion_outcome(outcome)
+    await store.async_close()
+
+    reopened = VisionEvidenceStore(database, tmp_path / "images")
+    await reopened.async_setup()
+    assert await reopened.async_get_fusion_outcomes(capture.capture_id) == [outcome]
+    await reopened.async_close()
+
+
+@pytest.mark.asyncio
+async def test_explainer_report_preserves_its_fusion_snapshot(tmp_path: Path) -> None:
+    """Optional prose stays bound to the fusion outcome it was written against."""
+    database = tmp_path / "growspace_vision.db"
+    store = VisionEvidenceStore(database, tmp_path / "images")
+    await store.async_setup()
+    capture = await _start_capture(store)
+    report = VisionExplainerReport(
+        report_id="report-1",
+        capture_id=capture.capture_id,
+        created_at="2026-09-01T06:00:03+00:00",
+        ai_task_entity_id="ai_task.cloud",
+        observation_source=ObservationSource.IMAGE_PASS,
+        scoring_policy_version=1,
+        observation="The canopy is even across the frame.",
+        environmental_risk="High VPD evaluation is active.",
+        hypothesis="",
+        recommendations=("Check humidification.",),
+        fusion_state="environmental_risk",
+        fusion_confidence="confirmed",
+        fusion_coverage="complete",
+    )
+
+    await store.async_add_explainer_report(report)
+    await store.async_close()
+
+    reopened = VisionEvidenceStore(database, tmp_path / "images")
+    await reopened.async_setup()
+    assert await reopened.async_get_explainer_reports(capture.capture_id) == [report]
+    await reopened.async_close()
+
+
+@pytest.mark.asyncio
+async def test_label_revisions_are_append_only_and_pin_the_capture(
+    tmp_path: Path,
+) -> None:
+    """A revision preserves its predecessor and records supersession explicitly."""
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", tmp_path / "images")
+    await store.async_setup()
+    capture = await _start_capture(store)
+    original = VisionLabel(
+        label_id="label-1",
+        capture_id=capture.capture_id,
+        label_kind=LabelKind.OBSERVATION,
+        created_at="2026-09-01T07:00:00+00:00",
+        author="grower",
+        symptom_labels=("chlorosis",),
+        note="Possible yellowing",
+    )
+    revision = replace(
+        original,
+        label_id="label-2",
+        created_at="2026-09-01T07:05:00+00:00",
+        symptom_labels=("senescence",),
+        note="Expected late-run colour change",
+    )
+
+    await store.async_add_label(original)
+    await store.async_add_label(revision, supersedes_label_id=original.label_id)
+
+    assert await store.async_get_labels(capture.capture_id) == [
+        replace(original, superseded_by=revision.label_id),
+        revision,
+    ]
+    assert await store.async_is_capture_pinned(capture.capture_id)
+    await store.async_close()
+
+
+@pytest.mark.asyncio
+async def test_failed_label_revision_leaves_no_partial_label(tmp_path: Path) -> None:
+    """Superseding a nonexistent predecessor rolls the new label back."""
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", tmp_path / "images")
+    await store.async_setup()
+    capture = await _start_capture(store)
+    label = VisionLabel(
+        label_id="label-1",
+        capture_id=capture.capture_id,
+        label_kind=LabelKind.OBSERVATION,
+        created_at="2026-09-01T07:00:00+00:00",
+        author="grower",
+        symptom_labels=("chlorosis",),
+    )
+
+    with pytest.raises(KeyError):
+        await store.async_add_label(label, supersedes_label_id="missing")
+
+    assert await store.async_get_labels(capture.capture_id) == []
+    await store.async_close()
+
+
+@pytest.mark.asyncio
+async def test_retention_deletes_only_old_unpinned_tracked_images(
+    tmp_path: Path,
+) -> None:
+    """Baseline, label and anomalous evidence stays; ordinary old images do not."""
+    image_root = tmp_path / "images"
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", image_root)
+    await store.async_setup()
+    old = datetime(2026, 5, 1, 6, tzinfo=UTC)
+    unpinned = await _start_capture(store, captured_at=old)
+    baseline_pinned = await _start_capture(store, captured_at=old)
+    labelled = await _start_capture(store, captured_at=old)
+    anomalous = await _start_capture(store, captured_at=old)
+    recent = await _start_capture(store)
+
+    completed, embedding, bucket, member, result = _analysis_records(baseline_pinned)
+    await store.async_record_analysis(
+        completed,
+        embedding=embedding,
+        comparison=result,
+        bucket=bucket,
+        member=member,
+    )
+    await store.async_add_label(
+        VisionLabel(
+            label_id="retention-label",
+            capture_id=labelled.capture_id,
+            label_kind=LabelKind.OBSERVATION,
+            created_at="2026-05-01T07:00:00+00:00",
+            author="grower",
+            symptom_labels=("chlorosis",),
+        )
+    )
+    anomalous_result = replace(
+        result,
+        result_id="anomalous-result",
+        capture_id=anomalous.capture_id,
+        bucket_id=None,
+        outcome=ComparisonOutcome.SCORED,
+        baseline_state=BaselineState.READY,
+        anomaly_score=0.72,
+        verdict=ComparisonVerdict.UNCERTAIN,
+        admitted_to_baseline=False,
+    )
+    await store.async_record_analysis(
+        replace(anomalous, analysis_state=AnalysisState.ANALYZED),
+        comparison=anomalous_result,
+    )
+    untracked = image_root / "untracked.jpg"
+    untracked.write_bytes(b"not indexed by the store")
+
+    deleted = await store.async_prune_images(
+        image_retention_days=90,
+        now=datetime(2026, 9, 1, 12, tzinfo=UTC),
+    )
+
+    assert deleted == 1
+    unpinned_file = (await store.async_get_capture_files(unpinned.capture_id))[0]
+    assert not (image_root / unpinned_file.relative_path).exists()
+    assert unpinned_file.deletion_reason is FileDeletionReason.RETENTION
+    for capture in (baseline_pinned, labelled, anomalous, recent):
+        capture_file = (await store.async_get_capture_files(capture.capture_id))[0]
+        assert (image_root / capture_file.relative_path).exists()
+    assert untracked.exists()
+    assert await store.async_get_capture(unpinned.capture_id) == unpinned
+    await store.async_close()
+
+
+@pytest.mark.asyncio
+async def test_zero_days_disables_image_retention(tmp_path: Path) -> None:
+    """The explicit zero setting preserves even old unpinned images."""
+    image_root = tmp_path / "images"
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", image_root)
+    await store.async_setup()
+    capture = await _start_capture(store, captured_at=datetime(2020, 1, 1, tzinfo=UTC))
+
+    assert (
+        await store.async_prune_images(
+            image_retention_days=0,
+            now=datetime(2026, 9, 1, tzinfo=UTC),
+        )
+        == 0
+    )
+    capture_file = (await store.async_get_capture_files(capture.capture_id))[0]
+    assert (image_root / capture_file.relative_path).exists()
+    await store.async_close()
+
+
+@pytest.mark.asyncio
+async def test_growspace_deletion_keeps_pinned_captures_as_named_orphans(
+    tmp_path: Path,
+) -> None:
+    """Deleting a growspace removes ordinary evidence but preserves labelled evidence."""
+    image_root = tmp_path / "images"
+    store = VisionEvidenceStore(tmp_path / "growspace_vision.db", image_root)
+    await store.async_setup()
+    ordinary = await _start_capture(store)
+    pinned = await _start_capture(store)
+    await store.async_add_label(
+        VisionLabel(
+            label_id="orphan-label",
+            capture_id=pinned.capture_id,
+            label_kind=LabelKind.OBSERVATION,
+            created_at="2026-09-01T07:00:00+00:00",
+            author="grower",
+            symptom_labels=("chlorosis",),
+        )
+    )
+    ordinary_file = (await store.async_get_capture_files(ordinary.capture_id))[0]
+    pinned_file = (await store.async_get_capture_files(pinned.capture_id))[0]
+
+    deleted = await store.async_delete_growspace("gs-1")
+
+    assert deleted == 1
+    assert await store.async_get_capture(ordinary.capture_id) is None
+    orphan = await store.async_get_capture(pinned.capture_id)
+    assert orphan is not None
+    assert orphan.growspace_id == "gs-1"
+    assert orphan.growspace_name == "Flower Tent"
+    assert not (image_root / ordinary_file.relative_path).exists()
+    assert (image_root / pinned_file.relative_path).exists()
+    assert await store.async_get_labels(pinned.capture_id)
+    await store.async_close()


### PR DESCRIPTION
## Summary

- add the forward-migrated `growspace_vision.db` repository and Home Assistant lifecycle wiring
- persist UUIDv7 Vision Checkups and captures, image variants, provenance, embeddings, additive comparison results, auditable baseline membership, fusion outcomes, explainer reports, and append-only labels
- enforce the locked 90-day image policy with baseline, label, and anomalous-result pinning, plus pinned-orphan behavior when a growspace is deleted
- preserve write failure atomicity across capture, analysis, and label operations and document the implemented storage boundary
- align the stored fusion vocabulary with the canonical `persistent_visual_anomaly` state

The legacy raw-capture bridge remains active until the Vision Checkup producer is cut over in its later integration ticket.

## Validation

- `./scripts/codex-worktree check backend full`
  - Ruff check and formatting passed
  - mypy passed for 217 source files
  - 5,324 tests and 44 snapshots passed
  - 99% aggregate coverage; 100% for the new evidence store
- commit hooks: Ruff, formatting, codespell, Prettier, pytest, and mypy passed

Closes Venosta-web/growspace_manager_workspace#88
