### PR TITLE
fix(growspace): make update_growspace a patch, not a replace

### DIFF
--- a/custom_components/growspace_manager/managers/growspace.py
+++ b/custom_components/growspace_manager/managers/growspace.py
@@ -60,6 +60,24 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def _is_given(kwargs: dict[str, Any], key: str) -> bool:
+    """Return whether an update actually carries a value for `key`.
+
+    Updates are patches, and a caller that omits a field expects it left alone.
+    A `None` reaching here is an adapter filling in a blank for a field nobody
+    sent, never an intent: a growspace has no nameless or gridless state to be
+    put into, so absence and `None` mean the same thing. `notification_target`
+    is deliberately not read through this — clearing it is a real intent, and
+    it is expressed by an empty value.
+    """
+    return kwargs.get(key) is not None
+
+
+def _given(kwargs: dict[str, Any], key: str, current: Any) -> Any:
+    """Return the update's value for `key`, or `current` when it gave none."""
+    return kwargs[key] if _is_given(kwargs, key) else current
+
+
 class GrowspaceManager(BaseService):
     """Handles all growspace CRUD operations and management logic."""
 
@@ -212,9 +230,9 @@ class GrowspaceManager(BaseService):
 
             growspace = self.repository.require_growspace(growspace_id)
             changes: list[str] = []
-            new_rows = int(kwargs.get("rows", growspace.rows))
+            new_rows = int(_given(kwargs, "rows", growspace.rows))
             new_plants_per_row = int(
-                kwargs.get("plants_per_row", growspace.plants_per_row)
+                _given(kwargs, "plants_per_row", growspace.plants_per_row)
             )
             grid_changed = (
                 new_rows != growspace.rows
@@ -309,14 +327,14 @@ class GrowspaceManager(BaseService):
     ) -> bool:
         """Update growspace structure (dimensions)."""
         updated = False
-        if "rows" in kwargs:
+        if _is_given(kwargs, "rows"):
             rows = int(kwargs["rows"])
             if rows != growspace.rows:
                 changes.append(f"rows: {growspace.rows} -> {rows}")
                 growspace.rows = rows
                 updated = True
 
-        if "plants_per_row" in kwargs:
+        if _is_given(kwargs, "plants_per_row"):
             ppr = int(kwargs["plants_per_row"])
             if ppr != growspace.plants_per_row:
                 changes.append(f"plants_per_row: {growspace.plants_per_row} -> {ppr}")
@@ -329,7 +347,7 @@ class GrowspaceManager(BaseService):
     ) -> bool:
         """Update growspace configuration."""
         updated = False
-        if "name" in kwargs:
+        if _is_given(kwargs, "name"):
             name = kwargs["name"]
             if name != growspace.name:
                 changes.append(f"name: {growspace.name} -> {name}")

--- a/custom_components/growspace_manager/services/growspace_facade.py
+++ b/custom_components/growspace_manager/services/growspace_facade.py
@@ -896,15 +896,24 @@ class GrowspaceFacade:
         strain_library: StrainLibrary,
         call: ServiceCall,
     ) -> None:
-        """Unpack an update_growspace ServiceCall and delegate to update_growspace."""
+        """Unpack an update_growspace ServiceCall and delegate to update_growspace.
+
+        Every field but the id is optional, and this service is a patch like the
+        rest: forward only what the caller actually sent, so an omitted name is
+        left alone rather than written through as None.
+        """
         growspace_id = call.data[ATTR_GROWSPACE_ID]
-        await self.update_growspace(
-            growspace_id=growspace_id,
-            name=call.data.get(ATTR_NAME),
-            rows=call.data.get(ATTR_ROWS),
-            plants_per_row=call.data.get(ATTR_PLANTS_PER_ROW),
-            notification_target=call.data.get(ATTR_NOTIFICATION_TARGET),
-        )
+        updates = {
+            attr: call.data[attr]
+            for attr in (
+                ATTR_NAME,
+                ATTR_ROWS,
+                ATTR_PLANTS_PER_ROW,
+                ATTR_NOTIFICATION_TARGET,
+            )
+            if attr in call.data
+        }
+        await self.update_growspace(growspace_id=growspace_id, **updates)
         _LOGGER.info("Growspace %s updated successfully", growspace_id)
 
     @handle_service_errors

