### PR TITLE
feat(lifecycle): accept an edit that moves more than one lifecycle date

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -298,14 +298,18 @@ An immutable `Applied`, `NoChange`, or `Rejected` proposal. It carries before/af
 **Lifecycle Correction**
 An explicit repair proposal that replaces the ambiguous current interval, preserves the maximal trustworthy and graph-compatible earlier prefix, rebuilds Compatibility Data, and drafts a Lifecycle Repair Event. It requires the corrected stage, its start date, the correction date, and a non-empty grower reason.
 
+**Lifecycle Reschedule**
+The repair proposal for an edit that moves more than one boundary at once: it rebuilds [[Stage History]] from a set of stage starts, retaining every interval the edit does not name. A supplied date retargets that stage's latest interval, a stage the Plant has never been in is inserted where its date places it, and boundaries are re-derived so the result is gapless by construction. Retained stages are never reordered — a set that would require it, one that predates its successor, one dated after the correction date, or an insertion that breaks the transition graph is refused naming the stages that conflict. The Plant ends up in the stage owning the last interval, so correcting existing dates cannot change [[Current Stage]] while entering a later stage's start advances it. `update_plant` selects it structurally: no explicit `stage` and two or more populated `*_start` fields. One save is one [[Lifecycle Repair Event]] listing every boundary it moved. See ADR-0047.
+_Avoid_: bulk date edit, multi-stage transition
+
 **Lifecycle Repair Warning**
 A machine-readable diagnosis produced for malformed, overlapping, nonchronological, future-dated, unknown-stage, or graph-invalid lifecycle data. Warnings fail lifecycle facts closed to Unknown Stage rather than activating a legacy fallback.
 
 **Lifecycle Repair Event**
-The immutable event draft produced by Lifecycle Correction, recording the prior/corrected stage, correction and stage-start dates, grower reason, discarded interval count, and warning codes. The domain module drafts it; an outer shell decides whether and where to publish it.
+The immutable event draft produced by [[Lifecycle Correction]] or [[Lifecycle Reschedule]], recording the prior/corrected stage, correction and stage-start dates, every corrected boundary, grower reason, discarded interval count, and warning codes. The domain module drafts it; an outer shell decides whether and where to publish it.
 
 **Compatibility Data**
-The lifecycle-owned projection for legacy Plant consumers: the shadow `stage`, latest per-stage `*_start` values, and Stage History. It is rebuilt from trusted intervals after every Applied transition or Lifecycle Correction so legacy fields cannot disagree with the domain result.
+The lifecycle-owned projection for legacy Plant consumers: the shadow `stage`, latest per-stage `*_start` values, and Stage History. It is rebuilt from trusted intervals after every Applied transition, Lifecycle Correction, or [[Lifecycle Reschedule]] so legacy fields cannot disagree with the domain result.
 
 **Current Stage Resolution**
 The read path's single rule for reporting [[Current Stage]], implemented in `domain/current_stage.py` and shared by the plant view model the card renders, the plant sensor's state and `stage` attribute, nutrient-preset stage matching, environmental stage-day assembly, and feed-EC week selection. Stored [[Stage History]] wins whenever it parses; older Plants without history are reconstructed by the [[Plant Lifecycle]] module from legacy lifecycle dates, while malformed present history fails closed to [[Unknown Stage]]. There is no separate growspace/date heuristic. Consequences: after a Reveg the stale `flower_start` no longer outranks the newer veg interval, and a promoted clone still sitting in the clone growspace reads as veg rather than taking a special-growspace shortcut.

--- a/custom_components/growspace_manager/domain/plant_lifecycle.py
+++ b/custom_components/growspace_manager/domain/plant_lifecycle.py
@@ -236,6 +236,13 @@ class LifecycleRepairEventDraft:
     corrected_stage_started_on: date
     discarded_interval_count: int
     warning_codes: tuple[RepairWarningCode, ...]
+    corrected_starts: tuple[tuple[LifecycleStage, date], ...] = ()
+    """Every boundary this correction moved, in Stage History order.
+
+    A single-stage repair moves exactly one, so this restates
+    :attr:`corrected_stage`; a Lifecycle Reschedule moves several and one
+    repair has to name all of them.
+    """
 
 
 class DecisionStatus(StrEnum):
@@ -524,6 +531,130 @@ class PlantLifecycle:
             corrected_stage_started_on=start,
             discarded_interval_count=discarded_count,
             warning_codes=tuple(warning.code for warning in self.history.warnings),
