### PR TITLE
feat(plants): return plant identity from add_plant service

### DIFF
--- a/custom_components/growspace_manager/services/plant_facade.py
+++ b/custom_components/growspace_manager/services/plant_facade.py
@@ -51,7 +51,7 @@ from custom_components.growspace_manager.services.plant_utils import (
 )
 from custom_components.growspace_manager.strain_library import StrainLibrary
 from custom_components.growspace_manager.utils import parse_date_field
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
@@ -548,7 +548,7 @@ class PlantFacade:
         hass: HomeAssistant,
         strain_library: StrainLibrary,
         call: ServiceCall,
-    ) -> None:
+    ) -> dict[str, str]:
         """Unpack an add_plant ServiceCall and delegate to add_plant."""
         _LOGGER.debug("Service call: add_plant with data: %s", call.data)
 
@@ -612,6 +612,8 @@ class PlantFacade:
         ) as err:
             _LOGGER.exception("Failed to add plant")
             raise ServiceValidationError(f"Failed to add plant: {err}") from err
+
+        return {"plant_id": plant_id}
 
     async def add_plants_from_call(
         self,
@@ -854,8 +856,10 @@ async def _handle_add_plant(
     coordinator: GrowspaceCoordinator,
     strain_library: StrainLibrary,
     call: ServiceCall,
-) -> None:
-    await coordinator.services.plants.add_plant_from_call(hass, strain_library, call)
+) -> dict[str, str]:
+    return await coordinator.services.plants.add_plant_from_call(
+        hass, strain_library, call
+    )
 
 
 async def _handle_add_plants(
@@ -910,6 +914,7 @@ SERVICES: list[ServiceDefinition] = [
         _handle_add_plant,
         ADD_PLANT_SCHEMA,
         needs_strain_lib=True,
+        supports_response=SupportsResponse.OPTIONAL,
     ),
     ServiceDefinition(
         GrowspaceService.ADD_PLANTS,

--- a/tests/integration/test_add_plant_service_boundary.py
+++ b/tests/integration/test_add_plant_service_boundary.py
@@ -1,0 +1,58 @@
+"""The public add_plant response crosses the real service registration."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.growspace_manager.const import DOMAIN
+from custom_components.growspace_manager.models import Growspace, Plant
+from custom_components.growspace_manager.service_registration import register_services
+from custom_components.growspace_manager.services.plant_facade import PlantFacade
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize("return_response", [True, False])
+async def test_add_plant_optional_response(
+    hass: HomeAssistant, return_response: bool
+) -> None:
+    """Existing callers still work; requesting callers receive the created ID."""
+    coordinator = MagicMock()
+    coordinator.growspaces = {"gs1": Growspace(id="gs1", name="Tent")}
+    plant = Plant(plant_id="created-plant", growspace_id="gs1", row=1, col=1)
+    coordinator._plant_manager.add_plant = AsyncMock(return_value=plant)
+    coordinator.services.plants = PlantFacade(coordinator)
+    entry = MockConfigEntry(domain=DOMAIN, entry_id="plant_boundary")
+    entry.add_to_hass(hass)
+    entry.mock_state(hass, ConfigEntryState.LOADED)
+    entry.runtime_data = coordinator
+    await register_services(hass, MagicMock())
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        "add_plant",
+        {
+            "growspace_id": "gs1",
+            "strain": "Blue Dream",
+            "row": 1,
+            "col": 1,
+            "clone_start": "2026-09-05",
+        },
+        blocking=True,
+        return_response=return_response,
+    )
+
+    assert response == ({"plant_id": "created-plant"} if return_response else None)
+    coordinator._plant_manager.add_plant.assert_awaited_once()
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "add_plant",
+            {"growspace_id": "missing", "strain": "Blue Dream", "row": 1, "col": 1},
+            blocking=True,
+            return_response=return_response,
+        )
+    coordinator._plant_manager.add_plant.assert_awaited_once()


### PR DESCRIPTION
Growspace Manager's `add_plant` service currently discards the created plant's identity. Return `{ plant_id }` when callers request a response and register the service with optional response support. Existing automation calls without a response continue unchanged.

This supplies the public-service prerequisite for the TC graduation bridge in Venosta-web/growspace_manager_workspace#118. The integration gains no dependency on TC.

Validation: 5,785 tests passed, 3 skipped, 44 snapshots passed; Ruff, formatting, mypy, and changed-file pre-commit hooks passed. Service-registry tests exercise both response-requesting and legacy calls plus invalid destinations through the production handler.

Land and release this before the TC bridge, then land the card UI.