--- a/tests/core/test_growspace_manager_patch_semantics.py
+++ b/tests/core/test_growspace_manager_patch_semantics.py
@@ -1,0 +1,93 @@
+"""Patch semantics for GrowspaceManager.update_growspace.
+
+Every growspace_manager service is a patch: an omitted field is left alone. The
+manager already reads its updates with `in kwargs`, so absence works — but an
+explicit ``None``, which a service adapter can hand it for a field the caller
+never sent, used to be read as a value. Blanking a growspace's name that way
+loses data silently, and a ``None`` grid crashes on ``int(None)``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.growspace_manager.data_access.growspace_repository import (
+    GrowspaceRepository,
+)
+from custom_components.growspace_manager.growspace_validator import GrowspaceValidator
+from custom_components.growspace_manager.managers.growspace import GrowspaceManager
+from custom_components.growspace_manager.models import Growspace
+from custom_components.growspace_manager.services.context import ServiceContext
+from custom_components.growspace_manager.view_model_builder import ViewModelBuilder
+
+
+@pytest.fixture
+def manager() -> GrowspaceManager:
+    """Return a manager over one named growspace with a notification target."""
+    repo = GrowspaceRepository()
+    repo.add_growspace(
+        Growspace(
+            id="gs1",
+            name="Tent 1",
+            rows=2,
+            plants_per_row=2,
+            notification_target="mobile_app_phone",
+        )
+    )
+    return GrowspaceManager(
+        ctx=ServiceContext(
+            save_callback=AsyncMock(),
+            lock=asyncio.Lock(),
+            add_event=MagicMock(),
+            invalidate_cache=MagicMock(),
+        ),
+        hass=MagicMock(),
+        repository=repo,
+        notification_state=MagicMock(),
+        validator=GrowspaceValidator(repo),
+        view_model_builder=MagicMock(spec=ViewModelBuilder),
+    )
+
+
+@pytest.mark.asyncio
+async def test_grid_update_leaves_the_omitted_name(manager: GrowspaceManager) -> None:
+    """Resizing the grid keeps the name and the notification target."""
+    await manager.update_growspace("gs1", rows=4, plants_per_row=5)
+
+    growspace = manager.repository.require_growspace("gs1")
+    assert (growspace.rows, growspace.plants_per_row) == (4, 5)
+    assert growspace.name == "Tent 1"
+    assert growspace.notification_target == "mobile_app_phone"
+
+
+@pytest.mark.asyncio
+async def test_explicit_none_name_is_not_a_value(manager: GrowspaceManager) -> None:
+    """A None name means "not given", never "blank the name"."""
+    await manager.update_growspace("gs1", name=None, rows=4, plants_per_row=5)
+
+    growspace = manager.repository.require_growspace("gs1")
+    assert growspace.name == "Tent 1"
+    assert (growspace.rows, growspace.plants_per_row) == (4, 5)
+
+
+@pytest.mark.asyncio
+async def test_explicit_none_grid_is_not_a_value(manager: GrowspaceManager) -> None:
+    """A None grid leaves the dimensions alone instead of raising on int(None)."""
+    await manager.update_growspace("gs1", name="Renamed", rows=None)
+
+    growspace = manager.repository.require_growspace("gs1")
+    assert growspace.name == "Renamed"
+    assert (growspace.rows, growspace.plants_per_row) == (2, 2)
+
+
+@pytest.mark.asyncio
+async def test_notification_target_is_still_clearable(
+    manager: GrowspaceManager,
+) -> None:
+    """Clearing the target is a real intent, so an empty value still lands."""
+    await manager.update_growspace("gs1", notification_target="")
+
+    assert manager.repository.require_growspace("gs1").notification_target is None

--- a/tests/services/test_growspace_services.py
+++ b/tests/services/test_growspace_services.py
@@ -119,7 +119,6 @@ async def test_handle_update_growspace(
         name="Updated GS",
         rows=5,
         plants_per_row=5,
-        notification_target=None,
     )
 
 
@@ -565,3 +564,41 @@ async def test_async_add_growspace_note_no_image_manager(
 
     fired_data = mock_hass.bus.async_fire.call_args[0][1]
     assert fired_data["images"] == []
+
+
+@pytest.mark.asyncio
+async def test_handle_update_growspace_omits_absent_fields(
+    mock_hass,
+    mock_coordinator,
+    mock_strain_library,
+    mock_call,
+) -> None:
+    """An update that resizes the grid must not blank the fields it left out."""
+    mock_call.data = {"growspace_id": "gs1", "rows": 4, "plants_per_row": 5}
+
+    await mock_coordinator.services.growspaces.update_growspace_from_call(
+        mock_hass, mock_strain_library, mock_call
+    )
+
+    mock_coordinator._growspace_manager.update_growspace.assert_awaited_once_with(
+        "gs1", rows=4, plants_per_row=5
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_update_growspace_forwards_only_the_name(
+    mock_hass,
+    mock_coordinator,
+    mock_strain_library,
+    mock_call,
+) -> None:
+    """A rename must not carry a grid the caller never asked to change."""
+    mock_call.data = {"growspace_id": "gs1", "name": "Renamed"}
+
+    await mock_coordinator.services.growspaces.update_growspace_from_call(
+        mock_hass, mock_strain_library, mock_call
+    )
+
+    mock_coordinator._growspace_manager.update_growspace.assert_awaited_once_with(
+        "gs1", name="Renamed"
+    )


### PR DESCRIPTION
`update_growspace` behaved as a replace rather than a patch, and silently
erased data.

`GrowspaceFacade.update_growspace_from_call` read every field with
`call.data.get(...)` and forwarded them all. `services.yaml` marks every field
but `growspace_id` optional, so a caller that changed only the grid handed the
manager `name=None`. Reproduced against the dev instance: calling
`growspace_manager.update_growspace` with just `growspace_id`, `rows` and
`plants_per_row` set the growspace's `name` to null in
`.storage/growspace_manager.config`, and its overview sensor's `identity.name`
became null with it. Every other growspace_manager service documents patch
semantics — the card's e2e setup fixture relies on it — so this one was the odd
one out.

## The fix

**The adapter** now forwards only the fields the call actually carries. The
facade's HA device rename already keys off `"name" in kwargs`, so it follows
without further change.

**The manager needed the same distinction on its own account.**
`GrowspaceManager.update_growspace` reads its updates with `in kwargs`, so
absence already worked — but an explicit `None` was read as a value, and an
adapter is exactly what hands it one. Two consequences, both fixed:

- `name=None` blanked the name, which is the erasure above.
- `rows=None` / `plants_per_row=None` crashed the grid pre-check on
  `int(None)`. Before this change, an update that set *only* the name raised
  `TypeError` — the same bug from the other side.

There is no nameless or gridless growspace to be put into, so `_is_given`
treats `None` as absent for those three fields. `notification_target`
deliberately does **not** go through it: clearing a target is a real intent,
expressed by an empty value, and that still lands.

## Tests

- `tests/services/test_growspace_services.py` — a grid-only update forwards
  neither `name` nor `notification_target`; a rename forwards no grid.
  `test_handle_update_growspace` lost its `notification_target=None`
  assertion, which was asserting the bug.
- `tests/core/test_growspace_manager_patch_semantics.py` (new) — at the
  manager: a resize leaves the name and target alone; an explicit `None` name
  or grid is not a value; an empty `notification_target` still clears.

All four new assertions fail on `prerelease`. `./scripts/check backend full`
is green: 5846 passed, 3 skipped.

## Follow-up

Hub PR Venosta-web/growspace_manager_workspace#183 works around this in
`scripts/seed-demo` by resending `name` and `notification_target` alongside the
grid. That workaround is harmless against both the old and the fixed backend,
and can be simplified once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