+            corrected_starts=((corrected_stage, start),),
+        )
+        return LifecycleCorrection(
+            lifecycle=lifecycle,
+            before=self.values(),
+            after=lifecycle.values(),
+            before_facts=self.facts(on=corrected),
+            after_facts=lifecycle.facts(on=corrected),
+            compatibility_data=lifecycle.compatibility_data,
+            repair_event=event,
+        )
+
+    def reschedule(
+        self,
+        stage_starts: Mapping[str, DateInput],
+        corrected_on: DateInput,
+        reason: str,
+    ) -> LifecycleCorrection:
+        """Rebuild Stage History from a set of stage starts, retaining the rest.
+
+        Moving several boundaries at once is neither a transition nor a
+        single-stage repair.  Each supplied stage retargets the last interval
+        the Plant already has in that stage, a stage it has never been in is
+        inserted where its date places it, and every interval the caller did
+        not name keeps its start.  Boundaries are then re-derived so the result
+        is gapless by construction; a set that would disorder the stages or
+        break the transition graph is refused by name instead.
+        """
+        corrected = _coerce_date(corrected_on)
+        if corrected is None:
+            raise ValueError("corrected_on must be a valid date")
+        if not reason.strip():
+            raise ValueError("reason must not be empty")
+        if not stage_starts:
+            raise ValueError("A lifecycle reschedule must supply a stage start")
+
+        supplied: dict[LifecycleStage, date] = {}
+        for raw_stage, raw_start in stage_starts.items():
+            stage = _stage_or_unknown(raw_stage)
+            if stage is LifecycleStage.UNKNOWN:
+                raise ValueError(f"Unknown stage: {raw_stage}")
+            start = _coerce_date(raw_start)
+            if start is None:
+                raise ValueError(f"{stage.value} start is not a valid date")
+            if start > corrected:
+                raise ValueError(
+                    f"{stage.value} start {start.isoformat()} is in the future"
+                )
+            supplied[stage] = start
+
+        # Only the trustworthy prefix may be retained: an interval the parser
+        # could not trust is not a boundary this edit is allowed to keep.
+        basis = self.history.trustworthy_intervals
+        rescheduled = [(item.stage, item.started_on) for item in basis]
+        inserted: list[tuple[LifecycleStage, date]] = []
+        for stage, start in supplied.items():
+            for index in reversed(range(len(rescheduled))):
+                if rescheduled[index][0] is stage:
+                    rescheduled[index] = (stage, start)
+                    break
+            else:
+                inserted.append((stage, start))
+
+        # Retained stages keep their order, so a start that jumps past its
+        # successor is a contradiction rather than a re-ordering request.
+        for index in range(len(rescheduled) - 1):
+            earlier, later = rescheduled[index], rescheduled[index + 1]
+            if earlier[1] > later[1]:
+                raise ValueError(
+                    f"{earlier[0].value} start {earlier[1].isoformat()} is after "
+                    f"{later[0].value} start {later[1].isoformat()}"
+                )
+
+        for stage, start in sorted(inserted, key=lambda item: item[1]):
+            position = next(
+                (
+                    index
+                    for index, (_, existing) in enumerate(rescheduled)
+                    if existing > start
+                ),
+                len(rescheduled),
+            )
+            rescheduled.insert(position, (stage, start))
+
+        for index in range(len(rescheduled) - 1):
+            previous_stage, next_stage = (
+                rescheduled[index][0],
+                rescheduled[index + 1][0],
+            )
+            if next_stage not in TRANSITION_GRAPH[previous_stage]:
+                raise ValueError(
+                    f"Stage order {previous_stage.value}->{next_stage.value} "
+                    "is not allowed"
+                )
+
+        intervals = tuple(
+            StageInterval(
+                stage,
+                start,
+                rescheduled[index + 1][1] if index + 1 < len(rescheduled) else None,
+            )
+            for index, (stage, start) in enumerate(rescheduled)
+        )
+        residual, _ = _validate_intervals(intervals, corrected, current_stage=None)
+        if residual:
+            raise ValueError(residual[0].message)
+
+        lifecycle = PlantLifecycle(
+            StageHistory(intervals=intervals, trustworthy_intervals=intervals)
+        )
+        current = intervals[-1]
+        event = LifecycleRepairEventDraft(
+            corrected_on=corrected,
+            reason=reason.strip(),
+            previous_stage=self.current_stage,
+            corrected_stage=current.stage,
+            corrected_stage_started_on=current.started_on,
+            discarded_interval_count=max(len(self.history.intervals) - len(basis), 0),
+            warning_codes=tuple(warning.code for warning in self.history.warnings),
+            corrected_starts=tuple(
+                (item.stage, item.started_on)
+                for item in intervals
+                if supplied.get(item.stage) == item.started_on
+            ),
         )
         return LifecycleCorrection(
             lifecycle=lifecycle,

--- a/custom_components/growspace_manager/managers/plant.py
+++ b/custom_components/growspace_manager/managers/plant.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import fields
 from datetime import date
@@ -252,32 +253,66 @@ class PlantManager(BaseService):
             history[-2]["end"] = corrected_timestamp
         return history
 
+    @classmethod
+    def _reschedule_history(
+        cls,
+        plant: Plant,
+        correction: LifecycleCorrection,
+        supplied_timestamps: Mapping[str, str],
+    ) -> list[dict[str, str | None]]:
+        """Project a reschedule, stamping only the boundaries the grower moved."""
+        projected = correction.compatibility_data.as_dict()["stage_history"]
+        history = [dict(item) for item in projected]
+        # `*_start` names a stage's latest interval, so that is the one a
+        # supplied date moved; an earlier interval of the same stage is retained
+        # and keeps whatever precision it was stored with.
+        latest = {item["stage"]: index for index, item in enumerate(history)}
+        raw_history = list(plant.stage_history or [])
+        cursor = 0
+        for index, item in enumerate(history):
+            supplied = supplied_timestamps.get(str(item["stage"]))
+            if supplied is not None and latest[item["stage"]] == index:
+                item["start"] = supplied
+                continue
+            for offset in range(cursor, len(raw_history)):
+                raw = raw_history[offset]
+                if raw["stage"] == item["stage"] and cls._same_lifecycle_day(
+                    raw["start"], item["start"]
+                ):
+                    item["start"] = str(raw["start"])
+                    cursor = offset + 1
+                    break
+            else:
+                # History reconstructed from legacy dates has no raw interval to
+                # borrow precision from; the legacy field itself is the source.
+                stored = getattr(plant, f"{item['stage']}_start", None)
+                if stored is not None and cls._same_lifecycle_day(
+                    stored, item["start"]
+                ):
+                    item["start"] = str(stored)
+
+        for index in range(len(history) - 1):
+            history[index]["end"] = history[index + 1]["start"]
+        history[-1]["end"] = None
+        return history
+
     def _lifecycle_compatibility_updates(
         self,
         plant: Plant,
         decision: LifecycleDecision | LifecycleCorrection,
-        lifecycle: PlantLifecycle,
-        target_stage: LifecycleStage,
-        target_timestamp: str,
+        history: list[dict[str, str | None]],
+        target_fields: Mapping[str, str],
     ) -> dict[str, Any]:
         """Build one timestamp-preserving update for every lifecycle-owned field."""
         projected = decision.compatibility_data.as_dict()
-        if isinstance(decision, LifecycleCorrection):
-            projected["stage_history"] = self._correction_history(
-                plant, decision, target_timestamp
-            )
-        else:
-            projected["stage_history"] = self._transition_history(
-                plant, lifecycle, decision, target_timestamp
-            )
+        projected["stage_history"] = history
 
-        target_field = f"{target_stage.value}_start"
         for field_name in DATE_FIELDS:
             projected_value = projected[field_name]
             if projected_value is None:
                 continue
-            if field_name == target_field:
-                projected[field_name] = target_timestamp
+            if field_name in target_fields:
+                projected[field_name] = target_fields[field_name]
                 continue
             stored_value = getattr(plant, field_name)
             if stored_value is not None and self._same_lifecycle_day(
@@ -285,6 +320,30 @@ class PlantManager(BaseService):
             ):
                 projected[field_name] = stored_value
         return projected
+
+    @staticmethod
+    def _lifecycle_reschedule_request(
+        requested_updates: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Resolve a multi-date edit into its supplied stage starts, else ``None``.
+
+        Two or more populated ``*_start`` fields name no single stage, so they
+        are a Lifecycle Reschedule rather than a transition or a single-stage
+        repair.  An explicit ``stage`` still selects one of those older shapes.
+        """
+        if requested_updates.get("stage") is not None:
+            return None
+        supplied = {
+            field_name: value
+            for field_name in DATE_FIELDS
+            if (value := requested_updates.get(field_name)) is not None
+        }
+        if len(supplied) < 2:
+            return None
+        return {
+            _as_lifecycle_stage(field_name.removesuffix("_start")).value: value
+            for field_name, value in supplied.items()
+        }
 
     @staticmethod
     def _lifecycle_edit_request(
@@ -302,9 +361,11 @@ class PlantManager(BaseService):
             if value is not None
         ]
         if (requested_stage := requested_updates.get("stage")) is None:
-            if len(non_empty_date_fields) != 1:
+            # Several populated dates are routed to the reschedule before this,
+            # so the only remaining ambiguity is a payload that names none.
+            if not non_empty_date_fields:
                 raise ValidationChangeError(
-                    "A lifecycle date edit must identify exactly one current stage"
+                    "A lifecycle date edit must supply a stage start"
                 )
             target = _as_lifecycle_stage(
                 non_empty_date_fields[0].removesuffix("_start")
@@ -335,6 +396,22 @@ class PlantManager(BaseService):
             return lifecycle.repair_current(
                 target,
                 target_timestamp,
+                observed_on,
+                _LIFECYCLE_CORRECTION_REASON,
+            )
+        except ValueError as err:
+            raise ValidationChangeError(str(err)) from err
+
+    @staticmethod
+    def _reschedule_lifecycle(
+        lifecycle: PlantLifecycle,
+        stage_timestamps: Mapping[str, str],
+        observed_on: date,
+    ) -> LifecycleCorrection:
+        """Translate reschedule input errors into the manager validation vocabulary."""
+        try:
+            return lifecycle.reschedule(
+                stage_timestamps,
                 observed_on,
                 _LIFECYCLE_CORRECTION_REASON,
             )
@@ -375,7 +452,11 @@ class PlantManager(BaseService):
     ) -> None:
         """Publish the domain repair draft to the plant-filterable timeline."""
         repair = correction.repair_event
-        stage_label = repair.corrected_stage.value.replace("_", " ").title()
+        reasons = [
+            f"Corrected {stage.value.replace('_', ' ').title()} start to "
+            f"{started_on.isoformat()}"
+            for stage, started_on in repair.corrected_starts
+        ]
         self.hass.bus.async_fire(
             EVENT_GROWSPACE_LOG_ENTRY,
             {
@@ -385,10 +466,7 @@ class PlantManager(BaseService):
                 "category": CATEGORY_MILESTONE,
                 "timestamp": dt_util.now().isoformat(),
                 "notes": repair.reason,
-                "reasons": [
-                    f"Corrected {stage_label} start to "
-                    f"{repair.corrected_stage_started_on.isoformat()}"
-                ],
+                "reasons": reasons,
                 "previous_stage": repair.previous_stage.value,
                 "corrected_stage": repair.corrected_stage.value,
                 "corrected_stage_started_on": (
@@ -592,12 +670,81 @@ class PlantManager(BaseService):
         async_fire_plant_event(self.hass, EVENT_PLANT_UPDATED, plant, updates)
         return plant
 
+    @staticmethod
+    def _lifecycle_timestamp(value: DateInput) -> str:
+        """Route a supplied lifecycle date through the one write seam."""
+        try:
+            return to_lifecycle_timestamp(value)
+        except (TypeError, ValueError) as err:
+            raise ValidationChangeError(str(err)) from err
+
+    def _single_stage_edit(
+        self,
+        plant: Plant,
+        lifecycle: PlantLifecycle,
+        request: tuple[LifecycleStage, Any, bool],
+        observed_on: date,
+    ) -> tuple[LifecycleCorrection | None, dict[str, Any]]:
+        """Decide and project an edit that names one stage: transition or repair."""
+        canonical_target, target_date, target_start_supplied = request
+        if target_date is None:
+            target_date = dt_util.now()
+        target_timestamp = self._lifecycle_timestamp(target_date)
+
+        decision, correction = self._lifecycle_editor_decision(
+            lifecycle,
+            canonical_target,
+            target_timestamp,
+            observed_on,
+            target_start_supplied,
+        )
+        if not isinstance(decision, (Applied, LifecycleCorrection)):
+            return correction, {}
+
+        history = (
+            self._correction_history(plant, decision, target_timestamp)
+            if isinstance(decision, LifecycleCorrection)
+            else self._transition_history(plant, lifecycle, decision, target_timestamp)
+        )
+        updates = self._lifecycle_compatibility_updates(
+            plant,
+            decision,
+            history,
+            {f"{canonical_target.value}_start": target_timestamp},
+        )
+        return correction, updates
+
+    def _reschedule_edit(
+        self,
+        plant: Plant,
+        lifecycle: PlantLifecycle,
+        supplied_dates: dict[str, Any],
+        observed_on: date,
+    ) -> tuple[LifecycleCorrection, dict[str, Any]]:
+        """Decide and project an edit that moves several boundaries at once."""
+        timestamps = {
+            stage: self._lifecycle_timestamp(value)
+            for stage, value in supplied_dates.items()
+        }
+        correction = self._reschedule_lifecycle(lifecycle, timestamps, observed_on)
+        history = self._reschedule_history(plant, correction, timestamps)
+        updates = self._lifecycle_compatibility_updates(
+            plant,
+            correction,
+            history,
+            {f"{stage}_start": value for stage, value in timestamps.items()},
+        )
+        return correction, updates
+
     async def _commit_lifecycle_update(
         self, plant_id: str, requested_updates: dict[str, Any]
     ) -> Plant:
         """Commit an editor lifecycle correction/transition and other fields once."""
-        canonical_target, target_date, target_start_supplied = (
-            self._lifecycle_edit_request(requested_updates)
+        supplied_dates = self._lifecycle_reschedule_request(requested_updates)
+        single_stage_request = (
+            None
+            if supplied_dates is not None
+            else self._lifecycle_edit_request(requested_updates)
         )
 
         async with self._lock:
@@ -609,29 +756,15 @@ class PlantManager(BaseService):
             lifecycle = self._plant_lifecycle(
                 plant, observed_on=observed_on, allow_repair=True
             )
-            if target_date is None:
-                target_date = dt_util.now()
-            try:
-                target_timestamp = to_lifecycle_timestamp(target_date)
-            except (TypeError, ValueError) as err:
-                raise ValidationChangeError(str(err)) from err
-
-            decision, correction = self._lifecycle_editor_decision(
-                lifecycle,
-                canonical_target,
-                target_timestamp,
-                observed_on,
-                target_start_supplied,
-            )
-
-            lifecycle_updates: dict[str, Any] = {}
-            if isinstance(decision, (Applied, LifecycleCorrection)):
-                lifecycle_updates = self._lifecycle_compatibility_updates(
-                    plant,
-                    decision,
-                    lifecycle,
-                    canonical_target,
-                    target_timestamp,
+            correction: LifecycleCorrection | None
+            if supplied_dates is not None:
+                correction, lifecycle_updates = self._reschedule_edit(
+                    plant, lifecycle, supplied_dates, observed_on
+                )
+            else:
+                assert single_stage_request is not None
+                correction, lifecycle_updates = self._single_stage_edit(
+                    plant, lifecycle, single_stage_request, observed_on
                 )
 
             regular_updates = {

--- a/custom_components/growspace_manager/managers/plant.py
+++ b/custom_components/growspace_manager/managers/plant.py
@@ -670,14 +670,6 @@ class PlantManager(BaseService):
         async_fire_plant_event(self.hass, EVENT_PLANT_UPDATED, plant, updates)
         return plant
 
-    @staticmethod
-    def _lifecycle_timestamp(value: DateInput) -> str:
-        """Route a supplied lifecycle date through the one write seam."""
-        try:
-            return to_lifecycle_timestamp(value)
-        except (TypeError, ValueError) as err:
-            raise ValidationChangeError(str(err)) from err
-
     def _single_stage_edit(
         self,
         plant: Plant,
@@ -689,7 +681,7 @@ class PlantManager(BaseService):
         canonical_target, target_date, target_start_supplied = request
         if target_date is None:
             target_date = dt_util.now()
-        target_timestamp = self._lifecycle_timestamp(target_date)
+        target_timestamp = to_lifecycle_timestamp(target_date)
 
         decision, correction = self._lifecycle_editor_decision(
             lifecycle,
@@ -723,7 +715,7 @@ class PlantManager(BaseService):
     ) -> tuple[LifecycleCorrection, dict[str, Any]]:
         """Decide and project an edit that moves several boundaries at once."""
         timestamps = {
-            stage: self._lifecycle_timestamp(value)
+            stage: to_lifecycle_timestamp(value)
             for stage, value in supplied_dates.items()
         }
         correction = self._reschedule_lifecycle(lifecycle, timestamps, observed_on)

--- a/docs/adr/0047-a-multi-date-lifecycle-edit-reschedules-stage-history.md
+++ b/docs/adr/0047-a-multi-date-lifecycle-edit-reschedules-stage-history.md
@@ -1,0 +1,108 @@
+# ADR 0047 — A multi-date lifecycle edit reschedules Stage History
+
+**Status:** Accepted (extends [ADR-0013](./0013-lifecycle-dates-are-datetime-through-one-write-seam.md))
+
+## Context
+
+`update_plant` understood exactly two shapes of lifecycle edit. A **Lifecycle
+Transition** moves the Plant forward through the stage graph: it closes the open
+interval and appends a new one. A **Lifecycle Correction** (`repair_current`)
+rewrites the open interval's start, retaining the maximal trustworthy and
+graph-compatible earlier prefix and discarding everything after it.
+
+Both shapes require the edit to name **one** stage — explicitly through `stage`,
+or implicitly by being the single populated `*_start` field. A payload carrying
+two populated dates and no `stage` fits neither, and was refused with
+`A lifecycle date edit must identify exactly one current stage`.
+
+The plant overview renders every stage's date input together and, since
+[card ADR-0018] and lovelace-growspace-manager-card#894, sends exactly the fields
+the grower touched. So the dialog invites precisely the edit the backend refused:
+a grower who realises both the veg start and the flower start were wrong had to
+fix them one save at a time, and each intermediate save was itself a correction
+on the timeline.
+
+Two dates are not a transition and not a single-stage repair. They are closer to
+_rebuild the stage history from this set of stage starts_ — and the domain, which
+reasons as one open interval plus movement between stages, had no room for two
+rewritten boundaries at once.
+
+## Decision
+
+A third operation, **Lifecycle Reschedule** (`PlantLifecycle.reschedule`), owns
+edits that move more than one boundary. It is selected structurally: an edit with
+no explicit `stage` and **two or more populated `*_start` fields** is a
+reschedule; everything else keeps the transition/repair routing unchanged.
+
+1. **Unmentioned intervals are retained, not discarded.** A reschedule starts
+   from the Plant's existing trustworthy intervals and changes only what the
+   edit names. This is deliberately the opposite of the single-stage repair,
+   which discards the ambiguous tail: a repair is told one boundary and cannot
+   know whether later intervals still make sense, whereas a reschedule is told
+   where each named boundary belongs and the rest is untouched evidence. Only
+   the intervals the parser could not trust are dropped, and they are counted
+   into the repair event's `discarded_interval_count` as before.
+
+2. **A supplied date retargets a stage's latest interval.** `veg_start` is the
+   Compatibility Data projection of the _last_ veg interval, so that is the one
+   it moves. After a Reveg, editing `veg_start` corrects the newer veg interval
+   and leaves the pre-flower one alone.
+
+3. **A stage the Plant has never been in is inserted where its date places it.**
+   Recording a seedling start that was never captured, or entering a flip date
+   beside a corrected veg start, is the same gesture as correcting one — the
+   dialog offers one input per stage and does not distinguish them.
+
+4. **A coherent set is one that satisfies the existing Stage History rules.**
+   Boundaries are re-derived after the moves (each interval ends where the next
+   begins, the last stays open), so gaps and overlaps cannot be expressed. What
+   remains refusable is: a start later than the correction date; a retained stage
+   whose start jumps past its successor's; and an insertion that breaks the
+   transition graph. Each is refused **by name** —
+   `veg start 2026-08-14 is after flower start 2026-08-12`, not the old
+   one-stage wording — and the constructed result is re-validated through the
+   same `_validate_intervals` the parser uses, so there is one definition of
+   coherent rather than two.
+
+5. **Retained stages are never reordered.** A set that would require it is a
+   contradiction, not a re-ordering request. This is what makes the refusal
+   messages nameable: the grower is told which two stages disagree, instead of
+   being handed a silently re-sorted history.
+
+6. **The Plant ends up in the stage owning the last interval** — the latest
+   supplied or retained start. Because retained stages keep their order, a
+   reschedule that only corrects existing dates cannot change the Current Stage;
+   one that inserts a later stage advances it, which is the point of entering a
+   flip date.
+
+7. **One save is one Lifecycle Repair Event.** The draft gains
+   `corrected_starts`, every boundary the correction moved in Stage History
+   order, and the timeline entry carries one `reasons` line per moved boundary.
+   `repair_current` populates it with its single boundary, so the emitted payload
+   for a single-stage repair is byte-for-byte what it was.
+
+Refusal happens entirely before the persistence shell is entered, so the existing
+atomic guarantee is unchanged: a contradictory set leaves the Plant untouched.
+
+## Consequences
+
+- The card needs no change. It already sends only touched fields, and the
+  backend now accepts what the dialog produces.
+- Calendar-day reasoning in the domain against full stored Lifecycle Timestamps
+  (ADR-0013) is unchanged. The manager stamps the write seam's timestamp only on
+  the boundaries the edit named; an untouched interval keeps the precision it was
+  stored with, and the derived `end` values chain from the next interval's start.
+- A reschedule of untrustworthy history rebuilds it from the supplied starts,
+  which makes it a second route out of [[Unknown Stage]] — one that preserves
+  more than `repair_current` does, when the grower supplies enough dates.
+- `_lifecycle_compatibility_updates` now takes the projected history and the map
+  of fields the edit stamped, rather than deriving both from a single target
+  stage. The three projections (`_transition_history`, `_correction_history`,
+  `_reschedule_history`) stay separate because they preserve stored precision by
+  different rules.
+- A reschedule that advances the Current Stage does **not** perform the placement
+  side effects of a real transition (special growspace moves, harvest metrics) —
+  consistent with the editor path's existing corrections, which have never moved
+  a Plant between growspaces.
+
+[card ADR-0018]: https://github.com/Venosta-web/lovelace-growspace-manager-card/blob/main/docs/adr/0018-lifecycle-timestamps-datetime-through-one-seam.md

--- a/tests/domain/test_plant_lifecycle.py
+++ b/tests/domain/test_plant_lifecycle.py
@@ -686,6 +686,35 @@ def test_reschedule_refuses_a_contradictory_set_by_name(
         lifecycle.reschedule(starts, TODAY, "Grower corrected the dates")
 
 
+def test_reschedule_refuses_a_retained_interval_dated_after_the_correction() -> None:
+    """The rebuilt history is re-validated, so a retained future start refuses too."""
+    lifecycle = lifecycle_for(
+        ("veg", "2026-08-01", "2026-08-10"),
+        ("flower", "2026-08-10", None),
+    )
+
+    with pytest.raises(ValueError, match="future date"):
+        lifecycle.reschedule(
+            {"veg": "2026-07-01"},
+            date(2026, 8, 5),
+            "Grower corrected the veg start",
+        )
+
+
+@pytest.mark.parametrize(
+    ("corrected_on", "message"),
+    [("not-a-date", "corrected_on must be a valid date"), (None, "valid date")],
+)
+def test_reschedule_requires_a_correction_date(
+    corrected_on: str | None, message: str
+) -> None:
+    """A reschedule is dated, like every other correction."""
+    lifecycle = lifecycle_for(("veg", "2026-07-01", None))
+
+    with pytest.raises(ValueError, match=message):
+        lifecycle.reschedule({"veg": "2026-06-01"}, corrected_on, "Grower corrected it")
+
+
 def test_reschedule_requires_a_reason() -> None:
     """A correction stays explainable however many boundaries it moves."""
     lifecycle = lifecycle_for(("veg", "2026-07-01", None))

--- a/tests/domain/test_plant_lifecycle.py
+++ b/tests/domain/test_plant_lifecycle.py
@@ -542,6 +542,158 @@ def test_repair_rejects_invalid_correction_inputs(
         lifecycle.repair_current(stage, start, corrected, reason)
 
 
+def test_reschedule_moves_several_boundaries_and_retains_the_rest() -> None:
+    """A multi-date correction rewrites only the stages the grower named."""
+    lifecycle = lifecycle_for(
+        ("seedling", "2026-05-01", "2026-05-08"),
+        ("veg", "2026-05-08", "2026-07-01"),
+        ("flower", "2026-07-01", None),
+    )
+
+    correction = lifecycle.reschedule(
+        {"veg": "2026-05-06", "flower": "2026-06-28"},
+        TODAY,
+        "Grower corrected both flip dates",
+    )
+
+    assert [
+        (item.stage.value, item.started_on.isoformat(), item.ended_on)
+        for item in correction.after.stage_history
+    ] == [
+        ("seedling", "2026-05-01", date(2026, 5, 6)),
+        ("veg", "2026-05-06", date(2026, 6, 28)),
+        ("flower", "2026-06-28", None),
+    ]
+    assert correction.after.current_stage is LifecycleStage.FLOWER
+    assert correction.compatibility_data.seedling_start == "2026-05-01"
+    assert correction.compatibility_data.veg_start == "2026-05-06"
+    assert correction.compatibility_data.flower_start == "2026-06-28"
+    assert correction.lifecycle.history.is_valid
+    assert correction.repair_event.discarded_interval_count == 0
+    assert correction.repair_event.corrected_starts == (
+        (LifecycleStage.VEG, date(2026, 5, 6)),
+        (LifecycleStage.FLOWER, date(2026, 6, 28)),
+    )
+
+
+def test_reschedule_inserts_a_stage_the_plant_has_never_been_in() -> None:
+    """A date for an unrecorded stage joins the history where it belongs."""
+    lifecycle = lifecycle_for(("veg", "2026-06-01", None))
+
+    correction = lifecycle.reschedule(
+        {"seedling": "2026-05-20", "veg": "2026-05-28"},
+        TODAY,
+        "Grower recorded the seedling start",
+    )
+
+    assert [item.stage.value for item in correction.after.stage_history] == [
+        "seedling",
+        "veg",
+    ]
+    assert correction.after.current_stage is LifecycleStage.VEG
+    assert correction.after.current_stage_started_on == date(2026, 5, 28)
+
+
+def test_reschedule_can_advance_the_current_stage() -> None:
+    """The latest supplied start owns the open interval once boundaries move."""
+    lifecycle = lifecycle_for(("veg", "2026-06-01", None))
+
+    correction = lifecycle.reschedule(
+        {"veg": "2026-05-28", "flower": "2026-07-10"},
+        TODAY,
+        "Grower recorded the flip",
+    )
+
+    assert correction.before.current_stage is LifecycleStage.VEG
+    assert correction.after.current_stage is LifecycleStage.FLOWER
+    assert correction.repair_event.previous_stage is LifecycleStage.VEG
+    assert correction.repair_event.corrected_stage is LifecycleStage.FLOWER
+
+
+def test_reschedule_retargets_only_the_latest_interval_of_a_stage() -> None:
+    """After a Reveg, ``veg_start`` names the newer veg interval, not the first."""
+    lifecycle = lifecycle_for(
+        ("veg", "2026-04-01", "2026-05-01"),
+        ("flower", "2026-05-01", "2026-06-01"),
+        ("veg", "2026-06-01", None),
+    )
+
+    correction = lifecycle.reschedule(
+        {"flower": "2026-05-04", "veg": "2026-06-05"},
+        TODAY,
+        "Grower corrected the reveg",
+    )
+
+    assert [
+        (item.stage.value, item.started_on.isoformat())
+        for item in correction.after.stage_history
+    ] == [("veg", "2026-04-01"), ("flower", "2026-05-04"), ("veg", "2026-06-05")]
+
+
+def test_reschedule_rebuilds_untrustworthy_history_from_the_supplied_starts() -> None:
+    """History the parser cannot trust is rebuilt, and the loss is counted."""
+    lifecycle = lifecycle_for(
+        ("veg", "2026-05-08", "2026-07-01"),
+        ("flower", "2026-06-20", None),
+    )
+    assert lifecycle.current_stage is LifecycleStage.UNKNOWN
+
+    correction = lifecycle.reschedule(
+        {"veg": "2026-05-08", "flower": "2026-07-01"},
+        TODAY,
+        "Grower re-entered both dates",
+    )
+
+    assert correction.lifecycle.history.is_valid
+    assert correction.after.current_stage is LifecycleStage.FLOWER
+    assert correction.repair_event.discarded_interval_count == 1
+    assert RepairWarningCode.OVERLAPPING_INTERVALS in (
+        correction.repair_event.warning_codes
+    )
+
+
+@pytest.mark.parametrize(
+    ("starts", "message"),
+    [
+        (
+            {"veg": "2026-07-05", "flower": "2026-07-01"},
+            "veg start 2026-07-05 is after flower start 2026-07-01",
+        ),
+        (
+            {"veg": "2026-05-08", "flower": "2026-09-01"},
+            "flower start 2026-09-01 is in the future",
+        ),
+        (
+            {"veg": "2026-05-08", "cure": "2026-07-10"},
+            "Stage order flower->cure is not allowed",
+        ),
+        ({"veg": "2026-05-08", "mystery": "2026-07-01"}, "Unknown stage"),
+        ({"veg": "2026-05-08", "flower": "not-a-date"}, "not a valid date"),
+        ({}, "must supply a stage start"),
+    ],
+)
+def test_reschedule_refuses_a_contradictory_set_by_name(
+    starts: dict[str, str], message: str
+) -> None:
+    """Every refusal names the stages that conflict, never a single-stage rule."""
+    lifecycle = lifecycle_for(
+        ("seedling", "2026-05-01", "2026-05-08"),
+        ("veg", "2026-05-08", "2026-07-01"),
+        ("flower", "2026-07-01", None),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        lifecycle.reschedule(starts, TODAY, "Grower corrected the dates")
+
+
+def test_reschedule_requires_a_reason() -> None:
+    """A correction stays explainable however many boundaries it moves."""
+    lifecycle = lifecycle_for(("veg", "2026-07-01", None))
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        lifecycle.reschedule({"veg": "2026-06-01"}, TODAY, "   ")
+
+
 def test_unknown_and_negative_age_have_unknown_cultivation_band() -> None:
     """Band classification has an explicit fail-closed identity."""
     assert cultivation_band_for("unknown", 1).identity is CultivationBandId.UNKNOWN

--- a/tests/managers/test_plant_lifecycle_atomic.py
+++ b/tests/managers/test_plant_lifecycle_atomic.py
@@ -732,6 +732,23 @@ async def test_update_plant_rejects_invalid_lifecycle_edit_without_mutation(
 
 
 @pytest.mark.asyncio
+async def test_update_plant_rejects_a_lifecycle_edit_naming_no_stage_start(
+    manager_factory, repository: GrowspaceRepository
+) -> None:
+    """Clearing the only supplied date names nothing to correct, and is refused."""
+    manager = manager_factory()
+    plant = _plant("cleared-edit", PlantStage.VEG, "2026-08-01")
+    repository.add_plant(plant)
+
+    with pytest.raises(ValidationChangeError, match="must supply a stage start"):
+        await manager.update_plant("cleared-edit", veg_start=None, sex="female")
+
+    assert plant.sex is None
+    assert plant.veg_start == "2026-08-01"
+    assert plant.stage_history == [{"stage": "veg", "start": "2026-08-01", "end": None}]
+
+
+@pytest.mark.asyncio
 async def test_update_plant_plain_edit_skips_lifecycle_parse(
     manager_factory, repository: GrowspaceRepository
 ) -> None:

--- a/tests/managers/test_plant_lifecycle_atomic.py
+++ b/tests/managers/test_plant_lifecycle_atomic.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from copy import deepcopy
 from datetime import date
 from unittest.mock import AsyncMock, Mock
 
@@ -458,6 +459,244 @@ async def test_update_plant_ambiguous_correction_discards_later_intervals(
         if call.args[0] == EVENT_GROWSPACE_LOG_ENTRY
     )
     assert repair_event["discarded_interval_count"] == 3
+
+
+@pytest.fixture
+def rescheduled_plant(repository: GrowspaceRepository) -> Plant:
+    """A grown plant whose three boundaries carry full stored timestamps."""
+    plant = Plant(
+        plant_id="multi-date-edit",
+        growspace_id="main",
+        genetics=PlantGenetics(strain_name="Test"),
+        stage=PlantStage.FLOWER,
+        seedling_start="2026-08-01T09:15:00+00:00",
+        veg_start="2026-08-05T11:30:00+00:00",
+        flower_start="2026-08-10T18:45:00+00:00",
+        stage_history=[
+            {
+                "stage": "seedling",
+                "start": "2026-08-01T09:15:00+00:00",
+                "end": "2026-08-05T11:30:00+00:00",
+            },
+            {
+                "stage": "veg",
+                "start": "2026-08-05T11:30:00+00:00",
+                "end": "2026-08-10T18:45:00+00:00",
+            },
+            {
+                "stage": "flower",
+                "start": "2026-08-10T18:45:00+00:00",
+                "end": None,
+            },
+        ],
+    )
+    repository.add_plant(plant)
+    return plant
+
+
+@pytest.mark.asyncio
+async def test_update_plant_multi_date_edit_rebuilds_stage_history(
+    manager_factory, rescheduled_plant: Plant
+) -> None:
+    """Two corrected dates save at once and leave every value agreeing."""
+    manager = manager_factory()
+
+    await manager.update_plant(
+        "multi-date-edit",
+        veg_start=date(2026, 8, 3),
+        flower_start=date(2026, 8, 12),
+        sex="female",
+    )
+
+    assert rescheduled_plant.stage == PlantStage.FLOWER
+    assert rescheduled_plant.sex == "female"
+    assert rescheduled_plant.veg_start == "2026-08-03T00:00:00+00:00"
+    assert rescheduled_plant.flower_start == "2026-08-12T00:00:00+00:00"
+    # The untouched boundary keeps the precision it was stored with (ADR-0013).
+    assert rescheduled_plant.seedling_start == "2026-08-01T09:15:00+00:00"
+    assert rescheduled_plant.stage_history == [
+        {
+            "stage": "seedling",
+            "start": "2026-08-01T09:15:00+00:00",
+            "end": "2026-08-03T00:00:00+00:00",
+        },
+        {
+            "stage": "veg",
+            "start": "2026-08-03T00:00:00+00:00",
+            "end": "2026-08-12T00:00:00+00:00",
+        },
+        {
+            "stage": "flower",
+            "start": "2026-08-12T00:00:00+00:00",
+            "end": None,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_plant_multi_date_edit_is_one_timeline_repair(
+    manager_factory, rescheduled_plant: Plant
+) -> None:
+    """One save is one lifecycle repair, naming every boundary it moved."""
+    manager = manager_factory()
+
+    await manager.update_plant(
+        "multi-date-edit",
+        veg_start=date(2026, 8, 3),
+        flower_start=date(2026, 8, 12),
+    )
+
+    repair_events = [
+        call.args[1]
+        for call in manager.hass.bus.async_fire.call_args_list
+        if call.args[0] == EVENT_GROWSPACE_LOG_ENTRY
+    ]
+    assert len(repair_events) == 1
+    assert repair_events[0]["sensor_type"] == "lifecycle_repair"
+    assert repair_events[0]["reasons"] == [
+        "Corrected Veg start to 2026-08-03",
+        "Corrected Flower start to 2026-08-12",
+    ]
+    assert repair_events[0]["previous_stage"] == "flower"
+    assert repair_events[0]["corrected_stage"] == "flower"
+    assert repair_events[0]["corrected_stage_started_on"] == "2026-08-12"
+    assert repair_events[0]["discarded_interval_count"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    [
+        (
+            {"veg_start": date(2026, 8, 14), "flower_start": date(2026, 8, 12)},
+            "veg start 2026-08-14 is after flower start 2026-08-12",
+        ),
+        (
+            {"veg_start": date(2026, 8, 3), "flower_start": date(2099, 1, 1)},
+            "flower start 2099-01-01 is in the future",
+        ),
+        (
+            {"veg_start": date(2026, 8, 3), "cure_start": date(2026, 8, 15)},
+            "Stage order flower->cure is not allowed",
+        ),
+    ],
+)
+async def test_update_plant_rejects_contradictory_multi_date_edit(
+    manager_factory,
+    rescheduled_plant: Plant,
+    updates: dict[str, object],
+    message: str,
+) -> None:
+    """A contradictory set is named and leaves the Plant completely untouched."""
+    manager = manager_factory()
+    before = deepcopy(rescheduled_plant)
+
+    with pytest.raises(ValidationChangeError, match=message):
+        await manager.update_plant("multi-date-edit", sex="female", **updates)
+
+    assert rescheduled_plant.stage == before.stage
+    assert rescheduled_plant.sex is None
+    assert rescheduled_plant.stage_history == before.stage_history
+    assert {
+        field: getattr(rescheduled_plant, field)
+        for field in ("seedling_start", "veg_start", "flower_start", "cure_start")
+    } == {
+        "seedling_start": "2026-08-01T09:15:00+00:00",
+        "veg_start": "2026-08-05T11:30:00+00:00",
+        "flower_start": "2026-08-10T18:45:00+00:00",
+        "cure_start": None,
+    }
+    manager.hass.bus.async_fire.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_plant_multi_date_edit_can_add_a_stage(
+    manager_factory, repository: GrowspaceRepository
+) -> None:
+    """Filling in an unrecorded stage alongside a correction flips the plant."""
+    manager = manager_factory()
+    plant = _plant("added-stage", PlantStage.VEG, "2026-08-01")
+    repository.add_plant(plant)
+
+    await manager.update_plant(
+        "added-stage",
+        veg_start=date(2026, 7, 30),
+        flower_start=date(2026, 8, 20),
+    )
+
+    assert plant.stage == PlantStage.FLOWER
+    assert plant.veg_start == "2026-07-30T00:00:00+00:00"
+    assert plant.flower_start == "2026-08-20T00:00:00+00:00"
+    assert plant.stage_history == [
+        {
+            "stage": "veg",
+            "start": "2026-07-30T00:00:00+00:00",
+            "end": "2026-08-20T00:00:00+00:00",
+        },
+        {
+            "stage": "flower",
+            "start": "2026-08-20T00:00:00+00:00",
+            "end": None,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_multi_date_edit_keeps_legacy_timestamp_precision(
+    manager_factory, repository: GrowspaceRepository
+) -> None:
+    """A Plant whose history is reconstructed still keeps its stored moments."""
+    manager = manager_factory()
+    plant = Plant(
+        plant_id="legacy-edit",
+        growspace_id="main",
+        genetics=PlantGenetics(strain_name="Test"),
+        stage=PlantStage.VEG,
+        seedling_start="2026-08-01T09:15:00+00:00",
+        veg_start="2026-08-05T11:30:00+00:00",
+        stage_history=[],
+    )
+    repository.add_plant(plant)
+
+    await manager.update_plant(
+        "legacy-edit",
+        veg_start=date(2026, 8, 3),
+        flower_start=date(2026, 8, 12),
+    )
+
+    assert plant.seedling_start == "2026-08-01T09:15:00+00:00"
+    assert plant.stage_history[0] == {
+        "stage": "seedling",
+        "start": "2026-08-01T09:15:00+00:00",
+        "end": "2026-08-03T00:00:00+00:00",
+    }
+    assert [item["stage"] for item in plant.stage_history] == [
+        "seedling",
+        "veg",
+        "flower",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failed_multi_date_edit_restores_every_lifecycle_field(
+    manager_factory, rescheduled_plant: Plant
+) -> None:
+    """A persistence failure rolls the whole reschedule back as one write."""
+    manager = manager_factory(AsyncMock(side_effect=RuntimeError("disk failed")))
+    before = deepcopy(rescheduled_plant)
+
+    with pytest.raises(RuntimeError, match="disk failed"):
+        await manager.update_plant(
+            "multi-date-edit",
+            veg_start=date(2026, 8, 3),
+            flower_start=date(2026, 8, 12),
+            sex="female",
+        )
+
+    assert rescheduled_plant.sex is None
+    assert rescheduled_plant.veg_start == before.veg_start
+    assert rescheduled_plant.flower_start == before.flower_start
+    assert rescheduled_plant.stage_history == before.stage_history
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes Venosta-web/growspace_manager_workspace#125

## The problem

A save carrying two or more populated `*_start` fields was refused with
`A lifecycle date edit must identify exactly one current stage`. `update_plant`
only understood a graph transition or a single-stage repair of the open
interval, and two changed dates fit neither shape.

The plant overview renders every stage's date input together and — since
lovelace-growspace-manager-card#894 — sends exactly the fields the grower
touched. So the dialog invited precisely the edit the backend rejected: a grower
who realised both the veg start and the flower start were wrong had to fix them
one save at a time, each intermediate save landing on the timeline as its own
correction.

## The decision

A third domain operation, **Lifecycle Reschedule** (`PlantLifecycle.reschedule`),
recorded as [ADR-0047](docs/adr/0047-a-multi-date-lifecycle-edit-reschedules-stage-history.md)
with a `CONTEXT.md` glossary entry. It is selected structurally: no explicit
`stage` and two or more populated `*_start` fields.

- **Unmentioned intervals are retained**, deliberately the opposite of the
  single-stage repair's discard. A repair is told one boundary and cannot know
  whether later intervals still make sense; a reschedule is told where each
  named boundary belongs and the rest is untouched evidence.
- A supplied date **retargets that stage's latest interval** — after a Reveg,
  `veg_start` corrects the newer veg interval, not the pre-flower one — and a
  stage the Plant has never been in is **inserted where its date places it**.
- **Coherent means what the existing Stage History rules already mean.**
  Boundaries are re-derived after the moves, so gaps and overlaps cannot be
  expressed; the constructed result is re-validated through the same
  `_validate_intervals` the parser uses, so there is one definition rather than
  two. What stays refusable: a start after the correction date, a retained stage
  whose start jumps past its successor's, and an insertion that breaks the
  transition graph.
- **Retained stages are never reordered.** A set that would require it is a
  contradiction, not a re-ordering request — which is what makes every refusal
  name the two stages that disagree instead of restating a one-stage rule.
- **The Plant ends up in the stage owning the last interval.** Correcting
  existing dates cannot change Current Stage; entering a later stage's start
  advances it.
- **One save is one Lifecycle Repair Event.** The draft gains `corrected_starts`
  and the timeline entry carries one `reasons` line per moved boundary.

Refusal happens entirely before the persistence shell is entered, so the
existing atomic guarantee is unchanged.

## What does not change

Single-date edits keep their present routing and their **emitted event payload
byte-for-byte**: a graph-valid forward edit still transitions, an edited current
start still repairs, and a plain non-lifecycle edit still skips the lifecycle
parse. `repair_current` populates `corrected_starts` with its single boundary,
so the rendered `reasons` line is identical.

Calendar-day reasoning against full stored Lifecycle Timestamps (ADR-0013) is
unchanged. Only the boundaries the edit named are stamped through the write
seam; an untouched interval keeps the precision it was stored with, including
history reconstructed from legacy `*_start` fields.

The card needs no change.

## Verification

`./scripts/check backend full` — **5803 passed, 3 skipped**; ruff, ruff-format,
mypy and pre-commit clean. 19 new tests (9 domain, 6 manager scenarios of which
3 are parametrised refusals).

Against the dev runtime at `:8123`, mounted on this worktree via
`GROWSPACE_BACKEND_SRC` and driven through the same
`growspace_manager/update_plant` WebSocket command the plant overview sends:

```
saving veg_start=2026-08-01T08:30:00 flower_start=2026-09-03T19:45:00
update result: success: true
after:  veg_start   2026-08-01T08:30:00+02:00
        flower_start 2026-09-03T19:45:00+02:00
timeline (plant-filtered): 1 lifecycle_repair entry
  reasons: ["Corrected Veg start to 2026-08-01",
            "Corrected Flower start to 2026-09-03"]
contradictory pair: validation_failed
  "veg start 2026-09-03 is after flower start 2026-08-01"
```

## Follow-up (not in this PR)

`plant-overview.container.ts` still documents `_changedAttributes()` as working
around the backend rejecting multi-date payloads. That reason is gone; the
comment wants rewriting around the reason that still holds (not re-stamping
untouched dates). Comment-only, and it belongs in the card repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
